### PR TITLE
spec-002+: lean core install, end-to-end notebook, sklearn get_params fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `CITATION.cff` for GitHub "Cite this repository" support (paper DOI placeholder pending).
+- End-to-end feature-tour notebook (`notebooks/00_End_to_End_Feature_Tour.ipynb`) exercising the full public API on the shipped Zeller 2014 CRC dataset.
 
 ### Fixed
 - Version metadata is now consistent: `pyproject.toml` bumped to `0.2.0` to match `microfactual.__version__`.
+- `MicrobiomeClassifier` now exposes forwarded model kwargs (e.g. `n_estimators`, `max_depth`) through `get_params`/`set_params`, so `sklearn.clone`, `set_params`, and `GridSearchCV` can tune the underlying classifier's hyperparameters. Previously these raised `Invalid parameter` under GridSearchCV.
 
 ## [0.1.1] - 2026-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Lean core install**: `dice-ml` and `explainerdashboard` moved out of core dependencies into an optional `explainability` extra. Install with `pip install 'microfactual[explainability]'`. Counterfactual and dashboard entry points raise a clear ImportError pointing to the extra when it isn't installed.
+- Moved `ruff` from runtime dependencies to the dev dependency group (it is a lint tool, not a runtime requirement).
 - **Narrative reframing**: repositioned MicroFactual around interpretable, sklearn-native counterfactual explanations for microbiome classification. Updated package `description`, keywords, and README headline accordingly.
 - Rewrote the README roadmap (removed duplicated entries) around the v0.2.0 release plan.
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,18 @@ graph TB
 ## Installation
 
 ```bash
-# Using uv (recommended)
-uv pip install -e .
-
-# Or using pip
+# Core install (lean — preprocessing, models, visualization)
 pip install -e .
+
+# With the interpretability stack (DiCE counterfactuals + ExplainerDashboard)
+pip install -e '.[explainability]'
+
+# Using uv (recommended)
+uv pip install -e '.[explainability]'
 ```
 
-Requires Python 3.10+
+Requires Python 3.10+. The `explainability` extra pulls in the heavier
+`dice-ml` and `explainerdashboard` dependencies; the core install stays lean.
 
 ## Quick Start
 

--- a/notebooks/00_End_to_End_Feature_Tour.ipynb
+++ b/notebooks/00_End_to_End_Feature_Tour.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cc070fcf",
+   "id": "7de33c61",
    "metadata": {},
    "source": [
     "# MicroFactual — End-to-End Feature Tour\n",
@@ -30,13 +30,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "339082fe",
+   "id": "dbb62e89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:15.128189Z",
-     "iopub.status.busy": "2026-07-11T20:48:15.128065Z",
-     "iopub.status.idle": "2026-07-11T20:48:16.649641Z",
-     "shell.execute_reply": "2026-07-11T20:48:16.649379Z"
+     "iopub.execute_input": "2026-07-11T20:55:21.638172Z",
+     "iopub.status.busy": "2026-07-11T20:55:21.638098Z",
+     "iopub.status.idle": "2026-07-11T20:55:23.857687Z",
+     "shell.execute_reply": "2026-07-11T20:55:23.857333Z"
     }
    },
    "outputs": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78f77738",
+   "id": "8a32899d",
    "metadata": {},
    "source": [
     "## 1. Load a real dataset\n",
@@ -74,13 +74,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "fb973782",
+   "id": "a181516d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:16.651042Z",
-     "iopub.status.busy": "2026-07-11T20:48:16.650900Z",
-     "iopub.status.idle": "2026-07-11T20:48:16.669415Z",
-     "shell.execute_reply": "2026-07-11T20:48:16.669097Z"
+     "iopub.execute_input": "2026-07-11T20:55:23.859413Z",
+     "iopub.status.busy": "2026-07-11T20:55:23.859229Z",
+     "iopub.status.idle": "2026-07-11T20:55:23.887482Z",
+     "shell.execute_reply": "2026-07-11T20:55:23.887246Z"
     }
    },
    "outputs": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "957f3a1b",
+   "id": "c62ab1f8",
    "metadata": {},
    "source": [
     "## 2. Explore the data\n",
@@ -126,13 +126,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c113982b",
+   "id": "fa7375a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:16.670717Z",
-     "iopub.status.busy": "2026-07-11T20:48:16.670635Z",
-     "iopub.status.idle": "2026-07-11T20:48:16.675536Z",
-     "shell.execute_reply": "2026-07-11T20:48:16.675114Z"
+     "iopub.execute_input": "2026-07-11T20:55:23.888613Z",
+     "iopub.status.busy": "2026-07-11T20:55:23.888539Z",
+     "iopub.status.idle": "2026-07-11T20:55:23.893898Z",
+     "shell.execute_reply": "2026-07-11T20:55:23.893682Z"
     }
    },
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b69c228d",
+   "id": "0015746f",
    "metadata": {},
    "source": [
     "## 3. Microbiome-aware preprocessing\n",
@@ -179,13 +179,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "925bd759",
+   "id": "62d35994",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:16.676939Z",
-     "iopub.status.busy": "2026-07-11T20:48:16.676860Z",
-     "iopub.status.idle": "2026-07-11T20:48:16.680843Z",
-     "shell.execute_reply": "2026-07-11T20:48:16.680629Z"
+     "iopub.execute_input": "2026-07-11T20:55:23.895117Z",
+     "iopub.status.busy": "2026-07-11T20:55:23.895042Z",
+     "iopub.status.idle": "2026-07-11T20:55:23.898991Z",
+     "shell.execute_reply": "2026-07-11T20:55:23.898776Z"
     }
    },
    "outputs": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd44ad85",
+   "id": "b238ab93",
    "metadata": {},
    "source": [
     "The `MicrobiomeDataset` also offers convenience methods that track a preprocessing history:"
@@ -227,13 +227,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e67a9108",
+   "id": "9c114eb2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:16.681999Z",
-     "iopub.status.busy": "2026-07-11T20:48:16.681920Z",
-     "iopub.status.idle": "2026-07-11T20:48:16.687662Z",
-     "shell.execute_reply": "2026-07-11T20:48:16.687463Z"
+     "iopub.execute_input": "2026-07-11T20:55:23.900120Z",
+     "iopub.status.busy": "2026-07-11T20:55:23.900047Z",
+     "iopub.status.idle": "2026-07-11T20:55:23.905530Z",
+     "shell.execute_reply": "2026-07-11T20:55:23.905315Z"
     }
    },
    "outputs": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7efa1343",
+   "id": "5de4ae70",
    "metadata": {},
    "source": [
     "## 4. sklearn-native usage\n",
@@ -276,13 +276,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "12d1d982",
+   "id": "a1264408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:16.688707Z",
-     "iopub.status.busy": "2026-07-11T20:48:16.688627Z",
-     "iopub.status.idle": "2026-07-11T20:48:17.069564Z",
-     "shell.execute_reply": "2026-07-11T20:48:17.069258Z"
+     "iopub.execute_input": "2026-07-11T20:55:23.906524Z",
+     "iopub.status.busy": "2026-07-11T20:55:23.906438Z",
+     "iopub.status.idle": "2026-07-11T20:55:24.297367Z",
+     "shell.execute_reply": "2026-07-11T20:55:24.297106Z"
     }
    },
    "outputs": [
@@ -313,13 +313,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e1d9b30c",
+   "id": "ff1b3fd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:17.070798Z",
-     "iopub.status.busy": "2026-07-11T20:48:17.070721Z",
-     "iopub.status.idle": "2026-07-11T20:48:17.528842Z",
-     "shell.execute_reply": "2026-07-11T20:48:17.528566Z"
+     "iopub.execute_input": "2026-07-11T20:55:24.298549Z",
+     "iopub.status.busy": "2026-07-11T20:55:24.298471Z",
+     "iopub.status.idle": "2026-07-11T20:55:24.936271Z",
+     "shell.execute_reply": "2026-07-11T20:55:24.935970Z"
     }
    },
    "outputs": [
@@ -327,23 +327,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best params: {'algorithm': 'random_forest', 'preprocessing': None}\n",
-      "Best CV ROC-AUC: 0.833\n"
+      "Best params: {'max_depth': None, 'n_estimators': 50}\n",
+      "Best CV ROC-AUC: 0.818\n"
      ]
     }
    ],
    "source": [
-    "# GridSearchCV works over the estimator's declared params (algorithm, preprocessing).\n",
-    "# NOTE: underlying-model kwargs (e.g. n_estimators) are passed via **model_params and\n",
-    "# are not currently exposed through get_params, so they can't be tuned this way yet.\n",
+    "# GridSearchCV can tune both the wrapper's own params and keyword args\n",
+    "# forwarded to the underlying classifier (e.g. n_estimators, max_depth).\n",
     "from sklearn.model_selection import GridSearchCV\n",
     "\n",
     "grid = GridSearchCV(\n",
-    "    mf.MicrobiomeClassifier(),\n",
-    "    param_grid={\n",
-    "        \"algorithm\": [\"random_forest\", \"logistic\"],\n",
-    "        \"preprocessing\": [\"auto\", None],\n",
-    "    },\n",
+    "    mf.MicrobiomeClassifier(algorithm=\"random_forest\"),\n",
+    "    param_grid={\"n_estimators\": [50, 100], \"max_depth\": [None, 5]},\n",
     "    cv=3,\n",
     "    scoring=\"roc_auc\",\n",
     ")\n",
@@ -354,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8f2bbff",
+   "id": "f0d28808",
    "metadata": {},
    "source": [
     "## 5. One-liner API\n",
@@ -365,13 +361,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "0bc5860b",
+   "id": "3a8c89dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:17.530107Z",
-     "iopub.status.busy": "2026-07-11T20:48:17.530027Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.024798Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.024536Z"
+     "iopub.execute_input": "2026-07-11T20:55:24.937740Z",
+     "iopub.status.busy": "2026-07-11T20:55:24.937664Z",
+     "iopub.status.idle": "2026-07-11T20:55:25.454241Z",
+     "shell.execute_reply": "2026-07-11T20:55:25.453970Z"
     }
    },
    "outputs": [
@@ -381,8 +377,8 @@
      "text": [
       "Returned keys: ['model', 'dataset', 'cv_scores']\n",
       "CV scores:\n",
-      "            fit_time: 0.070\n",
-      "          score_time: 0.004\n",
+      "            fit_time: 0.072\n",
+      "          score_time: 0.005\n",
       "       test_accuracy: 0.751\n",
       "      train_accuracy: 1.000\n",
       "             test_f1: 0.818\n",
@@ -408,7 +404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80b4795c",
+   "id": "92abb878",
    "metadata": {},
    "source": [
     "## 6. Train / test evaluation\n",
@@ -419,13 +415,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "cca5c8b6",
+   "id": "1a87b4af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.026031Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.025953Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.097842Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.097589Z"
+     "iopub.execute_input": "2026-07-11T20:55:25.455522Z",
+     "iopub.status.busy": "2026-07-11T20:55:25.455442Z",
+     "iopub.status.idle": "2026-07-11T20:55:25.530559Z",
+     "shell.execute_reply": "2026-07-11T20:55:25.530324Z"
     }
    },
    "outputs": [
@@ -464,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7313af49",
+   "id": "5058f1f0",
    "metadata": {},
    "source": [
     "## 7. Visualization\n",
@@ -475,13 +471,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "102e512c",
+   "id": "305fef73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.099001Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.098926Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.166755Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.166543Z"
+     "iopub.execute_input": "2026-07-11T20:55:25.531678Z",
+     "iopub.status.busy": "2026-07-11T20:55:25.531606Z",
+     "iopub.status.idle": "2026-07-11T20:55:25.599994Z",
+     "shell.execute_reply": "2026-07-11T20:55:25.599772Z"
     }
    },
    "outputs": [
@@ -504,13 +500,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "4d4cd7fd",
+   "id": "d089972c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.167823Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.167747Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.213389Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.213119Z"
+     "iopub.execute_input": "2026-07-11T20:55:25.601131Z",
+     "iopub.status.busy": "2026-07-11T20:55:25.601053Z",
+     "iopub.status.idle": "2026-07-11T20:55:25.665695Z",
+     "shell.execute_reply": "2026-07-11T20:55:25.665210Z"
     }
    },
    "outputs": [
@@ -535,13 +531,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "df693453",
+   "id": "ac989563",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.214564Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.214481Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.337731Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.337462Z"
+     "iopub.execute_input": "2026-07-11T20:55:25.668573Z",
+     "iopub.status.busy": "2026-07-11T20:55:25.668440Z",
+     "iopub.status.idle": "2026-07-11T20:55:25.800739Z",
+     "shell.execute_reply": "2026-07-11T20:55:25.800422Z"
     }
    },
    "outputs": [
@@ -566,7 +562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5258d955",
+   "id": "601a9305",
    "metadata": {},
    "source": [
     "## 8. Counterfactual explanations (headline feature)\n",
@@ -582,13 +578,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9c5f7822",
+   "id": "783983ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.339070Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.338981Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.403979Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.403763Z"
+     "iopub.execute_input": "2026-07-11T20:55:25.802083Z",
+     "iopub.status.busy": "2026-07-11T20:55:25.801984Z",
+     "iopub.status.idle": "2026-07-11T20:55:25.870185Z",
+     "shell.execute_reply": "2026-07-11T20:55:25.869888Z"
     }
    },
    "outputs": [
@@ -624,13 +620,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a75bb925",
+   "id": "9b93c361",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.405064Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.404992Z",
-     "iopub.status.idle": "2026-07-11T20:48:18.860294Z",
-     "shell.execute_reply": "2026-07-11T20:48:18.860045Z"
+     "iopub.execute_input": "2026-07-11T20:55:25.871385Z",
+     "iopub.status.busy": "2026-07-11T20:55:25.871299Z",
+     "iopub.status.idle": "2026-07-11T20:55:26.345664Z",
+     "shell.execute_reply": "2026-07-11T20:55:26.345358Z"
     }
    },
    "outputs": [
@@ -654,7 +650,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.55it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
      ]
     },
     {
@@ -662,7 +658,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.54it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
      ]
     },
     {
@@ -947,7 +943,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc01985a",
+   "id": "e6e913ab",
    "metadata": {},
    "source": [
     "## 9. Compare algorithms\n",
@@ -958,13 +954,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "f3b02e5e",
+   "id": "e079d234",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:48:18.861453Z",
-     "iopub.status.busy": "2026-07-11T20:48:18.861366Z",
-     "iopub.status.idle": "2026-07-11T20:48:19.247567Z",
-     "shell.execute_reply": "2026-07-11T20:48:19.247316Z"
+     "iopub.execute_input": "2026-07-11T20:55:26.347047Z",
+     "iopub.status.busy": "2026-07-11T20:55:26.346942Z",
+     "iopub.status.idle": "2026-07-11T20:55:26.755554Z",
+     "shell.execute_reply": "2026-07-11T20:55:26.755296Z"
     }
    },
    "outputs": [
@@ -990,7 +986,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72534d69",
+   "id": "7533b890",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/notebooks/00_End_to_End_Feature_Tour.ipynb
+++ b/notebooks/00_End_to_End_Feature_Tour.ipynb
@@ -1,0 +1,1029 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cc070fcf",
+   "metadata": {},
+   "source": [
+    "# MicroFactual — End-to-End Feature Tour\n",
+    "\n",
+    "This notebook exercises **every major feature** of MicroFactual on a *real* microbiome\n",
+    "dataset (Zeller et al. 2014 colorectal-cancer stool metagenomes), so it doubles as a\n",
+    "smoke test and a guided tour.\n",
+    "\n",
+    "**What we cover**\n",
+    "1. Loading a real dataset with `MicrobiomeDataset`\n",
+    "2. Data exploration (`get_info`)\n",
+    "3. Microbiome-aware preprocessing transforms (abundance / prevalence / CLR)\n",
+    "4. sklearn-native usage — `Pipeline`, `cross_validate`, `GridSearchCV`\n",
+    "5. The one-liner `mf.classify()` API\n",
+    "6. Train / test evaluation with `MicrobiomeClassifier`\n",
+    "7. Visualization — ROC, confusion matrix, feature importance\n",
+    "8. **Counterfactual explanations** (the headline feature) via `DiCEExplainer`\n",
+    "9. Comparing algorithms (random forest vs. logistic regression)\n",
+    "\n",
+    "> The dataset ships in `datasets/` (`abundance_crc.txt`, `metadata_crc.txt`).\n",
+    "> The counterfactual section requires the optional extra:\n",
+    "> `pip install 'microfactual[explainability]'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "339082fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:15.128189Z",
+     "iopub.status.busy": "2026-07-11T20:48:15.128065Z",
+     "iopub.status.idle": "2026-07-11T20:48:16.649641Z",
+     "shell.execute_reply": "2026-07-11T20:48:16.649379Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MicroFactual version: 0.2.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import microfactual as mf\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")  # keep the tour output clean\n",
+    "print(\"MicroFactual version:\", mf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78f77738",
+   "metadata": {},
+   "source": [
+    "## 1. Load a real dataset\n",
+    "\n",
+    "`MicrobiomeDataset.from_files` reads a species×samples abundance table and a metadata table, aligns them on the sample column, and gives sklearn-shaped `X` (samples×features) and encoded `y`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fb973782",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:16.651042Z",
+     "iopub.status.busy": "2026-07-11T20:48:16.650900Z",
+     "iopub.status.idle": "2026-07-11T20:48:16.669415Z",
+     "shell.execute_reply": "2026-07-11T20:48:16.669097Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MicrobiomeDataset Summary:\n",
+      "  Samples: 141\n",
+      "  Features: 1753\n",
+      "  Target: Group (2 classes)\n",
+      "  Sparsity: 90.83%\n",
+      "  Preprocessing steps: 0\n",
+      "\n",
+      "Target classes: ['CRC', 'Control']\n"
+     ]
+    }
+   ],
+   "source": [
+    "ABUNDANCE = \"../datasets/abundance_crc.txt\"\n",
+    "METADATA = \"../datasets/metadata_crc.txt\"\n",
+    "\n",
+    "dataset = mf.MicrobiomeDataset.from_files(\n",
+    "    abundance_file=ABUNDANCE,\n",
+    "    metadata_file=METADATA,\n",
+    "    target_column=\"Group\",       # CRC vs Control\n",
+    "    sample_column=\"Sample ID\",\n",
+    ")\n",
+    "print(dataset)\n",
+    "print(\"\\nTarget classes:\", dataset.target_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "957f3a1b",
+   "metadata": {},
+   "source": [
+    "## 2. Explore the data\n",
+    "\n",
+    "`get_info()` returns dimensions, class balance, sparsity and read-depth statistics — useful sanity checks for compositional data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c113982b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:16.670717Z",
+     "iopub.status.busy": "2026-07-11T20:48:16.670635Z",
+     "iopub.status.idle": "2026-07-11T20:48:16.675536Z",
+     "shell.execute_reply": "2026-07-11T20:48:16.675114Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                 n_samples: 141\n",
+      "                n_features: 1753\n",
+      "            target_classes: ['CRC', 'Control']\n",
+      "        class_distribution: {'Control': 88, 'CRC': 53}\n",
+      "                  sparsity: 0.9083273658530665\n",
+      "  mean_features_per_sample: 160.70212765957447\n",
+      "\n",
+      "X shape: (141, 1753) | y distribution: {1: 88, 0: 53}\n"
+     ]
+    }
+   ],
+   "source": [
+    "info = dataset.get_info()\n",
+    "for key in [\n",
+    "    \"n_samples\", \"n_features\", \"target_classes\", \"class_distribution\",\n",
+    "    \"sparsity\", \"mean_features_per_sample\",\n",
+    "]:\n",
+    "    print(f\"{key:>26}: {info[key]}\")\n",
+    "\n",
+    "X, y = dataset.X, dataset.y\n",
+    "print(\"\\nX shape:\", X.shape, \"| y distribution:\", dict(y.value_counts()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b69c228d",
+   "metadata": {},
+   "source": [
+    "## 3. Microbiome-aware preprocessing\n",
+    "\n",
+    "The transforms are plain sklearn transformers, usable standalone or in a `Pipeline`:\n",
+    "- **`AbundanceFilter`** — drop very-low-abundance features\n",
+    "- **`PrevalenceFilter`** — drop features present in too few samples\n",
+    "- **`CLRTransform`** — centered log-ratio transform for compositional data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "925bd759",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:16.676939Z",
+     "iopub.status.busy": "2026-07-11T20:48:16.676860Z",
+     "iopub.status.idle": "2026-07-11T20:48:16.680843Z",
+     "shell.execute_reply": "2026-07-11T20:48:16.680629Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raw features:            1753\n",
+      "After abundance filter:  322\n",
+      "After prevalence filter: 321\n",
+      "After CLR (shape kept):  321\n",
+      "CLR output is real-valued (log-ratios): min=-3.13, max=11.24\n"
+     ]
+    }
+   ],
+   "source": [
+    "from microfactual import AbundanceFilter, CLRTransform, PrevalenceFilter\n",
+    "\n",
+    "step1 = AbundanceFilter(min_abundance=1e-6).fit_transform(X)\n",
+    "step2 = PrevalenceFilter(min_prevalence=0.01).fit_transform(step1)\n",
+    "step3 = CLRTransform().fit_transform(step2)\n",
+    "\n",
+    "print(f\"Raw features:            {X.shape[1]}\")\n",
+    "print(f\"After abundance filter:  {step1.shape[1]}\")\n",
+    "print(f\"After prevalence filter: {step2.shape[1]}\")\n",
+    "print(f\"After CLR (shape kept):  {step3.shape[1]}\")\n",
+    "print(\"CLR output is real-valued (log-ratios):\",\n",
+    "      f\"min={np.asarray(step3).min():.2f}, max={np.asarray(step3).max():.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd44ad85",
+   "metadata": {},
+   "source": [
+    "The `MicrobiomeDataset` also offers convenience methods that track a preprocessing history:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e67a9108",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:16.681999Z",
+     "iopub.status.busy": "2026-07-11T20:48:16.681920Z",
+     "iopub.status.idle": "2026-07-11T20:48:16.687662Z",
+     "shell.execute_reply": "2026-07-11T20:48:16.687463Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: Negative values found in abundance data\n",
+      "MicrobiomeDataset Summary:\n",
+      "  Samples: 141\n",
+      "  Features: 321\n",
+      "  Target: Group (2 classes)\n",
+      "  Sparsity: 0.00%\n",
+      "  Preprocessing steps: 2\n",
+      " - filter_features {'abundance_cutoff': 1e-06, 'prevalence_cutoff': 0.01}\n",
+      " - clr_transform {'log_n0': 1e-06}\n"
+     ]
+    }
+   ],
+   "source": [
+    "processed = dataset.filter_features(\n",
+    "    abundance_cutoff=1e-6, prevalence_cutoff=0.01, inplace=False\n",
+    ")\n",
+    "processed = processed.clr_transform(inplace=False)\n",
+    "print(processed)\n",
+    "for step in processed._preprocessing_history:\n",
+    "    print(\" -\", step[\"step\"], step.get(\"parameters\", {}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7efa1343",
+   "metadata": {},
+   "source": [
+    "## 4. sklearn-native usage\n",
+    "\n",
+    "`MicrobiomeClassifier` is a drop-in sklearn estimator (`preprocessing=\"auto\"` bundles the three transforms above), so all of sklearn's model-selection machinery works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "12d1d982",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:16.688707Z",
+     "iopub.status.busy": "2026-07-11T20:48:16.688627Z",
+     "iopub.status.idle": "2026-07-11T20:48:17.069564Z",
+     "shell.execute_reply": "2026-07-11T20:48:17.069258Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   test_accuracy: 0.751 ± 0.061\n",
+      "         test_f1: 0.818 ± 0.043\n",
+      "    test_roc_auc: 0.852 ± 0.071\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.model_selection import cross_validate\n",
+    "\n",
+    "clf = mf.MicrobiomeClassifier(algorithm=\"random_forest\", preprocessing=\"auto\")\n",
+    "\n",
+    "cv = cross_validate(\n",
+    "    clf, X, y, cv=5,\n",
+    "    scoring=[\"accuracy\", \"f1\", \"roc_auc\"],\n",
+    "    return_train_score=False,\n",
+    ")\n",
+    "for metric in [\"test_accuracy\", \"test_f1\", \"test_roc_auc\"]:\n",
+    "    print(f\"{metric:>16}: {cv[metric].mean():.3f} ± {cv[metric].std():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1d9b30c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:17.070798Z",
+     "iopub.status.busy": "2026-07-11T20:48:17.070721Z",
+     "iopub.status.idle": "2026-07-11T20:48:17.528842Z",
+     "shell.execute_reply": "2026-07-11T20:48:17.528566Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best params: {'algorithm': 'random_forest', 'preprocessing': None}\n",
+      "Best CV ROC-AUC: 0.833\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GridSearchCV works over the estimator's declared params (algorithm, preprocessing).\n",
+    "# NOTE: underlying-model kwargs (e.g. n_estimators) are passed via **model_params and\n",
+    "# are not currently exposed through get_params, so they can't be tuned this way yet.\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "\n",
+    "grid = GridSearchCV(\n",
+    "    mf.MicrobiomeClassifier(),\n",
+    "    param_grid={\n",
+    "        \"algorithm\": [\"random_forest\", \"logistic\"],\n",
+    "        \"preprocessing\": [\"auto\", None],\n",
+    "    },\n",
+    "    cv=3,\n",
+    "    scoring=\"roc_auc\",\n",
+    ")\n",
+    "grid.fit(X, y)\n",
+    "print(\"Best params:\", grid.best_params_)\n",
+    "print(f\"Best CV ROC-AUC: {grid.best_score_:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8f2bbff",
+   "metadata": {},
+   "source": [
+    "## 5. One-liner API\n",
+    "\n",
+    "`mf.classify()` wraps load → preprocess → cross-validate → fit into a single call, straight from file paths."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0bc5860b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:17.530107Z",
+     "iopub.status.busy": "2026-07-11T20:48:17.530027Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.024798Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.024536Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Returned keys: ['model', 'dataset', 'cv_scores']\n",
+      "CV scores:\n",
+      "            fit_time: 0.070\n",
+      "          score_time: 0.004\n",
+      "       test_accuracy: 0.751\n",
+      "      train_accuracy: 1.000\n",
+      "             test_f1: 0.818\n",
+      "            train_f1: 1.000\n",
+      "        test_roc_auc: 0.852\n",
+      "       train_roc_auc: 1.000\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = mf.classify(\n",
+    "    ABUNDANCE, METADATA,\n",
+    "    target_column=\"Group\",\n",
+    "    sample_column=\"Sample ID\",\n",
+    "    algorithm=\"random_forest\",\n",
+    "    cv_folds=5,\n",
+    ")\n",
+    "print(\"Returned keys:\", list(results))\n",
+    "print(\"CV scores:\")\n",
+    "for k, v in results[\"cv_scores\"].items():\n",
+    "    print(f\"  {k:>18}: {v:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b4795c",
+   "metadata": {},
+   "source": [
+    "## 6. Train / test evaluation\n",
+    "\n",
+    "A held-out split to produce predictions we can visualize below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cca5c8b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.026031Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.025953Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.097842Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.097589Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "         CRC       0.70      0.44      0.54        16\n",
+      "     Control       0.73      0.89      0.80        27\n",
+      "\n",
+      "    accuracy                           0.72        43\n",
+      "   macro avg       0.71      0.66      0.67        43\n",
+      "weighted avg       0.72      0.72      0.70        43\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import classification_report\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.3, random_state=42, stratify=y\n",
+    ")\n",
+    "\n",
+    "model = mf.MicrobiomeClassifier(algorithm=\"random_forest\", preprocessing=\"auto\")\n",
+    "model.fit(X_train, y_train)\n",
+    "\n",
+    "y_pred = model.predict(X_test)\n",
+    "y_proba = model.predict_proba(X_test)[:, 1]\n",
+    "\n",
+    "print(classification_report(y_test, y_pred, target_names=dataset.target_names))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7313af49",
+   "metadata": {},
+   "source": [
+    "## 7. Visualization\n",
+    "\n",
+    "Built-in plotting helpers return matplotlib figures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "102e512c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.099001Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.098926Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.166755Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.166543Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAr4AAAIjCAYAAADlfxjoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfFlJREFUeJzt3Qd0VNXWwPFNAgmh9w6JShEUAelNuijSBBTpHaWJNKWDFFGqCgjSEUFREUVBeKKANEGa9N57DRBKCMl8a5/3TV4qJCGTO+X/W2sgc6edmZuZ7Nl3n32S2Ww2mwAAAABuzsvqAQAAAABJgcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB6BwBcAEGdr166VZMmSmf8BwNUQ+AJwqGPHjsnbb78tTz/9tKRMmVLSpUsnFStWlM8++0zu3bsXfr2AgAATUNlPqVOnljJlyshXX30V4/3eunVLPvzwQylWrJikSZNG/Pz85Pnnn5cPPvhAzp8/L85g165d0rJlS8mbN6/4+vpKpkyZpGbNmjJ37lwJDQ112ONu2rRJhg8fLoGBgeJu9HlF/D1JkSKF+d159913Y32+ISEh8vnnn0vp0qUlbdq05vdFf9ZtellMdP/ofqpatarZb7r/9HHatWsn27Ztc/CzBOAoyR12zwA83vLly+WNN94wQUPr1q1NYPrgwQPZsGGD9OvXT/bt2yczZswIv37x4sWlT58+5ucLFy7IrFmzpE2bNhIcHCydOnUKv97x48dNAHn69Glz/507dxYfHx/ZvXu3zJ49W5YuXSqHDx8WK+nY33nnHcmePbu0atVKChQoILdv35Y//vhDOnToYJ7fwIEDHRb46peCtm3bSoYMGcQdTZs2zQSwd+7cMa/p5MmTZceOHeZ3KyK9/LXXXpN169ZJ3bp1zWvi5eUlK1eulJ49e8qPP/5ofk/1i5adfiFr1KiRuc5LL71k9pMGvydPnpTvvvtO5s+fb3738uTJY8EzB/BEbADgAMePH7elSZPG9uyzz9rOnz8f7fIjR47YPv300/Dz/v7+ttdeey3SdS5fvmzuo3DhwuHbQkJCbMWKFbOlSpXKtn79+mj3e/PmTdvAgQNtVtq8ebPN29vbVqlSJdutW7eiXf7PP//Y5s6d67DHHzdunE0/3k+cOPHY64aGhtru3bsX5/tes2aNuW/93wrDhg0zj3/lypVI25s2bWq2b9myJdL2zp07m+2TJ0+Odl9Tpkwxl73zzjuRtnfr1s1snzRpUrTbPHz40Ly+Z86cSbTnBCDpEPgCcAgNJjR42LhxY5yuH1Pgq0qVKmXz8fEJP//tt9+a+x09enSCxvX999+b269duzbaZdOnTzeX7dmzx5y/cOGCrW3btrbcuXObMeTIkcNWv379xwaUr7zyii158uS2U6dOxWlMQUFBtt69e9vy5MljHqdgwYImuAoLC4t0PR2bBmVLly61Pffcc+a6RYoUsf3222/RAsOoJ/uY7ffx9ddfm9vqOPX+1I4dO8zY06ZNa0udOrWtevXqJoh3hcDXHsQuWrQofJsGp/oFRJ9HbKpVq2ZeA3sgq//r+Vq1ajnwWQCwCqUOABzil19+MXW9FSpUSPB9PHz4UM6ePSsZM2YM37Zs2TLzv5YPJIQe9tZD5HrIukqVKpEuW7x4sTz33HOmJEM1btzYlGP06NHD1HdevnxZfv/9d3OYW8/H5O7du+bQux4iz5cv32PHo7Fo/fr1Zc2aNaYEQss9Vq1aZUpBzp07J5MmTYp0fT2Ur4fnu3btaupVtU5Vx6ljypw5szlEr2Ue33zzjbltlixZzO2yZs0afh9//vmnef7du3c3l+tz0edZuXJlU4P9/vvvm9rZL7/80tS4aplA2bJlxZlpGYKK+Lvy22+/mVpdLbOJjV6mr72WNXTs2NHcRn/vEvr7BcDJWRZyA3BbWm6gHy8NGjSI82004/vyyy+bTJ6eNOvaqlWr8AylXYkSJWzp06d/ovE1a9bMli1bNnPY2k6zu15eXrYRI0aY8zdu3DCPrZnX+Pj333/N7Xr27Bmn6//000/m+qNGjYq0vUmTJrZkyZLZjh49Gr5Nr6dZ3ojb7I8X8VD+o0oddLs+z3379kXa3rBhQ3Pfx44dC9+mJSqa/X3ppZecLuN76NAh83ty8uRJ25w5c2x+fn62rFmz2u7cuRN+3ffee89cd+fOnbHen2a59TqacVe9evV67G0AuC66OgBIdNpxQWlGMj7+85//mMyknooWLSoLFiwws+jHjRsX6b7je79RNW3a1GRvI7bk+uGHHyQsLMxcprRLhE6Y0+vcuHHDYc99xYoV4u3tbboSRKST/DRO1QxkRDqp75lnngk//8ILL5gsrU74iyvNdBcpUiT8vGZF9bVv2LChydLb5cyZU5o3b26yzPbn5SwKFSpkfk80W92+fXvJnz+/ea1SpUoVfh2dTPi4fWG/zP78Evq7C8A1UOoAINFpIBYx8IgrPZw+atQoE4jt3bvX/KxBpwagEe87PkFeTF555RVJnz69KW2oUaOG2aY/a5lBwYIFzXntRPHJJ5+YAFQ7M5QrV850BdBD4zly5Ei0537q1CnJlStXtECrcOHC4ZdHFFP5hB7ej09w/tRTT0U6f+XKFVOiocFkVDoO/UJw5swZUwYSF9q54/r165IQuq+1g8LjLFmyxLzWOnYt9zhx4oT5shKR/TV91L6IGhwn9HcXgGsg4wsg0WnwoMGcBq/xofWmmtGsXbu2CTi//vpr+emnn0zPX7tnn31Wbt68aQKxhNKgVrOb2vZM6zm1lnbjxo3h2V679957z9TLjhkzxvQgHjJkiAkEd+7cGet9a+YxefLksmfPHnEEzQ7H5L9VDHETNUB0RDs1zRYn5KQ1ynGhNdT6u9KsWTNTd63PqUWLFiZIj/rlQdvcxcZ+mT0Drr9fylH7D4C1CHwBOIRmR3Xxis2bNyf4PnQimh6W/+ijj0w/VlWvXj3zvwbFT0KD3KtXr5qJaN9//70JHKMGvkrLCjQI11IADeQ1mzlhwoRY71cPtVevXl3++uuvOAXn/v7+ZsGNqBnGgwcPhl8eX7qwQ3xoyYCO+9ChQ9Eu03Fo31tdhCOudFERDUYTcnrUaxsbnaw4bNgws2CITtqze/XVV80XBS2ZiY0ukKJfVPQoQMTbPOnvFwAnZXWRMQD3pBOwtCWWtsy6ePFijJc/ro+vWrFiRaSeqg8ePLAVLVrU3PemTZuiXV/75salj6/eT6ZMmWzt2rWzlStXzlamTJlIl+skqaj9bbXnbfbs2c3Es0fRFm7aRqtKlSq227dvR7t827Zttnnz5kWa3PbRRx9F60sb0+S2iBP9Ir52bdq0CT8/bdq0WCdoxXYfOrnN19c30oQ43W/p0qVzysltUduZ6f7UdnDFixePtL1jx47m+l988UW0+7K/Tm+//XaMrfg+//zzaLfR34Hx48fTxxdwUdT4AnAIzZQuWrTIZFH1kHPEldv0ULhmWXUVrcfRDJzebuLEidKtWzfTZkvbeelhbj3c/eabb5olkHW7tuTSx9Sa19GjRz/yfvX6elj922+/Ndnk8ePHR7pcSxy0/lfvXw+Da1ZQSyMuXbokb7311iPvW1u4TZ061bQc00PnEVdu08ly2pJN65ftGexq1arJoEGDTEsuzZZqdvnnn382pRYRJ7LFVcmSJc3/ep86Vn2u+jgRVyeLSsejGddKlSqZcevz1XZmumre2LFjxdnpc9SV2LQNnLYms2dwtaWbZq31OUXcri3j9DXWIwpRs8x6Xo9W6IRD/V3Toxf6O6Ut4/T3Vu/vcb8DAJyU1ZE3APd2+PBhW6dOnWwBAQGmXZa2x6pYsaJpv3X//v3HZnyVZkf14yriamfabmzo0KEm+6uruKVMmdL2/PPP2wYMGGBak8XF77//bu5XM6tRM3hXr141mVFdeU6zy9pCrWzZsrbvvvsuzs99+/bttubNm9ty5cplS5EihS1jxoy2GjVq2ObPn28yh3aaFdY2WvbrFShQ4JELWDwu46tGjhxpFt7Q1mUxLWARW2uv2rVrm9Xy9DXVxR2iZtWdNeNrb6On+0kz7REFBwebIwYlS5Y0+1Kf24svvmiOOGimOCba6m7WrFm2ypUrm/vU/aKvsx4hoNUZ4LqS6T9WB98AAACAozG5DQAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHsHjFrDQddx1edC0adPGe1lPAAAAOJ5229VFf3LlymWWTU8sHhf4atAbnzXnAQAAYI0zZ85Injx5Eu3+PC7w1UyvOnXqlGTIkMHq4SAJMvxXrlyRrFmzJuo3Rjgn9rdnYX97Fva3ZwkMDBR/f//wuC2xeFzgay9vSJcunTnB/T8o79+/b/Y1H5Tuj/3tWdjfnoX97Vl0f6vELkvlNwcAAAAegcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB6BwBcAAAAegcAXAAAAHoHAFwAAAB7B0sD3r7/+knr16kmuXLkkWbJk8tNPPz32NmvXrpUXX3xRfH19JX/+/DJv3rwkGSsAAABcm6WB7507d6RYsWIyderUOF3/xIkT8tprr0m1atVk165d8t5770nHjh1l1apVDh8rAAAAXFtyKx/81VdfNae4mj59ujz11FMyYcIEc75w4cKyYcMGmTRpktSuXduBIwUAAIi/63ceyLS1R+Vc4D2rh+JSgu8GuV/gG1+bN2+WmjVrRtqmAa9mfmMTHBxsTna3bt0y/4eFhZkT3JvuY5vNxr72EOxvz8L+9iyuur/nbjwhM9efsHoYLiUs5L7c+HOWQ+7bpQLfixcvSvbs2SNt0/MazN67d0/8/Pyi3WbMmDHy4YcfRtt+5coVefDggUPHC+vpB+TNmzfNh6WXF3M53R3727Owvz2Lq+7vk5duWD0ElxO4dq4E7fnDIfftUoFvQgwYMEB69+4dfl6D5Lx580rWrFklQ4YMlo4NSfNBqRMndX+70gclEob97VnY357FVfe3n9+l8J8XtC8tT2dNbel4nHn/njl9SvwDnpIr7QrLmTOnpX6tap4d+ObIkUMuXfrfL5DS8+nSpYsx26u0+4OeotI3jSu9cZBw+kHJ/vYc7G/Pwv72LK64v5NJsvCfs6f3k9wZCXyjOnfunLRr00b2798vx44dk9yFnpaA7JnEEVznN0dEypcvL3/8ETn1/fvvv5vtAAAAcC1LliyRokWLyoEDB+Srr76KNZHpFoFvUFCQaUumJ3u7Mv359OnT4WUKrVu3Dr/+O++8I8ePH5f3339fDh48KF988YV899130qtXL8ueAwAAAOJv+PDh0qRJE6levbrs3r07WgMDR7C01GHbtm2mJ6+dvRa3TZs2ZmGKCxcuhAfBSluZLV++3AS6n332meTJk0dmzZpFKzMAAAAXERoaKt7e3mZthnz58km7du1MGUtSsDTwrVq1qpmdGZuYVmXT2+zcudPBIwMAAEBiB7zabWvlypWyZs0aKV26tDklJZeq8QUAAIDrOXnypEleDhs2zJQ2WMWlujoAAADAtXz33XfSqVMnyZgxo6xbt04qVapk2VjI+AIAAMBh7t69K/Xq1ZN///3X0qBXEfgCAAAgUa1fv14GDx4c3rTg66+/lvTp04vVCHwBAACQKEJCQmTQoEGmnvevv/6Se/fuJVnHhrgg8AUAAMATO3LkiFSsWFHGjh0rI0eONJ0bHL0gRXwxuQ0AAABPbMaMGRIYGCibNm1K8jZlcUXgCwCAE7kfEiprD12RoOCHVg/FqdhsYXLr1m1Jd/aBJEvmOgesT1y9I+7s2rVrsmXLFqlTp47J8mq7sjRp0oizIvAFAMCJfLBkt/y867zVwwAea/Xq1WbimtbwHj16VFKmTCnOznW+MgEA4AF2nQm0eghwgHQpk0vejKnEHQQHB0ufPn2kVq1aUqRIEZPxdYWgV5HxBQDACaXy8ZaBdQpbPQynYbPZ5Pbt25I2bVqn6hIQF17JkslLBbOIn4+3uINevXrJ7NmzZcKECfLee++Jl5fr5FEJfAEAcEIpU3hLy3L+Vg/DaYSFhcnly5clW7ZsLhVoudMXj3PnzkmePHlk4MCB0rlzZylevLi4Gn5zAAAAEKtLly5J3bp1Tauy+/fvm+DXFYNeRcYXAAAAMfr111+lffv2prxk7ty5LlPLGxsyvgAAAIhmxIgRUq9ePSlTpozs2bPHtCxzdWR8AQAAEKmeVzO81apVk6xZs8o777zjchMKY0PGFwAAAKITCMePHy+vvPKKhIaGSuXKlaVLly5uE/QqAl8AAAAPd+7cOXn55ZelX79+8sILL5gg2B1R6gAAAODBli5dKh06dJBUqVKZ1dhq1Kgh7oqMLwAAgAc7f/68VK9eXXbv3u3WQa8i8AUAAPAwW7dulTFjxpifu3btKt9//71kypRJ3B2BLwAAgIcIDQ2VUaNGSYUKFeTnn382C1Lo5DV3msD2KAS+AAAAHuDkyZNStWpVGTZsmAwYMEDWr1/v8gtSxBeT2wAAADzAhAkT5MyZM7Ju3TqpVKmSeCIyvgAAAG4qMDBQ1qxZY37++OOPZdeuXR4b9CoyvgAAAG5ISxlatmwpDx8+lOPHj0vq1KnF05HxBQAAcCMhISEyaNAgU8+bL18+2bhxo/j6+lo9LKdA4AsAAOBGevToIWPHjpWRI0fK2rVrJSAgwOohOQ1KHQAAAFyczWaTq1evStasWeX999+X9u3bS5kyZaweltMh4wsAAODCrl27Jo0bN5by5ctLcHCwPP300wS9sSDjCwAA4KJWr14tbdq0MQtRzJw5k1rexyDjCwAA4II++ugjqVWrlhQpUkR2794tjRo1snpITo/AFwAAwMXqeVWpUqXMohSrVq2S3LlzWz0sl0DgCwAA4CIB75QpU0w9r/788ssvS+/evcXLi3AurnilAAAAnNylS5ekbt26plWZZne1Vy/ij8ltAAAATmzFihXStm1bSZYsmSxfvlzq1Klj9ZBcFhlfAAAAJ7Z3717TnmzPnj0EvU+IwBcAAMDJ7Nq1SyZPnmx+7tu3r/zyyy+SLVs2q4fl8gh8AQAAnERYWJiMHz/eZHjnzZsnDx48MJPXtMwBT47AFwAAwAmcO3fOdGro16+f9OzZUzZt2iQ+Pj5WD8utMLkNAJDotNXS5uPX5NutZ+TMjbsOehAxM9tTpDgm4kbJsAs371s9BFhk5MiRcuDAAbMaW40aNawejlsi8AUAJJqg4IeydMdZ+WrzKTlyOcjq4bg03+QclPUEQUFBZvJauXLl5JNPPpHRo0dL5syZrR6W2yLwBQA8saOXg2TB5pOyZMc5E/ziyfil8JZOlZ+2ehhwsC1btkiLFi0kODhYjh07JunTp7d6SG6PwBcAkCAPQ8Pkj4OX5avNJ2Xj0WvRLi8TkElalfeX2s/lEB8HZC91EtDly5fNTHdWroIrCQ0NlTFjxsjw4cOlZMmSsnDhQmp5kwiBLwAgXq4FBcvibWdk4d+n5VzgvWiZyoYlckmrcgFSJFc6y8YIOLNu3brJzJkzZeDAgTJ06FBJkSKF1UPyGAS+AIA42XUm0GR3f/33gjwIDYt0WUDmVNKynL+8UTKvpE/FH3EgJoGBgZIhQwbTsUFLHCpXrmz1kDwOgS8AIFb3Q0Jl+e4LJuD99+zNSJdpW9FqhbJJ6/L+8lKBrOLl5UatFYBEDng1y6uLUuzcuVMKFy5s9ZA8FoEvACCaszfuysItp2XxP2fk+p0HkS5L75dCmpbOKy3L+ku+zKksGyPgCtavXy8tW7Y0we+0adOo5bUYgS8AILz3rk5Sm7/5pPxx4JKE2SJfXiRnOmlbIUDqFcslfj7eVg0TcBljx46VAQMGSMWKFeWvv/4Sf39/q4fk8Qh8AcDD3b4fIku2n5UFf5+SY1fuRLoshXcyqVM0pylneDFfRpZNBeKhUKFCZlGKDz74QLy9+bLoDAh8AcBDHb5029TuLt1xTu48CI10WfZ0vtKirL+8VSavZEub0rIxAq521GTOnDkmuztv3jxp0KCBOcF5EPgCgIf13v19/yWzspouKRxV2acySZsKAVKrSHZJ4U1vXCCurl27Jp06dZKlS5dKhw4dzHLa1PM6HwJfAPAAV4OC5dutp82EtQs370e6LJWPt7xeIre0Lh8ghXKktWyMgKtavXq1tGnTRu7fvy9LliyRRo0aWT0kxILAFwDc+LDrTu29u+mkrNhzMVrv3aezpDYrqzUumUfSpaT3LpBQGzZskCJFipjyhty5c1s9HDwCgS8AuGHv3WX/njf1u3vP3Yp0mc5Nq/FsdjNZrVL+LPTeBRJo37598vfff5uyhiFDhpiJnyyd7fwIfAHATZy5fle+/vuUWU448G5IpMsypPpf7928mei9CzzJkZQvvvhC+vbtKwULFpRWrVpRy+tCCHwBwIWFhdlk/dGrppzhz0OXxRal927R3OlNdld776ZMQTsl4ElcunRJ2rdvLytWrJDu3bubPr0Eva6FwBcAXNDNe//rvXviauTeuz7eXvLaC//tvVs8bwZ67wKJRBej2LZtmyxfvlzq1Klj9XCQAAS+AOBCDl68ZVqRae/deyGRe+/mTJ9SWpbzNyUNWdL4WjZGwJ3cu3dPDh06JMWLFzcZ3jFjxkj27NmtHhYSiMAXAJxcSGiY/GffJbOU8NYT16NdXuGZzCa7W7NwdklO710g0ezatUuaN28uQUFBcvToUcmSJYvVQ8ITIvAFACd1+fZ9+WbLGVm09ZRcuhUc6bLUPt7S6MU8JuAtkJ3eu0BiCgsLk4kTJ8rAgQNNm7KVK1dSy+smCHwBwMlmjG8/dcOUM/y294KEhEaerfZM1tRmoYlGL+aWtPTeBRyiW7duMn36dNO5YdSoUeLrS+mQuyDwBQAncO+B9t49J/M3nZL9FyL33tVWu1rGoEsJa1kDk9UAx7hz546kTp1a3n77bWncuLHUrFnT6iEhkRH4AoCFTl27Y3rvfrftrOnUEFGm1D7yVum80qKcv+TO4GfZGAF3pzW8PXv2NDW9uiiFTmSDeyLwBQALeu+uO3LF9N5de/hKtN67xfJmkDbl/aVO0Zz03gUcbOvWrdKiRQu5cOGCfP7555I8OaGRO2PvAkASuXk3RL7ffsb03j117W6ky3ySe0m9F3KZyWoa+AJwvEmTJkm/fv2kZMmS8ttvv0n+/PmtHhIcjMAXABxs/3ntvXtSftp1Tu6HhEW6TEsYWpTLJ01L5ZXM9N4FklSOHDnMohRDhw6VFCmYLOoJCHwBwAEePAyTlfsuyoLNJ+WfkzeiXV4pfxaT3a1ROLt46+w1AEli4cKFsmnTJpk6dao0a9bM6uEgiRH4AkAiunTrvizacloWbT0tV25H7r2bxje5NCmZx6yulj9bGsvGCHiiwMBA06Zs0aJFpqY3JCSELK8HIvAFgETovasrqn319ylZtfeiPAyLPFutQLY00rpCgLxeIrcJfgEkrfXr10urVq3kxo0bJuOrq7HBM/EJDAAJdPfBQ/lp53lTv3vw4u1Il2n5wstFspvFJso9nYneu4CFfvnlF8mXL5+sW7dO/P39rR4OLETgCwDxdOLqHVmw+ZTp0HD7/sNIl2VJo71380nzsvkkF713AcscOXJEtm/fLm+99ZaMHj1avLy8xNub9oCejsAXAOLYe3fNoctmKeF1h69Eu7xEPu29GyCvFs0hvsn54wpYWXo0Z84csyBFQECAWYGNWl7YEfgCQByM+HW/zNt0MtI23+ReUr+Y9t4NkKJ50ls2NgD/de3aNencubP8+OOP0qFDB/n0008JehEJgS8AxMHaQ5fDf86T0U9alfOXN0vllYypfSwdF4D/6dWrl6xdu1aWLFkijRo1sno4cEIEvgAQB/Y+Den9Usi6ftXovQs4ieDgYDl+/LgULlxYxo4dK2PGjJHcuXNbPSw4KQJfAIgHDXgJegHnsG/fPtOT99atW3L48GGzEhvwKF5iMV05RYvPU6ZMKWXLlpWtW7c+8vpar1OoUCHx8/OTvHnzmsMa9+/fT7LxAgAA6yewafxQqlQpsxDF0qVLJXlycnlw8sB38eLF0rt3bxk2bJjs2LFDihUrJrVr15bLl/9XSxeRrrbSv39/c/0DBw7I7NmzzX0MHDgwyccOAACsoSuwde/eXTp27Cjbtm0z8QPg9IHvxIkTpVOnTtKuXTspUqSITJ8+XVKlSmXakMRE19auWLGiWXFFs8Qvv/yyWWf7cVliAADgHvW8qk2bNvLrr7/K5MmTzRFgIK4sOy7w4MED01h6wIAB4du0uXTNmjVl8+bNMd6mQoUK8vXXX5tAt0yZMqaYfcWKFWYZwke9SexvFKV1QCosLMyc4N50H+shMfa1Z3Do/rbPbuP3yWnw/vYcd+/elX79+pnsri4/XLp0abOdfe++why0by0LfK9evSqhoaGSPXv2SNv1/MGDB2O8jWZ69XaVKlUyH3YPHz6Ud95555GlDjq788MPP4y2/cqVKyb4hvu/cW7evGl+X/SLFdybI/e3fl6Zx7DZYi3HQtLi/e0Z9u7dK127dpUzZ86Y4Fd79bICm/u7efOmQ+7XpSrBtTffRx99JF988YWZCHf06FGzMsvIkSNlyJAhMd5GM8paRxwx46uT4rJmzSoZMmRIwtHDqj+MyZIlM/ubP4zuz5H72/6H1itZMsmWLVui3jcShve3+5syZYr07dtXnnvuOdmyZYvZ1+xvz+Dj4+NegW+WLFnMH5JLly5F2q7nY2tHosGtljVoMbsqWrSo3Llzx6zSMmjQoBjfCL6+vuYUlV6XN45n0D+M7G/P4bD9be9g9v/3D+fA+9u9pU6d2iS4Ro0aZVZg06Mt7G/P4OWgfexlZSRfsmRJ+eOPPyJ9e9fz5cuXj7XGJ+oLYc/C6KEuAADg2nTVNe3gpHTZ4XHjxsWYwAISwtKvTFqCMHPmTJk/f75pT9alSxeTwdUuD6p169aRJr/Vq1dPpk2bJt9++62cOHFCfv/9d5MF1u3U+wAA4LqCgoJMoNukSRM5cuSImccDuFWNb9OmTc0ks6FDh8rFixelePHisnLlyvAJb6dPn46U4R08eLA5rKX/nzt3ztT5aNA7evRoC58FAAB4EtqtSVdgu3DhgunRrwkw/XsPuN3kNm1ArafYJrNFpKuy6OIVegIAAO5hwYIFkilTJtOitECBAlYPB27M8sAXAAB4npMnT8q///4rDRo0MHW8WrKoE9gAR2JaJAAASFILFy40ywzrPB6t5U2ZMiVBL5IEgS8AAEgSgYGBppa3ZcuWZo6OrtSqZYxAUuG3DQAAJAldgW358uUm46ursQJJjYwvAABwmJCQEDl+/Lj5+eOPPzZ1vQS9sAoZXwAA4BDaj1dLG7TEYf/+/ZIvXz6rhwQPR8YXAAAkKl1NVfvxlihRwgS9WtpALS+cAYEvAABIVD169JCOHTtKs2bNZMeOHVK6dGmrhwQYfP0CAACJQluTaWZXlx2uXr26NGrUyOohAZEQ+AIAgCcSHBwsAwcOlN27d8uqVaukatWqVg8JiBGlDgAAIMH27dsnZcuWlSlTpsirr75q9XCARyLwBQAACTJjxgwpVaqUPHjwQLZs2SK9e/cWLy9CCzgvfjsBAECC3Lt3Tzp06CDbt2+X4sWLWz0c4LGo8QUAAHGmK69pp4YhQ4ZIz549rR4OEC9kfAEAwGPdvXtXunXrJnXr1pWtW7eaDg6AqyHjCwAAHmnXrl1mmeETJ07I1KlTpUuXLpIsWTKrhwXEG4EvAAB4JA12fX19TS1vkSJFrB4OkGAEvgAAIJpz586ZVmUvv/yyfPrpp2ZhCg1+AVdGjS8AAIhkyZIlUrRoUTN5LTQ0VFKnTk3QC7dA4AsAAIygoCDTnsy+5PCGDRvE29vb6mEBiYZSBwAAYGjQq+3KZs+eLe3atWMCG9wOGV8AADyYljKcPXvW/Dx69GjTwaF9+/YEvXBLZHwBAPBQJ0+elJYtW8r169dlz549kj9/fquHBDgUGV8AADzQwoULpVixYibbO2PGDGp54REIfAEA8DDvvfeeyfTWq1dP/v33X6lUqZLVQwKSBKUOAAB4iLCwMPHy8pJXXnlFypQpY1ZjAzwJgS8AAG4uJCREPvzwQ9m7d68sXbrUBL6AJ6LUAQAAN3bkyBGpWLGifPLJJ1K6dGmx2WxWDwmwDBlfAADc1Ny5c6VHjx6SK1cu2bRpkwl8AU9GxhcAADd18eJFadasmezYsYOgFyDjCwCAe1m9erXpydurVy/p378/C1EAEZDxBQDADQQHB0vfvn2lVq1asnLlSrMiG0EvEBmBLwAALm7fvn1StmxZmTx5skyYMEF+++03FqQAYkCpAwAALu7jjz+WBw8eyJYtW6R48eJWDwdwWgS+APAIx68EyYK/T8mFwPtWDwWI5NKlS3L48GGpXLmyTJkyRXx8fMTPz8/qYQFOjcAXAKIIDbPJmoOXZf7mk7L+yNVIl+XNlMqycQF2y5cvl3bt2kmWLFnMRLb06dNbPSTAJRD4AsD/u3HngSzedka+/vuUnL1xL9JlKVN4SYNiueW9WgUsGx9w79496devn0ydOlVee+01mTNnDrW8QDwQ+ALweHvO3pSvNp+UZf+el+CHYZEuy5cplbQq5y9vlMojGVL5WDZGQLVp00Z++eUX+eKLL+Sdd96hawMQTwS+ADxS8MNQ+W3PRVPOsPN0YLTLqxbKKm3KB0iVglnFy4vgAtYJCwuTq1evSrZs2WT48OHy4YcfSuHCha0eFuCSCHwBeJTzgfdk0ZbT8s3W03LtzoNIl6VLmVzeLJVXWpbzl4AsqS0bI2B37tw5k+XVwFdXXytSpIjVQwJcGoEvALdns9lk8/Fr8tWmU/L7gUtm8lpEhXOmk9bl/aVB8VySyoePRTiHJUuWSKdOnUynhvnz54uXF633gSfFJzwAtxUU/FCW7jgrX20+JUcuB0W6LLlXMnnl+RzSpkKAlPLPSK0knEqfPn1k4sSJ0rhxY/nyyy8lc+bMVg8JcAsEvgDczrHLQfL1ltOyZMc5E/xGlC2trzQvm0+al8kn2dKltGyMQGxHJ/RLWMWKFeW5554zLcv4UgYkHgJfAG7hYWiYrD5wSWb/dUT+OX072uVlAjJJ6wr+Uvu5HJLCm0PGcC6hoaEyZswYOXDggHz99dfSqFEjq4cEuCUCXwAu7VpQsOm9u/Dv03IuMHLvXb8U3tKwRC5pVS5AiuRKZ9kYgUc5efKktGrVSjZt2iSDBg0Kz/oCSHwEvgBc0q4zgab37q//XpAHoZF77/pn/v/euyXzSvpUKSwbI/A433zzjenHmzFjRlm3bp1UqlTJ6iEBbo3AF4DLuB8SKst3XzAB779nb0a6TBNkVQtmlfqF00u9UvkleXJWs4Lz27t3r9SrV8+sxMayw4DjEfgCcHpnb9yVhVtOy+J/zsj1KL130/ulkKal80rLsv6SJ2NKuXz5MgtOwKmtX79e9u/fL2+//baMHDmSNmVAEiLwBeCUtM5x49FrZmW1Pw5ckiitd6VIznTSpoK/1C+WW/x8vMNXuAKcVUhIiFl57eOPP5aqVauaHr0EvUDSIvAF4FRu3w+RJdvPyoK/T8mxK3ciXZbCO5m8+nxOE/C+mI/eu3AdR44ckRYtWsjOnTtNlveDDz4g6AUsQOALwGlsP3Vd2s79R27fj9x7N3s6X2lR1l/eKpNXsqWl9y5cz+DBgyUwMNB0bihdurTVwwE8FoEvAKfx445zkYLesk9lMiur1SqSnd67cDnXrl2T48ePm0D3iy++EF9fX0mTJo3VwwI8GoEvAKfxMPR/hbxz25WWaoWyWToeIKFWr14tbdq0MZ0atHMDSw4DzuGJUij3799PvJEAQAS5M/hZPQQg3oKDg6Vv375Sq1YtKVy4sPz+++/U8gJOJN7vRp01rYX5uXPnNods9DCOGjJkiMyePdsRYwQAwCW0bNlSJk+eLOPHj5f//Oc/5m8lABcOfEeNGiXz5s2TsWPHio+PT/j2559/XmbNmpXY4wMAwOlb7924ccP8PHDgQNmyZYv06dOHTC/ghOL9rvzqq69kxowZpi2Lt/f/VkYqVqyYHDx4MLHHBwCA07p06ZLUrVtXXnnlFXNEtESJElK8eHGrhwUgsSa3nTt3TvLnzx9tu77htTk3AACeYPny5dKuXTvTT3ru3LlkeAEXEO93aZEiRcxyi1H98MMP5psuAADurn///ibTW6ZMGdmzZ4/UqVPH6iEBcETGd+jQoaZFi2Z+Ncv7448/yqFDh0wJxK+//hrfuwMAwOXovJapU6dKly5dWEEQcOfAt0GDBvLLL7/IiBEjJHXq1CYQfvHFF802bd8CAIC70UTPxIkT5dixYzJt2jTTvQGAhyxgUblyZdObEAAAd6dHOPVI5x9//GF69GoQTD0v4Jri/c59+umnzTKMUeka5HoZAADuYsmSJVK0aFHTtUhXYxs3bhxBL+DC4v3uPXnypISGhsa4Wo1+KwYAwF1s2LBBqlevLrt375YaNWpYPRwASVXqsGzZsvCfV61aZdYft9NAWA8BBQQEPOl4AACw1NatW82k7VatWpkMr/asZwIb4GGBb8OGDc3/+ubXWqeIUqRIYYLeCRMmJP4IAQBIAprEGTNmjAwfPlwqVapkFmpKnjxBU2EAOKk4v6O1mF899dRT8s8//0iWLFkcOS4gTvacvSkz1x+XoOCHsS4l+uDBA/HxOU3GxgUcuHDL6iHAQ2kZn2Z4N23aJIMGDZIhQ4ZQywu4oXh/lT1x4oRjRgIkwIe/7JNtp25YPQw4QHIvvqgg6fTq1UvOnDkj69atM9leAO4pQcdw7ty5Yz4cTp8+bbJpEb377ruJNTbgsa4EBVs9BDjASwWzylNZUls9DLg57Uakf8deeOEF05vXz88v0vwVAO4n3oHvzp07zdKMd+/eNQFwpkyZ5OrVq5IqVSrJli0bgS8skSFVClnTp2q07WG2MLl65apkyZpFvJJx2NIVeCVLJulTpbB6GHBz69evN4tQpE2b1nRsyJEjh9VDAuCMga8eDqpXr55Mnz7dfDP++++/zeQ2/QDp2bOnY0YJxCFYypjaJ8ba9BC/5JIxlQ/1egAkJCTETF77+OOPpUKFCrJgwQI+GwAPEu93+65du6RPnz7mg0JbvGj/3rx588rYsWNl4MCBjhklAACJoHnz5ubv1ciRI2Xt2rW04QQ8TLwDX83u2r8da2mD1kcpzf7qxAAAAJyJdncJCgoyP2viZuPGjSZRo8kbAJ4l3qUOJUqUMO3MChQoIFWqVJGhQ4eaGl89XPT88887ZpQAACTAtWvXpFOnTub/NWvWSLly5aweEgBXyvh+9NFHkjNnTvPz6NGjJWPGjNKlSxe5cuWKfPnll44YIwAA8bZ69WrTsUG7EOkcFGp5AcQ741uqVKnwn7XUYeXKlYk9JgAAnsjgwYNNcqZmzZoyb948yZ07t9VDAuAEEu3r744dO6Ru3bqJdXcAACSYv7+/TJgwQVatWkXQCyBhga9+gPTt29dMCjh+/LjZdvDgQWnYsKGULl06fFnj+Jg6daqZVZsyZUopW7asbN269bENx7t162bKLXx9faVgwYKyYsWKeD8uAMC9JrBNmTJF+vXrZ85rXW/v3r0pbwAQSZw/EWbPni2vvvqqOWT0ySefmAkCX3/9tZQvX940/t67d2+8A9DFixebD6Zhw4aZjHGxYsWkdu3acvny5Rivr6vE1apVy6yp/sMPP8ihQ4dk5syZfJsHAA926dIlc8SxR48ecv/+fRMEA8AT1fh+9tlnJuDVb9NLliyRN954Q7744gvZs2eP5MmTRxJi4sSJ5lt5u3btzHldFGP58uUyZ84c6d+/f7Tr6/br16/Lpk2bTFs1RQ9GAPDsCWyaQEmWLJn5+6EriwLAEwe+x44dM8GuatSokSRPnlzGjRuX4KBXs7fbt2+XAQMGhG/TQ1I6EWHz5s0x3mbZsmUmw6ylDj///LNkzZrVNCP/4IMPYu3HqAts6Mnu1q1b5n8ty0hIaQacjD2xY7PFuD91m2Z/2Neegf3tWXQ/6wRrLbXTo5I64Zp97754f3uWMAft5zgHvvfu3ZNUqVKZn/WbtdbX2tuaJYT2/g0NDZXs2bNH2q7ntW44JlpX/Oeff0qLFi1MWcXRo0ela9euZglKLZeIyZgxY+TDDz+Mtl3br2nwDdemv0MqzGaLsURG3zg3b940H5bU+rk/9rdn0NI6LXnT7K4ehcySJYvZHluZHNwD72/PcvPmTevbmc2aNUvSpEljfn748KGp97V/4Ni9++674shfev1GP2PGDJPhLVmypJw7d85knmMLfDWjrIfBImZ8dYllzRZnyJDBYWN1J6FhNll/5KqcC7wnzuZuyH+/EXolS2Z+N2L6ndEvarq/+aB0f+xv99+/kyZNkkGDBpnJ0G3atGF/exDe357Fx8fH2sA3X758ZiKZnU5o09XaItJfyLgGvhowa/CqkxIi0vN63zHRDLPW9kYsayhcuLBcvHjRZG9jepE0M62nqPRNwxsnbhZuOSlDft4nTi1Zslj3p/5esr89B/vbPWmSQwPdP/74w3QXGjVqlPlbwP72LOxvz+HloH0c58BXDyslJg1SNWOrH2LaDs3+bU7Pd+/ePcbbVKxYURYtWmSuZ39BDh8+bAJiR30zgMjec/+ti3ZmxfOSvQfc2dtvv23K4HQyW40aNcw2aj0BOHzltsSkJQj6DV5XgytTpox8+umncufOnfAuD61btzatyrROV+nSyNqnUZee1LY1R44cMUsoO7K8ApH1fbmg5EjvJ84klY+3VCsUvcwBgGsLCgoymd5ChQrJtGnTzDyTzJkzWz0sAC7M0sC3adOmZpLZ0KFDTblC8eLFzQxd+4S306dPR0p1a22uLqLRq1cvs/66BsUaBGtXBySNl5/LIQWzp7V6GADcnC5mpBOZU6dOLTt37jSf/wDg0oGv0rKG2Eob1q5dG22btjP7+++/k2BkAAArOrXoUb7hw4ebcriFCxeauk4AcIvAFwAAu2bNmplFkgYOHGiOBtoXKwKAxEDgCwCwnC41nDJlStObXedwVK5c2eohAXBDCeoVoau4DR482HwztzcM/+2332TfPidveQUAcCqBgYGmlrdBgwZmYYKqVasS9AJwnsB33bp1UrRoUdmyZYv8+OOPZtat+vfff2NdRAIAgKjWr19vJjX/+uuv4YtRAIBTBb79+/c3jcN///33SL1zq1evzqQzAECcjBgxwmR3dXGk3bt3S/Pmza0eEgAPEO/Ad8+ePfL6669H267LxV69ejWxxgUAcGPp0qWTkSNHypo1a8Tf39/q4QDwEPGe3JYhQwa5cOGCPPXUU5G2a59F7asLAEBUWr87Z84cOXv2rCmLe++996weEgAPFO+M71tvvWUWjNAFJ7QeS5eM3Lhxo1k7XVdaAwAgomvXrknjxo2lY8eOZiU2DYIBwCUCX10i+NlnnzWr6OjEtiJFishLL70kFSpUMJ0eAACwW716tVlpUydGa3/eGTNmMIkNgOuUOuiEtpkzZ8qQIUNk7969JvgtUaKEFChQwDEjBAC4rPnz55sEybx58yiHA+B6ge+GDRukUqVKZiaungAAiEh7up86dUrq1KljMry+vr7i5ZWgtvEAkKji/Umkbct0YpsuJ7l///7EHQ0AwGVp7e6UKVOkVKlSMnr0aHPez8+PoBeA04j3p9H58+elT58+pl7r+eefN83Hx40bZ2bqAgA806VLl6Ru3bpmuWGdxKa1vdTyAnD5wDdLlizSvXt308lBly5+4403TA1XQECAyQYDADxP27ZtZdu2bbJ8+XKZPHmyyfQCgMvX+EakJQ+6kluxYsXMZDfNAgMAPMO9e/dMa0v9W6AlDmnTpjWLGQGAs0pw4ZVmfLt27So5c+Y0S01q2YN+0wcAuL9du3ZJyZIlzVE/reV95plnCHoBuF/gO2DAAPPtXssaTp8+LZ999pn5xr9gwQJ55ZVXHDNKAIBT0EWLxo8fL2XKlDHdGr766itqeQG4b6nDX3/9Jf369ZM333zT1PsCADyHHuFbvHixWa1z1KhRJvgFALcNfLXEAQDgWUJCQiRFihRmElunTp2kRo0aVg8JABwT+C5btkxeffVV86GnPz9K/fr14z8KAIBT0tU5e/bsKTdu3DBLDlPSBsDtA9+GDRuaOl6duKA/x0brvEJDQxNzfAAAi2zdulVatGghFy5cMPM5AMAjJrfpZAb7bF39ObYTQS8AuIePP/5YKlSoIJkyZZKdO3dKhw4dmMQGwPO6OugM3uDg4GjbHzx4YC4DALg+TWRoF58NGzZIgQIFrB4OAFgT+LZr105u3rwZbfvt27fNZQAA17Rw4ULTqkwNGjRIRo4caeZ2AIDHBr7aqDymw11nz56V9OnTJ9a4AABJJDAw0NTytmzZUvbu3Ws+5wHAo9uZlShRwgS8etI2NsmTJ490SOzEiRPM9gUAF7N+/Xpp1aqV6dqgGV/t0wsA4umBr72bgy5TWbt2bUmTJk34ZT4+PhIQECCNGzd2zCgBAA6h3Rry5s0ra9euNZ/jAODO4hz4Dhs2zPyvH4xNmzaVlClTOnJcAAAHOXLkiClPq1atmsydO1dSpUol3t7eVg8LAJyvxrdNmzYEvQDggrR2d/bs2aZ0TSev6fm0adMS9ALwGHHK+Gofx8OHD0uWLFkkY8aMj+zleP369cQcHwAgEVy7ds0sNbx06VLp2LGjTJo0ib68ADxOnAJf/YDUrID9Zz4sAcC1vPXWW7Jjxw6z7HCjRo2sHg4AOG/gq+UNdm3btnXkeAAAiUQXG7p69arkzp1bPv/8c0mXLp35GQA8VbxrfDVjsGfPnvDzP//8s+n4MHDgQLN6GwDAevv27ZOyZctKkyZNTC1v4cKFCXoBeLx4B75vv/22qfdVx48fNx0edEbw999/L++//74jxggAiCMNcqdOnSqlSpWSkJAQmT59OuVpAJDQwFeD3uLFi5ufNditUqWKLFq0SObNm2dqxwAA1tHV17p3724msG3btk2KFStm9ZAAwPX6+EbMJoSFhZmfV69eLXXr1jU/awN0rSUDACQ9XUFT25LpQkK6/HCdOnWsHhIAuH7gq4fPRo0aJTVr1pR169bJtGnTzHZdsjh79uyOGCMAIBZ3796Vfv36yc2bN+Xrr7+mYwMAJGapw6effmomuOmhNG2Anj9/frP9hx9+kAoVKsT37gAACaRLyGsyYs6cOebzV4/IAQASMeP7wgsvROrqYDdu3DhW/wGAJDJx4kTp37+/PPfcc7J9+3YpUqSI1UMCAPcLfO30g/bAgQPmZ/3AffHFFxNzXACAR7hy5Yr07NnTlJ75+vpaPRwAcM/A9/Lly6aFmdb3ZsiQwWwLDAyUatWqybfffitZs2Z1xDgBwONp5xz9DO7SpYt89NFHtCkDAEfX+Pbo0UOCgoJMc/Tr16+b0969e+XWrVvy7rvvxvfuAACPoZ+5HTp0MItRrF+/3tTyEvQCQBJkfFeuXGnamOkqQHZa6qAN019++eUEDAEAEJutW7ea9mQXLlyQ2bNnS7t27Qh6ASCpAl/t4ZsiRYpo23Wbvb8vACBxjBw5UjJlyiQrVqyQAgUKWD0cAPCsUofq1aubCRXnz58P33bu3Dnp1auX1KhRI7HHBwAe5+TJk7J582bz81dffSUbNmwg6AUAKwLfKVOmmHregIAAeeaZZ8zpqaeeMtsmT56cGGMCAI+1cOFCs8xwnz59TC1vxowZYzzKBgBIglIHXZpYF7D4448/wtuZab2vruQGAEgY7Y7TrVs3WbRokanp1XkT1PICgIWB7+LFi2XZsmXy4MEDU9agHR4AAE+ucePGsm3bNpPxbd68udXDAQDPDnynTZtmshFaZ+bn5yc//vijHDt2zKzYBgCIv5CQELlx44Zky5ZNJkyYYHqjaxkZAMDiGl+t7R02bJgcOnTIrA8/f/58+eKLLxw0LABwb0eOHJGKFSvKG2+8YWp5ixcvTtALAM4S+B4/flzatGkTfl4PxT18+ND0lgQAxI0GudqPt0SJEqaud/z48dTyAoCzBb7BwcGSOnXq/93Qy0t8fHzk3r17jhobALidtm3bSseOHaVZs2ZmonDp0qWtHhIAeIx4TW4bMmSIpEqVKvy8TnIbPXq0pE+fPnzbxIkTE3eEAOAG7MsM6wqXDRo0kEaNGlk9JADwOHEOfF966SVT3xtRhQoVTAmEHYfrACD60bJBgwbJnTt3zCRhbVUGAHDywHft2rWOHQkAuJn9+/eb+RDa8/yjjz4Kz/oCAFxk5TYAwONp15uSJUuakrAtW7aYldgIegHAWgS+AOAAmuXVSWzbt283rcoAAC64ZDEAIGbLly+Xq1evmtaPn3/+ORleAHAyZHwB4AlpW8fu3btL3bp15ddff6WWFwCcFBlfAHgCupKlTmA7ceKETJ06Vbp06ULQCwDulPFdv369tGzZUsqXLy/nzp0z2xYsWCAbNmxI7PEBgFN7//33zWI+WsvbtWtXgl4AcKfAd8mSJVK7dm3x8/OTnTt3mh6V6ubNm6ZdDwC4O/3Cr59/6uuvvzZdG4oUKWL1sAAAiR34jho1SqZPny4zZ86UFClShG+vWLGiWX4TANyZfvkvWrSoqenVWt5s2bKJr6+v1cMCADgi8NXV23QVt6h02eLAwMD43h0AuISgoCDp0KGDNGnSRKpXry7Lli2jrAEA3H1yW44cOeTo0aMSEBAQabvW9z799NOJOTYAcBr169eXrVu3yuzZs6Vdu3YEvQDgCYFvp06dpGfPnjJnzhzzwX/+/HnZvHmz9O3bV4YMGeKYUQKABR4+fCi3b9+WjBkzypgxYyRz5sySP39+q4cFAEiqwLd///4SFhYmNWrUkLt375qyB61v08C3R48eCR0HADiVkydPmu41qVKlklWrVknZsmWtHhIAIKkDX83yDho0SPr162dKHrTuTWczp0mT5knHAgBOYeHChaY1mWZ6tWsDZQ0A4OELWGjfStr3AHA3OoFNS7latGhhFqTQibsAAA8NfKtVq/bI7Meff/75pGMCgCRnX2ZYSxq0lEtXYwMAeHjgW7x48UjnQ0JCzJKde/fulTZt2iTm2ADA4fQz7MMPP5T79+/L+PHjpXPnzlYPCQDgLIHvpEmTYtw+fPhwU+8LAK7iyJEjpqRBV2HT4BcA4N7ivYBFbHT2s9bFAYAr0H68JUqUMAvvbNq0SQYOHGj1kAAArhL4ai/flClTJtbdAYBDbdy4UZo1a2aWWi9durTVwwEAOGOpQ6NGjaJNCLlw4YJs27aNBSwAOLXVq1fLjRs35I033pCZM2eKt7e31UMCADhzxldb+0Q8ZcqUSapWrSorVqyQYcOGOWaUAPAEgoODzSI7tWrVkkWLFpltBL0A4HnilfENDQ01a9QXLVrUNHYHAGe3b98+M4HtwIEDpmtDr169rB4SAMAVMr6aIXn55ZfNZJDEpE3iAwICTI2w9tDcunVrnG737bffmr6bDRs2TNTxAHAf3bp1kwcPHsiWLVukT58+4uWVaFMbAAAuJt5/AZ5//nk5fvx4og1g8eLF0rt3b1MmoZNMihUrJrVr15bLly8/8nYnT540hy4rV66caGMB4B4uXbpkMr325Ye3b98erQc5AMDzxDvwHTVqlAk4f/31VzOp7datW5FO8TVx4kTp1KmTKaHQJZCnT58uqVKlemRrNC250EOX2nfz6aefjvdjAnDvCWz6Bfqdd94x53Pnzi1+fn5WDwsA4Eo1viNGjDCHCevUqWPO169fP9LSxfblPjUojSs9/KiZmAEDBoRv08OQNWvWNO3RHjWWbNmySYcOHWT9+vWPndSiJzt7cB4WFmZOeDyb2MJ/drXXTceqv5uuNGYkzL1796Rfv34ybdo08zmlfXrZ7+6N97dnYX97ljAH7ec4B76aXdUMypo1axLtwa9evWoC5ezZs0farucPHjwY4202bNhg/qDpMslxMWbMmBhXZLpy5YoJvBG3gMLu+vXrcjnZ/867whvn5s2b5sOS2k731qRJE/NFWtsqvv3222bb40qm4Np4f3sW9rdnuXnzprWBr/6iqSpVqohVbt++La1atTL9N7NkyRKn22g2WWuII2Z88+bNK1mzZpUMGTI4cLTuw8/vUvjP2r4uW7a04koflHokQvc3H5TuR/fvnTt3JG3atDJy5EjJnDmz2dfsb8/A+9uzsL89i4+Pj/XtzCKWNiQGDV61U4RORIlIz+fIkSPa9Y8dO2YmtdWrVy9aKjx58uRy6NAheeaZZyLdxtfX15yi0jcNb5y4SSbJXPp1099bVxw3Hu3cuXPSpk0bMydg2bJlUq1aNfN5oFle9rfn4P3tWdjfnsPLQfs4XoFvwYIFHxv86qHw+ETzJUuWlD/++CO8JZn+4dLz3bt3j3b9Z599Vvbs2RNp2+DBg00m+LPPPjOZXADub8mSJWZSrE5amz9/vtXDAQC4iHgFvlorq6u1JSYtQ9CsTalSpaRMmTLy6aefmkOX2uVBtW7d2szK1lpd7fOr7dQispcrRN0OwP1oyVWXLl3kyy+/lMaNG5v/tbwBAIBED3zfeust000hMTVt2tRMNBs6dKhcvHjR9NpcuXJl+IS306dPc0gDgKFHnPTIj05w1S/HiV1+BQBwb3EOfB35B0bLGmIqbVBr16595G3nzZvnoFEBcAba+UWP+Dx8+FCGDx8u7733ntVDAgC4KK/4dnUAgKSik1m1k4yu7AgAQJJlfGkYDSAp6VLDXbt2lYwZM8q6deukUqVKVg8JAODiKJ4F4HT0CJO2KNPWhf/++y9BLwAg6Se3AYAj6RLkulpP3bp1ZcGCBQ5rYA4A8ExkfAFYLiQkRAYNGiRVq1aVWbNmmW0EvQCAxEbGF4Cljhw5Ii1atJCdO3eaZYc/+OADq4cEAHBTBL4ALK3lbdu2rQQGBsqmTZukdOnSVg8JAODGCHwBJLlr167JjRs3JH/+/KZ7Q5YsWSRNmjRWDwsA4Oao8QWQpFavXi0vvPCCdOzY0ZwPCAgg6AUAJAkCXwBJIjg4WPr27Su1atWSwoULm0wvAABJiVIHAElSy/vqq6/Kxo0bZfz48dKrVy/x8uJ7NwAgaRH4AnBowHv//n3x8/Mz3RqyZ88uxYsXt3pYAAAPReALwCEuXbok7du3l9SpU8t3330ntWvXtnpIAAAPx7FGAIlu+fLlUrRoUdm2bZtpVwYAgDMg8AWQqKUNPXv2NEsOlylTRvbs2SN16tSxelgAABgEvgASTbJkySRr1qwydepU+eWXXyRbtmxWDwkAgHDU+AJ4ImFhYTJx4kTzs7YrGzx4sNVDAgAgRmR8ASTY2bNnTV/efv36yfXr160eDgAAj0TGF0CC/PDDD9K5c2dJlSqVWY2tRo0aVg8JAIBHIuMLIEGT2ObPny/Vq1eX3bt3E/QCAFwCGV8AcbZ161a5ffu2CXS1N2/KlCnNhDYAAFwBGV8AjxUaGiqjR4+WChUqyKeffmq26WpsBL0AAFdC4AvgkU6ePClVq1aVoUOHyoABA+THH3+0ekgAACQIpQ4AHlnL27RpU7P88Lp166RSpUpWDwkAgAQj8AUQTWBgoNy6dUvy5csnCxYskOzZs0v69OmtHhYAAE+EUgcAkaxfv16KFy8u7du3N+cLFixI0AsAcAsEvgCMkJAQs+qa1vPmzZtXZs2aZfWQAABIVJQ6ADC1vHXq1JE1a9bIiBEjpH///uLt7W31sAAASFQEvoCHB7ya6fXx8ZFu3bqZlmVlypSxelgAADgEgS/goa5duyadOnWSdOnSybx586Rhw4ZWDwkAAIeixhfwQKtXr5YXXnjBtCirX7++1cMBACBJEPgCHlba0K9fP6lVq5YUKVJEdu/eLY0aNbJ6WAAAJAkCX8CD6BLDyZMnlwkTJsiqVaskd+7cVg8JAIAkQ40v4AFZ3qlTp4qXl5d07dpVxowZY/WQAACwBBlfwI3pUsN169aVHj16yPHjx60eDgAAliLjC7ip5cuXS7t27Ux5g/6sfXoBAPBkBL5Odkg6+GGYOJuHYTarh4AE/C5NmjTJ9OSdM2eOZMuWzeohAQBgOQJfJ3A+8J4s2nJavv3njFwNCrZ6OHBhu3btkjt37kjFihVl6dKlkiZNGpPxBQAABL6WZuQ2H78mX206Jb8fuCShLpBV9UomkiFVCquHgRiEhYXJxIkTZeDAgVK7dm355ZdfJG3atFYPCwAAp0Lgm8SCgh/K0h1n5avNp+TI5aBIlyX3SibF82aQFN7ON+fQy0vktaK5JFvalFYPBVGcO3dOWrduLX/++af07dtXRo0aZfWQAABwSgS+SeTo5SBZsPmkLNlxzgS/EWVN6yvNy+ST5mXzSfZ0BJaI35GDBg0ayMWLF81qbDVq1LB6SAAAOC0CXwd6GBomfxy8LAs2n5INR69Gu7x0QEZpVT5AXnkuh/gkd74sL5xXUFCQ3L59W3LmzClz586VXLlySebMma0eFgAATo3A1wGuBQXL4m1nZOHfp+Vc4L1Il6VM4SWvl8gtrcoFSJFc6SwbI1zX1q1bpUWLFlKgQAFZsWKFFC1a1OohAQDgEgh8E9G/ZwJl/uaT8uu/F+RBaOS2ZP6ZU0mrcv7yRsm8kp4JYkiA0NBQs+ra8OHDpWTJkvL5559bPSQAAFwKge8Tuh8SKst3X5CvNp+Uf8/ejHSZdpGqWjCrtK4QIFUKZBUvbYsAJLCWVxeg0Dpe7dwwdOhQSZGCL1AAAMQHgW8Cnb1xVxZuOS2L/zkj1+88iHRZupTJpWnpvNKynL/4Z05t2RjhHh4+fCjJkyeXNm3ayODBg6Vy5cpWDwkAAJdE4BvPrNvGo9dMdnf1gUsStfVukZzppE0Ff6lfLLf4+XhbNUy4icDAQOnWrZtkyJBBpk6dKs2bN7d6SAAAuDQC3zi4fT9EftxxzgS8x67cidZ7t07RnNK6vL+U9M/IKllIFOvXr5dWrVrJjRs3ZNq0aVYPBwAAt0Dg+whHLt02C038uOOs3HkQGumy7Ol8pUVZf3mrTF4WdUCiHlUYMmSImcRWoUIFWbt2rQQEBFg9LAAA3AKBbwy9d7WMYf6mU2ZJ4ajKPpVJWpcPkJefy+6UK6zBtekRAy1xGDFihPTv31+8vSmZAQAgsRD4/r+rQcHy7dbTZsLahZv3I13ml8JbXn8xtylneDYHvXeR+FneOXPmhE9gmzx5MiUzAAA4QHJPDzh2ngk0K6tpS7KovXefypLa9N5tXDKPpPejdRQS37Vr16RTp06ydOlSeffdd03gS9ALAIBjeGzgu3TnOflx717Zcy56790az2Yz5QyV8meh9y4cRnvyaqB7//59WbJkiTRq1MjqIQEA4NY8NvAdtmy/ePmmCj+fIVWK//beLesveTP9bzvgqKMNH374oRQpUkTmzZsnuXPntnpIAAC4PY8NfO2ez51O2pQPkHrFcknKFEwkgmPt379f7t27Z5Yc/vnnn02PXi8vJkkCAJAUPDbwfTpLKpnYqoKUyJuBmkokSYZXF6Ho16+f1KxZU3755RfJlCmT1cMCAMCjeGyq6ZlsaeTFfCw4Ace7dOmS1K1bV3r06CEdO3aU7777zuohAQDgkTw24wskVab3lVdekfPnz8vy5culTp06Vg8JAACPReALOMDdu3fNKUuWLDJjxgzx9/eXbNmyWT0sAAA8mseWOgCOsmvXLilVqpQpa1ClS5cm6AUAwAkQ+AKJJCwsTMaPHy9lypQRX19fGTNmjNVDAgAAEVDqACRSLW+9evXkt99+k759+8rIkSNN8AsAAJwHgS+QCJle7cX7+uuvS58+faR69epWDwkAAMSAwBdIoKCgIOnZs6dkzpxZxo4dG17TCwAAnBM1vkACbN26VUqUKCGLFy+WZ5991urhAACAOCDwBeJZyztq1CipUKGCWXlt586d0r59e6uHBQAA4oDAF4gHXenv2LFjMmDAANmwYYMUKFDA6iEBAIA4osYXiIOFCxdKihQp5M0335Q5c+aw1DUAAC6IjC/wCIGBgdKiRQtp2bKlrF271mwj6AUAwDWR8QVisX79ehPwavCrGd/mzZtbPSQAAPAECHyBWCaxaU/efPnyybp16yQgIMDqIQEAgCdE4AtEcOTIEQkODpbnn39efvnlF8mSJYt4e3tbPSwAAJAIqPEF/j/DO3v2bNObd+DAgWZb9uzZCXoBAHAjBL7weNeuXZPGjRubldeaNWsmixYtsnpIAADAASh1gHh6prdGjRpy5swZWbJkiTRq1MjqIQEAAAch8IVH0jre+/fvS/r06WXKlCny1FNPSe7cua0eFgAAcCBKHeBx9u3bJ2XLlpXOnTub85UqVSLoBQDAAzhF4Dt16lTTLiplypQmINm6dWus1505c6ZUrlxZMmbMaE41a9Z85PWBiGUN+rtWqlQpefDggVl2GAAAeA7LA9/FixdL7969ZdiwYbJjxw4pVqyY1K5dWy5fvhzj9XX1LJ2AtGbNGtm8ebPkzZtXXn75ZTl37lySjx2uFfS+/vrr0r17dzOJbfv27VK8eHGrhwUAADwp8J04caJ06tRJ2rVrJ0WKFJHp06dLqlSpZM6cOTFeX1fQ6tq1qwlann32WZk1a5aEhYXJH3/8keRjh+sEvbrMcLVq1WT58uUyefJk8fPzs3pYAADAkya36eFmzbxFPOTs5eVlyhc0mxsXd+/elZCQEMmUKVOsk5j0ZHfr1q3wYEgDZrive/fuSb9+/cwXqY8//lh69OhhtrPf3ZfuW97bnoP97VnY354lzEH72dLA9+rVqxIaGmoWCohIzx88eDBO9/HBBx9Irly5TLAckzFjxsiHH34YbXtw8INYyyng+vbu3WuODGibsvfff9/sa/1SBff/oLx586b548j+dn/sb8/C/vYsN2/edMj9unQ7M83iffvtt6buVyfGxUSzyVpDHDHjq3XBvr4+ki1btiQcLZKCfiBOmjTJrL6mpTNbtmyRrFmzmhMflJ7xh1HLWtjfnoH97VnY357Fx8fH/QLfLFmymCVhL126FGm7ns+RI8cjbzt+/HgT+K5evVpeeOGFWK/n6+trTlHpm4c3jvvRwFeD3Z49e8qoUaMkRYoU4dle9rdnsL+32d+egf3tWdjfnsPLQfvYy+povmTJkpEmptknqpUvXz7W240dO1ZGjhwpK1euNK2pAF117ddffzUfitopZNy4cTF+4QEAAJ7L8q9MWoagvXnnz58vBw4ckC5dusidO3dMlwfVunXrSJPfPvnkExkyZIjp+qC9fy9evGhOQUFBFj4LWEX3e4cOHaRJkyaybNkys41MAAAAcMoa36ZNm8qVK1dk6NChJoDVNmWaybVPeDt9+nSkQGbatGmmG4QGOhFpH+Dhw4cn+fhhHV24pEWLFnLhwgWZPXt2+JclAAAApwx8lS4qoKeY6MS1iE6ePJlEo4Iz05IYXXJY29itWLFCChQoYPWQAACAk3OKwBeIK/3ioxn/ggULmppePTKgE9gAAAAeh2JIuAxdtU+XtNa+vCpPnjwEvQAAIM4IfOH0AgMDTS1vy5YtpV69emYiJAAAQHxR6gCnr+WtWrWqnDhxwmR8mzdvbvWQAACAiyLwhVMKCQmR4OBgSZMmjenJq5PXtH0dAABAQlHqAKdz5MgRqVixonTt2tWcr1WrFkEvAAB4YgS+cKrlhmfNmmV6OWtdb48ePaweEgAAcCMEvnCaWt433nhDOnXqZOp4d+zYIaVLl7Z6WAAAwI1Q4wunoKvzlSxZ0nRveP31160eDgAAcEMEvrCMTl4bNGiQ5MyZU/r06SMDBgywekgAAMCNUeoAS+zfv1/Kli0rkydPZhEKAACQJAh8keQT2KZOnWrKGnTp4S1btsi7775r9bAAAIAHIPBFklu+fLl07NhRtm/fbjo4AAAAJAVqfJFkwa6vr6/UrFlTfv75Z8obAABAkiPjC4e6d++edO/eXerWrSvffPON2UbQCwAArEDGFw6za9cu05P3xIkTpq63S5cuVg8JAAB4MAJfOGxBCu3J6+PjY2p5ixQpYvWQAACAhyPwRaI6d+6cPHz4UPz9/eWXX36R3Llzm9peAAAAq1Hji0SzZMkSKVq0qPTq1cucf/rppwl6AQCA0yDwxRMLCgqSDh06SJMmTaR69eoyc+ZMq4cEAAAQDaUOeOJa3sqVK8uRI0dk9uzZ0q5dO0mWLJnVwwIAAIiGwBcJEhoaKiEhIZIyZUoZMWKEFC5cWPLnz2/1sAAAAGJFqQPi7eTJk1K1atXwpYbr1atH0AsAAJwegS/iZeHChVKsWDE5c+aMtG7d2urhAAAAxBmBL+Jc2tCyZUtz0gzvv//+K5UqVbJ6WAAAAHFGjS/ixNvb2/Tm1YyvrsYGAADgagh8ESudvDZ8+HDJkyePWW549OjRVg8JAAAgwQh8ESNtT6ZLDu/cuVPGjBlj9XAAwGHdaeA67TN1f92/f1+8vKjUdAc+Pj5Jvi8JfBGJzWaTOXPmSM+ePSVXrlyyadMmKV26tNXDAoBE/Zy7ePGiBAYGWj0UxHO/afB7+/Zt+sW7CS8vL3nqqadMAJxUCHwR7YNlwYIF0qxZM5k0aZKkSZPG6iEBQKKyB73ZsmWTVKlSEUS50N+nhw8fSvLkydlnbiAsLEzOnz8vFy5ckHz58iXZPiXwhbF69Wrx8/OTihUrysqVK83CFADgjuUN9qA3c+bMVg8H8UDg636yZs1qgl/drylSpEiSx6RIxsMFBwdL3759pVatWjJr1iyzjaAXgLuy1/RqpheAtewlDvqFNKmQ8fVg+/btMxPYDhw4IBMmTJD33nvP6iEBQJIgYwh45vuQwNdD6berRo0amf68W7ZskeLFi1s9JAAAAIei1MHDXLp0ydTTaMD7008/yfbt2wl6AQBu7dChQ5IjRw7TEQJJY//+/WYdgDt37ogzIfD1IMuXL5eiRYuGlzQULlzYTGgDADi/tm3bmkPDetKJQNoG6v333zd9baP69ddfpUqVKpI2bVpTz6xtKefNmxfj/S5ZskSqVq0q6dOnN518XnjhBRkxYoRcv35d3MWAAQOkR48e5vWI6tlnnxVfX1/T7SOqgIAA+fTTT6Nt18WdoiaN9Pb6GE8//bS5v7x580q9evXkjz/+EEf6/vvvzXPQ+Tn6N37FihVx/j1KFuH03HPPRXp+US/Xx7A7efJkjPehJx2PKlKkiJQrV04mTpwozoTA1wPcvXtXunXrJnXr1pUyZcrIlClTrB4SACABXnnlFdP+6fjx46bl5JdffinDhg2LdJ3JkydLgwYNTJceLWXbvXu3vPXWW/LOO++YycwRDRo0SJo2bWoC499++0327t1r5nz8+++/prVlUnnw4IHD7vv06dPmi4AGfFFt2LBB7t27J02aNJH58+cn+DE0ECxZsqT8+eefMm7cONmzZ4/pkFStWjXz99dRtNe+th/t0KGDWXCqYcOG5qT7MTafffaZ+R2yn86cOSOZMmWSN954I9L1NBCOeD19rew0qI94mZ4+/PBD88Xp1VdfDb9eu3btZNq0aaZrg9OweZibN2/a9Gm3n7HW5gkePnxoe/HFF20pU6a0TZ061RYWFmbzJKGhobYLFy6Y/+H+2N+eJSH7+969e7b9+/eb/11NmzZtbA0aNIi0rVGjRrYSJUqEnz99+rQtRYoUtt69e0e7/eeff27+/v3999/m/JYtW8z5Tz/9NMbHu3HjRqxjOXPmjO2tt96yZcyY0ZYqVSpbyZIlw+83pnH27NnTVqVKlfDz+nO3bt3M9syZM9uqVq1qa9asme3NN9+MdLsHDx6Yy+fPn2/+ft2/f982evRoW0BAgPm79sILL9i+//77R75u48aNs5UqVSrGy9q2bWvr37+/7bfffrMVLFgw2uX+/v62SZMmRds+bNgwW7FixcLPv/rqq7bcuXPbgoKC4vU6Pil9vV577bVI28qWLWt7++2343wfS5cutSVLlsx28uTJWJ9fXBQvXtzWvn37SNuCg4Ntvr6+ttWrV8f7/aivm/5+atyWmJjc5saNofUblrYK0UNhevhDDzsAAKKrN3mDXLkdnOSPmzWtr/zSo1KCbqtZPc34+fv7h2/74YcfTMu2qJld9fbbb8vAgQPlm2++kbJly8rChQtNhq5r164x3n+GDBli3B4UFGTKKHLnzi3Lli0ztbM7duwwf3fiQzOsXbp0kY0bN5rzR48eNVlHvX/74kmrVq0yRy1ff/11c/6TTz4x458+fboUKFBA/vrrL2nZsqXpB6tjisn69eulVKlS0bZrva8eltesuB7Gv3nzprlu5cqV4/U8tCREs7ujR4+W1KlTx/l1VLoPdL88imbiYxvT5s2bpXfv3pG21a5d28zhiavZs2dLzZo1I/0eqSNHjpgVXLWEonz58jJmzBiz0ERMdL7Qrl27ZOrUqZG2awyiJSH6utaoUUOcAYGvGzp37py0adNGnn/+eVObpIexAACx06D34q3otbLORg/Za1CoiQ3tw65LvkYsXzt8+LCp1c2ZM2e022oQovWneh17YKPn47twwKJFi+TKlSvyzz//mEPkKn/+/PF+Lhq4jh07Nvz8M888YwLHpUuXSqtWrcIfq379+qY2V2uZNfD9/fffpUKFCuZyHb8egteSj9gC31OnTsUY+H777bdmDPbaVi0H0SAwvoGvBuy6uEbEGti40uemX0IeRb9gxEbrirNnzx5pm56PqV45JufPnzeBtb7OEemYtCa8UKFC4WUM+rrol62Y6qT1ddN5Q/b9EpEGz7oPnAWBr5vRSQqdOnUyk9b69+9v9XAAwCVo5tUVHldrRrVmUmfKa42vrmLWuHHjBD22BmsJoZm9EiVKhAe9CaU1sRHpc3nzzTdNFlQDX32OP//8swlQ7QGmZn9ffvnlaPXBOp7YaA1vTAszzZkzx2SL7fRnDZ61Rjqm4C6xX0eljxOfx0ps8+fPNxlprQuOKGKdrk521EBYM8LfffedqSeO+vpq4DxkyJAYH0PjEd1vzoLA14368nbu3Nm8kfVDUL/9shwnAMRNQssNkppmRO3ZVf28L1asmMm22YORggULmkP2msnTTFvUAPHYsWMmeLZfV7OlWhoRn6zv47oBaRY6ajBoXzEv6nOJShdV0uDz8uXLJrOrj6UT+pSWQNiz3tomKyLtohCbLFmyyI0bN6K12vr7779l69at8sEHH0T6W6qBtiaQVLp06czrGZUue62ZdaVZY+1mcPDgwVjH4KhSBy0z0TalEel53f44NpvN/A7plwz7Cmqx0eBYf1/0y0dUWl6jgW3r1q1jLQXRbL6zoKuDm9C+vHr4Sz8AtWaJoBcA3JsGmFqzO3jwYJN1U5r40CBWOzNEpXWxmkXVLgCqefPmJpj84osvYrx/De5iohlAzfrG1u5M62318HhEev240EPl2jFg8eLFJijUml97UK7zVDTA1S4NGvxHPOltYqPZYA10I9K/lS+99JLpXqFjs5+0XlYvs9ND/Vq/GpXWNGsgqDTzrXW1Wt8aU8/a2F5He6lDxMeP6RRTmYad1t5GbZemXxh0++OsW7fOBLJRM7gx0d8T/dIUUwmNvl76PHS/x0TLIx6VkU9yNg/jTl0dtGPDyJEjzWxXxIxZ/p6F/e1Z6Opgs4WEhJhuAtq5wE67EHh5edkGDhxoO3DggO3o0aO2CRMmmNn1ffr0iXT7999/3+bt7W3r16+fbdOmTWZmv87Ab9KkSazdHnSmvnZAqFy5sm3Dhg22Y8eO2X744Qdze7Vy5UrTJUD/Nh0+fNg2dOhQW7p06aJ1ddCODjEZNGiQrUiRIrbkyZPb1q9fH75duzpoBwbt8jBv3jzzvLZv3266Vej52CxbtsyWLVs28zfT3ikia9astmnTpkW7rv5uaIywd+9ec37jxo3mtRw1apS5bM+ePeZ11bHpz3b6GuTIkcOMW18Lfd56/c8++8z27LPP2hxFx6djGT9+vNnX2o1Bu3pEHJu+Zq1atYp225YtW5oOEDHR35O1a9faTpw4YR6jZs2atixZstguX74c6XpHjhwx+1q7YsREbx+1Y4TVXR0IfF2U/jJVrFjRvCG1tQtiRiDkWdjfnoXA97/GjBljArmIrbR+/vlnE5imTp3atP3SdmNz5syJ8X4XL15se+mll2xp06Y119cWYSNGjHhkGy4NZBo3bmwCWm1npu3CtD2anQa72bNnt6VPn97Wq1cvW/fu3eMc+NqDT20lFrEFp/6sQbcG9oUKFTIBnj7v2rVr29atWxfrWPXLQa5cuUxArjQw1b+dFy9ejPH6hQsXNmO2W7Vqlfl7q63b7K3XYnq88+fPmxZtOm4fHx/zhaR+/fq2NWvW2Bzpu+++M19E9DGfe+452/Lly6P93kR87VVgYKDNz8/PNmPGDFtMmjZtasuZM2f489Dz+kUjqgEDBtjy5s0b63vwo48+MvsnNlYEvsn0H/Egt27dMnU57WesldmdYp4B6uz08I+2n8mYMaN8/fXXUqmSa9SmWUHb62itWLZs2cxhQbg39rdnScj+1s4AJ06cMKuexTThCc5LwxXtZqGT4LSmNj60DEFbr2l7NCQNrSnX+med+KaLqcT3/aglIhrnaI211lonFia3uRgtvP/888/NMoj6RrYX1wMAgJjpBDINpLR3r5VdFDzJ6dOnTQ16bEGvVQh8XYQ2f9b11rX9ixay25t7AwCAR9MssS7PjKRjn3jobDgW6OS0BYzO2K1atarpLagIegEAAOKPjK8T01V1tKfhzp07ZeTIkZF6DQIAACB+CHyduJa3Tp06poBf12IvXbq01UMCAABwaQS+TubatWtmprI2gtaFKLQ+htIGAACAJ0eNrxNZvXq1WRGnZ8+e5nzx4sUJegEAABIJga8TCA4Olr59+0qtWrWkcOHCMm7cOKuHBAAA4HYodbCYNuOuXLmyWS98/Pjx0qtXLxrvAwAAOAARlhOsQKOrsG3ZskX69OlD0AsAcEo62fqnn34SZ3Ly5Ekzrl27djn8sebNmycZMmSItG3GjBmSN29e87f7008/leHDh5syRTgvoiwLXLp0SerWrStDhw4159u2bcsbBQDwSPq3QoM8PaVIkcIs8/r++++bZV/heE2bNpXDhw+Hn79165Z0797dtBo9d+6cdO7c2ZQt6iJTcF6UOiSx5cuXS7t27cwHV7du3aweDgDAhbzyyisyd+5cs7jR9u3bpU2bNubvySeffGL10Nyen5+fOUVcklf3w2uvvSY5c+YM3/6kk9L1PvWLDRyDjG8S0bIG/Waomd4yZcrInj17TJ9eAADiytfXV3LkyGEOrzds2FBq1qwpv//+e6SWmM2aNZPcuXObZe6LFi0q33zzTaT70JVA3333XZMtzpQpk7k/PUQfdQGll156SVKmTClFihSJ9Bh2+nesevXqJhjMnDmzyXgGBQVFylDrGD/66CPJnj27KRMYMWKE+XvYr18/89h58uQxgfyjaIvPsWPHSoECBUxQ6e/vL6NHj461B36HDh1MNlzHVahQIfnss88iXWft2rXm73Dq1KnNmCpWrCinTp0yl+l8m2rVqknatGklXbp0UrJkSdm2bVu0Ugf9WV9b9fTTT5svH1p2EVOpw6xZs8zEdX0tn332Wfniiy+ilWosXrxYqlSpYq6zcOHCR74eeDJkfJOIt7e33L17V6ZOnSpdunQxv+gAAOdx4cIFc4ooY8aMJojScoL9+/dHu82LL75o/j906JDcuXMn0mUBAQEmuLty5YqcOXMm0mUaWGkg9yT27t1rFjjSQNBOx6nBmh5+18BNjzK2atVKnnnmGRPs2c2fP1969+5t5pds3rzZBKkaAGp3IQ00GzVqZIJVvfzmzZvy3nvvRXpsfa61a9eW8uXLyz///COXL1+Wjh07mgSPBoV2f/75pwlu//rrL9m4caMJSnXMGlTrfWvA9/bbb5vH1evFZMCAATJz5kyZOHGilCtXzrye+nrHRMeu96N98DUY18fSgFwzsm+++aYJujUY79Spk/lC8ODBA9m6dWv432RdLbVEiRIybdo083dba4djyr5q2YN++dAvHnp7/Vn770elQayWNU6ZMsXcr67Eqo+tQbdm6+369+8vEyZMMNfR4BcOZPMwN2/etOnTbj9jrcMfKzQ01DZu3Djb999/7/DHQuz74MKFC+Z/uD/2t2dJyP6+d++ebf/+/eb/qIYNG2b+PkQ8tWjRwlx25MiRaJdF/BNarly5aJctWLDAXDZlypRol7388svxfr5t2rSxeXt721KnTm3z9fU19+Pl5WX74YcfHnm71157zdanT5/w81WqVLFVqlQp0nVKly5t++CDD8zPq1atsiVPntx27ty58Mt/++0383hLly4152fMmGHLmDGjLSgoKPw6y5cvN+O5ePFi+Hj9/f0j7Z9ChQrZKleuHH7+4cOH5vl88803MY791q1b5rnOnDnTFhYWZnvw4IH53+7EiRNmXDt37oz1+Xfr1s3WuHFj8/O1a9fM9deujTkGSJs2rW3evHkxXjZ37lxb+vTpw8/rY+p96Rgi/g4VK1Ys/PwzzzxjW7RoUaT7GTlypK18+fKRxv/pp5/aPNG9R7wfb9y4YV4bjdsSExlfBzl79qz5Nqffdj/88EOrhwMAeAzNPNavXz9axldpFlFramOjWc6YMr5KM42aGY2a8U0IPQyv2Uh9rEmTJpnOQI0bN450qF9LC7777jsz4UozmtorXsseItLFkiLSjKhmbdWBAwdMBjNXrlzhl0cdv16nWLFiJnNppxljzbhqNlazxeq5556L1K1Itz///PPh5zWrqplZ+2NHpY+j469Ro0acXyM9sjpnzhxTg3vv3j3zGtjLDzQDr9ltzVZrllkztrp/7DW6mgXXzPWCBQvMZW+88YbJlieE7qNjx46ZLLdmee0065w+ffpI1y1VqlSCHgPxR+DrAD/88IM5tKIfNLoaW3zesAAAa2jwE3GSUkR6+Nle1hATrSWNjR4Cj+kweEJooKlL2SsN7jT4nD17tgmulC6ApDWt2lpLa1D1+lqmoMFfRFEP3+uhfg1aE1tMjxOfx444mSwuvv32W9NZQcsGNFjXLxj6mmhZhZ3WFGuN88qVK02pxeDBg00Ns5ZRaI1u8+bNTYnIb7/9JsOGDTP3+frrr0t82eudtUyjbNmykS7TgD+iiF8g4FhMbktk+k1u1KhRpuB/9+7dBL0AAIfQTOrAgQNN4KaZTaV1tA0aNJCWLVuaoFgnXkVswRUXOhFLa5Ij1jv//fff0a6jE8EiZrn1sXVMj/oSEF9aB63Bb1xbhOkYKlSoYPrja72sfknQrGtUepnWDmsNsGagFy1aFH5ZwYIFzWJS//nPf0yt8+Mm38VGs9uaNT9+/LgZR8ST1o3DGgS+iUSL23WigR52WrNmjSms10MqAAA4ih6K1+yhHt63B4qavdSATssEtHxDe8fHhx7i1+BPy/U0uF2/fr0MGjQo0nV0EphmwfU6+rdP/+716NHDTKSzlzkkBn0MnainHSi++uorE8RqEK5Z7pjo89cuDKtWrTIB/5AhQ8zkO7sTJ06YgFcn9GknBw1utYOFBvL65UEn52nXB71Mg2i9rV6WUFrqOGbMGPn888/NeLQThgbSOlEP1iDwfUJaT6UZXv2GqUsO22vC6NoAAHA0TbZosKbtvjT7qtlfLcnQGlZtW6atyrSLQXxo1nbp0qUmENROEFrzGrV9mJbyaXB5/fp1KV26tDRp0sQc4dTuBYlNg1dd2VTLDrQ2+a233oq1JlgDfc3SatcFLS/Q9m6a/Y047oMHD5q6aA3utSxRe+rr7fQLhF6/devW5jKt/X311VefaJ6OvnbazkyDXS090ZZlWg9Oxtc6yXSGm3gQXWlFi8rbz1grsztVeaL70v57+u1Wv1nr4SZtWULTaeeidWP6AZktWzaWg/YA7G/PkpD9re2+NOungQdto1yLhitaTqjBPskl93D/Ee/HwMBAk0jUdnrami+xMLktgfTNp99uNeO7bt06qVSpktVDAgAAwCMQ+MaTfgPRb536LUQbU2vtT9S2JAAAAHA+HAuMBy3w116AOttTaesTgl4AAADXQOAbByEhIWbCgE4UyJcvHwtSAAAAuCBKHeJQy6uzMLVd2YgRI8x62lEbTwMAXIuHzesGnJLNgvchge8jdoaedPao9ivUVXC0rQsAwHXZO+/cvXs33quCAUhc9hUFkzKhSOAbA+3jp+tqlyxZ0jTt1h5/AADXp39gM2TIEN4HVvu60hrLNdDOzP3aEV65csW8B3WfJhUC3yhWr15tVqLR3nK65CMAwL3oog4qtkUQ4LyBrwZL2rOZwNc9eHl5mblTSbk/CXz/n36L1GURdRlBXa5RV1bJnTu31cMCACQy/SObM2dOs/CFTl6Ga9CgV4/IZs6cmQVq3ISPj0+S70sC3wiHv86ePSsTJkyQ9957jzcVAHjA5z6TlV0r8NUabV3hi7/RSCin+M2ZOnWqBAQEmF9mXVtbOyg8yvfffy/PPvusub6ufb1ixYoEHzbRx9bbawbg22+/ld69e/OGAgAAcEOWR3iLFy82weawYcNkx44dUqxYMaldu3astVebNm2SZs2aSYcOHWTnzp3SsGFDc9q7d2+8HvfuzetSt25d6d69u/z9999mGzVDAAAA7iuZzeJmhprhLV26tEyZMiX8UEbevHmlR48epmduVE2bNpU7d+7Ir7/+Gr5NV1DTFdWmT5/+2Me7deuWWW3NN00GSZ/KR+bOnSt16tRJ5GcFZ6G/T/olSmv5yOS7P/a3Z2F/exb2t2cJDAyUjBkzys2bNyVdunTuUeOr/du2b98uAwYMCN+mv8w6uWzz5s0x3ka3a4Y4Is0Q//TTTzFePzg42Jzs9AVUmfPml7U/L5KsWbOaFxfu+0GpX3asKKBH0mN/exb2t2dhf3uWwP+PzRI7P2tp4Hv16lUJDQ2V7NmzR9qu5w8ePBjjbS5evBjj9XV7TMaMGRPjEsPnD2yTggULPtH4AQAA4DjayUOP1CcWt+/qoNnkiBli/Qbh7+8vp0+fTtQXEs5JswNaOnPmzJlEPVQC58T+9izsb8/C/vYsN2/eND1+M2XKlKj3a2ngmyVLFtNK5tKlS5G263l7g/GodHt8ru/r62tOUWnQyxvHc+i+Zn97Dva3Z2F/exb2t2fxSuSyFkuLZLROR5cF/uOPPyLV8Oj58uXLx3gb3R7x+ur333+P9foAAACAU5Q6aBmCLhFcqlQpKVOmjHz66aema0O7du3M5a1btzYrqGmtrurZs6dUqVLFLDTx2muvmd6727ZtkxkzZlj8TAAAAODMLA98tT3ZlStXZOjQoWaCmrYlW7lyZfgENq3FjZjmrlChgixatEgGDx4sAwcOlAIFCpiODs8//3ycHk/LHrRncEzlD3A/7G/Pwv72LOxvz8L+9iy+DtrflvfxBQAAAJICjfAAAADgEQh8AQAA4BEIfAEAAOARCHwBAADgEdwy8J06daoEBARIypQppWzZsrJ169ZHXv/777+XZ5991ly/aNGismLFiiQbK5J2f8+cOVMqV64sGTNmNKeaNWs+9vcDrv3+ttPWh8mSJZOGDRs6fIywbn/r6pzdunWTnDlzmtngujQ9n+nuu7+1BWqhQoXEz8/PrOrWq1cvuX//fpKNFwn3119/Sb169SRXrlzms1k7dD3O2rVr5cUXXzTv7fz588u8efPi/8A2N/Ptt9/afHx8bHPmzLHt27fP1qlTJ1uGDBlsly5divH6GzdutHl7e9vGjh1r279/v23w4MG2FClS2Pbs2ZPkY4fj93fz5s1tU6dOte3cudN24MABW9u2bW3p06e3nT17NsnHDsfvb7sTJ07YcufObatcubKtQYMGSTZeJO3+Dg4OtpUqVcpWp04d24YNG8x+X7t2rW3Xrl1JPnY4fn8vXLjQ5uvra/7Xfb1q1Spbzpw5bb169UrysSP+VqxYYRs0aJDtxx9/1O5itqVLlz7y+sePH7elSpXK1rt3bxOvTZ482cRvK1eujNfjul3gW6ZMGVu3bt3Cz4eGhtpy5cplGzNmTIzXf/PNN22vvfZapG1ly5a1vf322w4fK5J+f0f18OFDW9q0aW3z58934Chh5f7WfVyhQgXbrFmzbG3atCHwdeP9PW3aNNvTTz9te/DgQRKOElbtb71u9erVI23ToKhixYoOHysSV1wC3/fff9/23HPPRdrWtGlTW+3ateP1WG5V6vDgwQPZvn27OXxtp4tf6PnNmzfHeBvdHvH6qnbt2rFeH669v6O6e/euhISESKZMmRw4Uli5v0eMGCHZsmWTDh06JNFIYdX+XrZsmVm+XksddBEkXdjoo48+ktDQ0CQcOZJqf+uCVnobeznE8ePHTVlLnTp1kmzcSDqJFa9ZvnJbYrp69ar5gLOv+man5w8ePBjjbXS1uJiur9vhfvs7qg8++MDUF0V9M8E99veGDRtk9uzZsmvXriQaJazc3xr4/Pnnn9KiRQsTAB09elS6du1qvtzqClBwr/3dvHlzc7tKlSrp0Wt5+PChvPPOO2ZVV7ifi7HEa7du3ZJ79+6ZOu+4cKuMLxAfH3/8sZnwtHTpUjORAu7l9u3b0qpVKzOhMUuWLFYPB0kgLCzMZPdnzJghJUuWlKZNm8qgQYNk+vTpVg8NDqATnTSj/8UXX8iOHTvkxx9/lOXLl8vIkSOtHhqcmFtlfPWPm7e3t1y6dCnSdj2fI0eOGG+j2+Nzfbj2/rYbP368CXxXr14tL7zwgoNHCiv297Fjx+TkyZNm1nDEwEglT55cDh06JM8880wSjBxJ9f7WTg4pUqQwt7MrXLiwyRTpoXQfHx+HjxtJt7+HDBlivtx27NjRnNeuTHfu3JHOnTubLzxaKgH3kSOWeC1dunRxzvYqt/qt0A81/Zb/xx9/RPpDp+e17ismuj3i9dXvv/8e6/Xh2vtbjR071mQEVq5cKaVKlUqi0SKp97e2KNyzZ48pc7Cf6tevL9WqVTM/a+sjuNf7u2LFiqa8wf4FRx0+fNgExAS97re/dY5G1ODW/qXnv/Ol4E7KJ1a8ZnPDdija3mTevHmm3UXnzp1NO5SLFy+ay1u1amXr379/pHZmyZMnt40fP960txo2bBjtzNx4f3/88cemXc4PP/xgu3DhQvjp9u3bFj4LOGp/R0VXB/fe36dPnzZdWrp37247dOiQ7ddff7Vly5bNNmrUKAufBRy1v/Xvte7vb775xrS6+s9//mN75plnTLcmOL/bt2+b1qJ60nB04sSJ5udTp06Zy3Vf6z6P2s6sX79+Jl7T1qS0M/t/2tstX758JsDR9ih///13+GVVqlQxf/wi+u6772wFCxY019dWGcuXL7dg1EiK/e3v72/eYFFP+gEK93x/R0Tg6/77e9OmTaYlpQZQ2tps9OjRpqUd3G9/h4SE2IYPH26C3ZQpU9ry5s1r69q1q+3GjRsWjR7xsWbNmhj/Htv3sf6v+zzqbYoXL25+P/T9PXfuXFt8JdN/EjcZDQAAADgft6rxBQAAAGJD4AsAAACPQOALAAAAj0DgCwAAAI9A4AsAAACPQOALAAAAj0DgCwAAAI9A4AsAAACPQOALACIyb948yZAhg7iqZMmSyU8//fTI67Rt21YaNmyYZGMCAGdD4AvAbWhgpwFg1NPRo0edIrC2j8fLy0vy5Mkj7dq1k8uXLyfK/V+4cEFeffVV8/PJkyfN4+zatSvSdT777DMzDkcaPnx4+PP09vaWvHnzSufOneX69evxuh+CdACOkNwh9woAFnnllVdk7ty5kbZlzZpVnEG6dOnk0KFDEhYWJv/++68JfM+fPy+rVq164vvOkSPHY6+TPn16SQrPPfecrF69WkJDQ+XAgQPSvn17uXnzpixevDhJHh8AYkPGF4Bb8fX1NUFgxJNmHidOnChFixaV1KlTmyxk165dJSgoKNb70cC0WrVqkjZtWhOwlixZUrZt2xZ++YYNG6Ry5cri5+dn7u/dd9+VO3fuPHJsmgXV8eTKlctkZ/U2GiDeu3fPBMMjRowwmWB9DsWLF5eVK1eG3/bBgwfSvXt3yZkzp6RMmVL8/f1lzJgxMZY6PPXUU+b/EiVKmO1Vq1aNlkWdMWOGGYc+bkQNGjQwgardzz//LC+++KJ5zKefflo+/PBDefjw4SOfZ/Lkyc3zzJ07t9SsWVPeeOMN+f3338Mv14C4Q4cOZpz6+hUqVMhkoyNmjefPn28e2549Xrt2rbnszJkz8uabb5qylEyZMpnxaoYbAOKCwBeAR9Dygs8//1z27dtngqo///xT3n///Viv36JFCxOE/vPPP7J9+3bp37+/pEiRwlx27Ngxk1lu3Lix7N6922QyNRDWwDQ+NOjTwFMDSQ38JkyYIOPHjzf3Wbt2balfv74cOXLEXFfHvmzZMvnuu+9M1njhwoUSEBAQ4/1u3brV/K9BtZZA/Pjjj9Guo8HotWvXZM2aNeHbtBxBg2197mr9+vXSunVr6dmzp+zfv1++/PJLUyoxevToOD9HDUo1o+3j4xO+TZ+zvrbff/+9ud+hQ4fKwIEDzXNTffv2NcGtvsY6fj1VqFBBQkJCzOuiX0Z0bBs3bpQ0adKY6+kXAwB4LBsAuIk2bdrYvL29balTpw4/NWnSJMbrfv/997bMmTOHn587d64tffr04efTpk1rmzdvXoy37dChg61z586Rtq1fv97m5eVlu3fvXoy3iXr/hw8fthUsWNBWqlQpcz5Xrly20aNHR7pN6dKlbV27djU/9+jRw1a9enVbWFhYjPevH+dLly41P584ccKc37lzZ7TXp0GDBuHn9ef27duHn//yyy/NOEJDQ835GjVq2D766KNI97FgwQJbzpw5bbEZNmyYeR30tU+ZMqUZh54mTpxoe5Ru3brZGjduHOtY7Y9dqFChSK9BcHCwzc/Pz7Zq1apH3j8AKGp8AbgVLU+YNm1a+HktbbBnP7U04ODBg3Lr1i2TZb1//77cvXtXUqVKFe1+evfuLR07dpQFCxaEH65/5plnwssgNCurWVc7jT01k3nixAkpXLhwjGPTOlfNUOr19LErVaoks2bNMuPRWt+KFStGur6e18eylynUqlXLlAVohrNu3bry8ssvP9FrpZndTp06yRdffGHKK/T5vPXWWyY7bn+emlWNmOHVMoVHvW5Kx6jZab3e119/bSbZ9ejRI9J1pk6dKnPmzJHTp0+bUg/N2Gp5x6PoeHSiomZ8I9LH0Sw8ADwOgS8At6KBbv78+aMdbtdAsUuXLiaI09pQLU3QOlMNuGIK4LTOtHnz5rJ8+XL57bffZNiwYfLtt9/K66+/bmqD3377bVOjG1W+fPliHZsGbDt27DCBpdbqaqmD0sD3cbTOVoNqHYsG8VoKoAH5Dz/8IAlVr149E7DrcyxdurQpH5g0aVL45fo8taa3UaNG0W6rNb+x0bIG+z74+OOP5bXXXjP3M3LkSLNNX0ctZ9DSjvLly5vXZdy4cbJly5ZHjlfHo7XWEb9wONsERgDOjcAXgNvTGl3NsmqgZc9m2utJH6VgwYLm1KtXL2nWrJnpFqGBrwahWpsaNcB+HH3smG6jk+d0oplmV6tUqRK+Xc+XKVMm0vWaNm1qTk2aNDGZX63L1UA+Ins9rWZnH0WDVw1qNZDUTKpmavW52enPWk8c3+cZ1eDBg6V69ermi4f9eWrNrk4wtIuasdXnEHX8Oh6tp86WLZt5LQAgvpjcBsDtaeCmE6MmT54sx48fN+UL06dPj/X6euhdJ6ppJ4FTp06ZQE0nudlLGD744APZtGmTuY4extcJaNqBIL6T2yLq16+ffPLJJyaw02BTJ9PpfevEMqVdKb755htTqnH48GEzMUw7J8S06IYGhppN1olqly5dMiUWjyp30Iyvlh3YJ7XZ6aSzr776ymRrdVKgtibTbK0GsvGhWd0XXnhBPvroI3O+QIECpkOGTnrT5zJkyBDz+kakE/e0nERfi6tXr5r9p+PLkiWL6eSg2WnNgOs+0sz72bNn4zUmAJ6JwBeA2ytWrJgJHDWwfP75502GM2IrsKi0/Zl2PNCOBprx1bICbT+mAaDSIG7dunUmaNOWZto2TINEzWYmlAZvWlfcp08f03ZNg1atk9UgUWk5wNixY6VUqVKmLEHLN1asWBGewY7aTky7QGgXBh2TBoqx0UysZow1wNTSjoi0g8Kvv/4q//nPf8xjlitXzpRCaCu1+NKsudYzazsyLRPRTLNmrsuWLWte64jZX6W1x5qB1uerZQz65UNLUv766y9TTqK31y8iWq6iNb5kgAHERTKd4RanawIAAAAujIwvAAAAPAKBLwAAADwCgS8AAAA8AoEvAAAAPAKBLwAAADwCgS8AAAA8AoEvAAAAPAKBLwAAADwCgS8AAAA8AoEvAAAAPAKBLwAAAMQT/B9FtGAlmvMT5AAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = mf.plot_roc(y_test, y_proba, title=\"CRC vs Control — ROC\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4d4cd7fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.167823Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.167747Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.213389Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.213119Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApAAAAIjCAYAAAC06yuLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAR25JREFUeJzt3Qd4VGXaxvFnAiShJHRIIqH3rqgs0pcmuggoii4KSHFFQBABQaUIKrugYmPBVaqKKKKgqCBSRZqAKEj5CAQI0qSGBAkl813P685s5iQZcmCSSSb/n9e5MnPOmTPvjJvN4/2W43A6nU4BAAAAMigooycCAAAAigISAAAAtlBAAgAAwBYKSAAAANhCAQkAAABbKCABAABgCwUkAAAAbKGABAAAgC0UkAAAALCFAhJAltq7d6+0bdtWChcuLA6HQxYuXOjT6x84cMBcd9asWT69bk7WokULswGAr1BAArnQvn375B//+IdUrFhRQkNDJTw8XBo3bixvvPGG/PHHH5n63j169JDt27fLSy+9JO+//77ceuutEih69uxpilf9PtP6HrV41uO6vfLKK7avf+TIERk7dqxs27bNRy0GgOuT9zpfByCH+uqrr+T++++XkJAQ6d69u9SuXVsuXboka9eulWHDhsmvv/4q//nPfzLlvbWoWr9+vTz33HMyYMCATHmPcuXKmffJly+f+EPevHnlwoUL8uWXX8oDDzzgcezDDz80BfvFixev69paQL7wwgtSvnx5qV+/foZf9+23317X+wFAeigggVwkNjZWHnzwQVNkrVixQiIjI93H+vfvLzExMabAzCy///67+VmkSJFMew9N97RI8xctzDXN/eijj1IVkHPnzpW7775bFixYkCVt0UK2QIECEhwcnCXvByD3oAsbyEUmTpwoCQkJMn36dI/i0aVy5coyaNAg9/MrV67I+PHjpVKlSqYw0uTr2WeflaSkJI/X6f6//e1vJsW8/fbbTQGn3eNz5sxxn6Ndr1q4Kk06tdDT17m6fl2PU9LX6HkpLVu2TJo0aWKK0EKFCkm1atVMm641BlIL5qZNm0rBggXNazt27Ci7du1K8/20kNY26Xk6VvPRRx81xVhG/f3vf5dvvvlGzp496973448/mi5sPWZ1+vRpGTp0qNSpU8d8Ju0Cb9++vfz888/uc1atWiW33XabeaztcXWFuz6njnHUNHnLli3SrFkzUzi6vhfrGEgdRqD/jqyfv127dlK0aFGTdAKANxSQQC6i3apa2N1xxx0ZOr9Pnz4yevRoueWWW2Ty5MnSvHlzmTBhgkkxrbTo6tKli7Rp00ZeffVVU4hoEaZd4uree+8111APPfSQGf/4+uuv22q/XksLVS1gx40bZ97nnnvukR9++MHr67777jtTHJ04ccIUiUOGDJF169aZpFALTitNDs+fP28+qz7WIk27jjNKP6sWd5999plH+li9enXzXVrt37/fTCbSz/baa6+ZAlvHier37SrmatSoYT6zeuyxx8z3p5sWiy6nTp0yhad2b+t327JlyzTbp2NdS5YsaQrJq1evmn3vvPOO6ep+6623JCoqKsOfFUAu5QSQK5w7d86pv/IdO3bM0Pnbtm0z5/fp08dj/9ChQ83+FStWuPeVK1fO7FuzZo1734kTJ5whISHOp59+2r0vNjbWnDdp0iSPa/bo0cNcw2rMmDHmfJfJkyeb57///nu67Xa9x8yZM9376tev7yxVqpTz1KlT7n0///yzMygoyNm9e/dU79erVy+Pa3bu3NlZvHjxdN8z5ecoWLCgedylSxdnq1atzOOrV686IyIinC+88EKa38HFixfNOdbPod/fuHHj3Pt+/PHHVJ/NpXnz5ubYtGnT0jymW0pLly4157/44ovO/fv3OwsVKuTs1KnTNT8jACgSSCCXiI+PNz/DwsIydP7XX39tfmpal9LTTz9tflrHStasWdN0EbtowqXdy5qu+Ypr7OSiRYskOTk5Q685evSombWsaWixYsXc++vWrWvSUtfnTOnxxx/3eK6fS9M913eYEdpVrd3Ox44dM93n+jOt7mulwwOCgv78v2NNBPW9XN3zW7duzfB76nW0ezsjdCklnYmvqaYmptqlrSkkAGQEBSSQS+i4OqVdsxlx8OBBU9TouMiUIiIiTCGnx1MqW7ZsqmtoN/aZM2fEV7p27Wq6nbVrvXTp0qYr/ZNPPvFaTLraqcWYlXYLnzx5UhITE71+Fv0cys5nueuuu0yx/vHHH5vZ1zp+0fpdumj7tXu/SpUqpggsUaKEKcB/+eUXOXfuXIbf86abbrI1YUaXEtKiWgvsN998U0qVKpXh1wLI3SgggVxUQOrYth07dth6nXUSS3ry5MmT5n6n03nd7+Ean+eSP39+WbNmjRnT+Mgjj5gCS4tKTRKt596IG/ksLloIarI3e/Zs+fzzz9NNH9XLL79skl4dz/jBBx/I0qVLzWShWrVqZThpdX0/dvz0009mXKjSMZcAkFEUkEAuopM0dBFxXYvxWnTGtBYvOnM4pePHj5vZxa4Z1b6gCV/KGcsu1pRTaSraqlUrM9lk586dZkFy7SJeuXJlup9D7dmzJ9Wx3bt3m7RPZ2ZnBi0atUjT1DetiUcun376qZnworPj9TztXm7dunWq7ySjxXxGaOqq3d069EAn5egMfZ0pDgAZQQEJ5CLDhw83xZJ2AWshaKXFpc7QdXXBKutMaS3clK5n6Cu6TJB21WqimHLsoiZ31uVurFwLaluXFnLR5Yr0HE0CUxZkmsTqrGPX58wMWhTqMkhvv/226fr3lnha08358+fLb7/95rHPVeimVWzb9cwzz8ihQ4fM96L/TnUZJZ2Vnd73CAApsZA4kItooabLyWi3r47/S3knGl3WRosWnWyi6tWrZwoKvSuNFiy6pMymTZtMwdGpU6d0l4i5Hpq6aUHTuXNnefLJJ82ai1OnTpWqVat6TCLRCR/aha3FqyaL2v3673//W8qUKWPWhkzPpEmTzPI2jRo1kt69e5s71ehyNbrGoy7rk1k0LX3++eczlAzrZ9NEUJdY0u5kHTepSy5Z//3p+NNp06aZ8ZVaUDZs2FAqVKhgq12a2Or3NmbMGPeyQjNnzjRrRY4aNcqkkQDgDQkkkMvouoma9OmajTqbWe9AM2LECLMeoq6rqJMpXN577z2z/qF2bQ4ePNgUHiNHjpR58+b5tE3Fixc3aaMufq0pqRapugZjhw4dUrVdJ7jMmDHDtHvKlClm3KC2S4vB9Gh38JIlS8z76LqWOnnkL3/5i1k/0m7xlRl0wW+d3a5jH3Uhdy2adZZ7dHS0x3l6e0b9bjSx1Jniup7m6tWrbb2Xdqf36tVLbr75ZnNLyZQzzfW99X8DGzZs8NlnAxCYHLqWj78bAQAAgJyDBBIAAAC2UEACAADAFgpIAAAA2EIBCQAAAFsoIAEAAGALBSQAAABsYSHxLKC3gzty5IhZ+NeXtyIDACAQ6QqDumZpVFSUWZA/q128eNHcYCEzBAcHS2hoqOR0FJBZQItH64LAAADAu7i4OHOnqawuHvOHFRe5ciFTrh8RESGxsbE5voikgMwCmjyqbzfukoKF/nwMIHs4kci9n4Hs5kLCeen21/ruv59ZySSPVy5ISM0eInmCfXvxq5fk2M7Z5j0oIHFNrm5rLR4LhYX7uzkAUkh0XPR3EwCkw6/DvvKGisPHBaTTEThTTyggAQAArLR29XUB65CAETilMAAAALIECSQAAICVdjf7usvZETi5XeB8EgAAAGQJEkgAAAArHf/o8zGQDgkUJJAAAACwhQQSAADAijGQXgXOJwEAAECWIIEEAACwYgykVxSQAAAAqWRCF7YETsdv4HwSAAAAZAkSSAAAACu6sL0igQQAAIAtJJAAAABWLOPjVeB8EgAAAGQJEkgAAAArxkB6RQIJAAAAW0ggAQAArBgD6RUFJAAAgBVd2F4FTikMAACALEECCQAAYEUXtleB80kAAACQJUggAQAA0hwD6esE0iGBggQSAAAAtpBAAgAAWAU5/tx8fc0AQQIJAAAAWyggAQAA0puF7estgyZMmCC33XabhIWFSalSpaRTp06yZ88e9/HTp0/LwIEDpVq1apI/f34pW7asPPnkk3Lu3Dmv1+3Zs6c4HA6P7c477xS76MIGAADIZguJr169Wvr372+KyCtXrsizzz4rbdu2lZ07d0rBggXlyJEjZnvllVekZs2acvDgQXn88cfNvk8//dTrtbVgnDlzpvt5SEiI7Y9CAQkAAJDNLFmyxOP5rFmzTBK5ZcsWadasmdSuXVsWLFjgPl6pUiV56aWX5OGHHzYFZ9686Zd4WjBGRETcUPvowgYAAMjCLuz4+HiPLSkp6ZrNcXVNFytWzOs54eHhXotHtWrVKlOMavd3v3795NSpU7a/HgpIAACALBQdHS2FCxd2bzre0Zvk5GQZPHiwNG7c2CSPaTl58qSMHz9eHnvssWt2X8+ZM0eWL18u//rXv0xXefv27eXq1au2PgNd2AAAAFk4BjIuLs4khRkdg6hjIXfs2CFr165N87immHfffbcZCzl27Fiv13rwwQfdj+vUqSN169Y13d+aSrZq1SrDH4UEEgAAIAuFh4d7bN4KyAEDBsjixYtl5cqVUqZMmVTHz58/b1JFna39+eefS758+Wy1pWLFilKiRAmJiYmx9ToSSAAAACuby+5kiI3rOZ1Os0yPFoWaDlaoUCHN5LFdu3amAP3iiy8kNDRU7Dp8+LAZAxkZGWnrdSSQAAAA2Uz//v3lgw8+kLlz55p08dixY2b7448/3MWjLuuTmJgo06dPN89d56Qcz1i9enVThKqEhAQZNmyYbNiwQQ4cOGDGQXbs2FEqV65sClE7SCABAACy2TqQU6dONT9btGjhsV/Xb9TFwLdu3SobN240+7QATCk2NlbKly9vHuvi464Z3Hny5JFffvlFZs+eLWfPnpWoqChThOrkG7trQVJAAgAAZMMubG+0sLzWOSrlOXrHmqVLl4ov0IUNAAAAW0ggAQAAslkXdnZHAgkAAABbSCABAABSyYQxkBI4uV3gfBIAAABkCRJIAAAAK8ZAekUCCQAAAFtIIAEAANJMIH29DqRDAgUFJAAAQDZbSDy7C5xPAgAAgCxBAgkAAGDFJBqvSCABAABgCwkkAACAFWMgvQqcTwIAAIAsQQIJAABgxRhIr0ggAQAAYAsJJAAAgBVjIL2igAQAALCiC9urwCmFAQAAkCVIIAEAACwcDofZfHxRCRQkkAAAALCFBBIAAMCCBNI7EkgAAADYQgIJAABgpWGhrwNDhwQMEkgAAADYQgIJAABgwRhI7yggAQAALCggvaMLGwAAALaQQAIAAFiQQHpHAgkAAABbSCABAAAsSCC9I4EEAACALSSQAAAAViwk7hUJJAAAAGwhgQQAALBgDKR3JJAAAACwhQQSAAAgjbDQ9wmkBAwKSAAAAAuH/uPzLmeHBAq6sAEAAGALCSQAAIAFk2i8I4EEAACALSSQAAAAViwk7hUJJAAAAGwhgQQAALDKhDGQTsZAAgAAILNMmDBBbrvtNgkLC5NSpUpJp06dZM+ePR7nXLx4Ufr37y/FixeXQoUKyX333SfHjx/3el2n0ymjR4+WyMhIyZ8/v7Ru3Vr27t1ru30UkAAAAOnMwvb1llGrV682xeGGDRtk2bJlcvnyZWnbtq0kJia6z3nqqafkyy+/lPnz55vzjxw5Ivfee6/X606cOFHefPNNmTZtmmzcuFEKFiwo7dq1M8WoHXRhAwAAZMEyPg4b11uyZInH81mzZpkkcsuWLdKsWTM5d+6cTJ8+XebOnSt//etfzTkzZ86UGjVqmKLzL3/5S5rp4+uvvy7PP/+8dOzY0eybM2eOlC5dWhYuXCgPPvhghttHAgkAAJCF4uPjPbakpKRrvkYLRlWsWDHzUwtJTSW1C9qlevXqUrZsWVm/fn2a14iNjZVjx455vKZw4cLSsGHDdF+THgpIAACA9Jbx8fUmItHR0aZwc2063tGb5ORkGTx4sDRu3Fhq165t9mkhGBwcLEWKFPE4V9NEPZYW1349J6OvSQ9d2AAAAFkoLi5OwsPD3c9DQkK8nq9jIXfs2CFr166V7IIEEgAAIAsn0YSHh3ts3grIAQMGyOLFi2XlypVSpkwZ9/6IiAi5dOmSnD171uN8nYWtx9Li2m+dqe3tNemhgAQAAMhmnE6nKR4///xzWbFihVSoUMHjeIMGDSRfvnyyfPly9z5d5ufQoUPSqFGjNK+p19BCMeVrdAymzsZO7zXpoQsbAAAgm83C7t+/v5lhvWjRIrMWpGuMoo6Z1PUb9Wfv3r1lyJAhZmKNJpkDBw40hWDKGdg6sUbHWHbu3Nm8v46lfPHFF6VKlSqmoBw1apRERUWZdSbtoIAEAADIZqZOnWp+tmjRwmO/LtXTs2dP83jy5MkSFBRkFhDXmdy6nuO///1vj/M1lXTN4FbDhw83a0k+9thjpvu7SZMmZsmg0NBQW+1zODUjRabSeFj/S+GHXw9LobD/DZoF4H/HE+wtngsg8yUmnJfOt1cyhU/KySZZ+Te7VI85EhRcwKfXTr50QU7M7u6Xz+VrJJAAAADZrAs7u2MSDQAAAGwhgQQAALBKsfC3T68ZIEggAQAAYAsJJAAAgAVjIL0jgQQAAIAtJJAAAAAWJJDekUACAADAFhJIAAAACxJI7yggAQAArFjGxyu6sAEAAGALCSQAAIAFXdjekUACAADAFhJIAAAACxJI70ggAQAAYAsJJJABnfr8S46eOJtq/313/UWGP97RL20C8KcLfyTJh/NXyobNu+XcuUSpWD5C+na/U6pUusnfTUMO5pBMSCCFBDLbO3bsmAwcOFAqVqwoISEhEh0dLR06dJDly5eb4+XLl3fH0wUKFJA6derIe++9l+o6K1eulLvuukuKFy9uzqtZs6Y8/fTT8ttvv/nhU8FfZr7aX76e/ax7e2tcb7O/VeM6/m4akOu9/e6Xsm37fnmqX2d581/9pH6dSjLq5ffl1Ol4fzcNCFgBWUAeOHBAGjRoICtWrJBJkybJ9u3bZcmSJdKyZUvp37+/+7xx48bJ0aNHZceOHfLwww9L37595ZtvvnEff+edd6R169YSEREhCxYskJ07d8q0adPk3Llz8uqrr/rp08EfihYuJMWLhrm3tT/ukjIRxeSW2hX83TQgV0u6dFnWbdopPf/eWmrXKCdREcXk711aSGTpYvLNd5v93TzkYK6QyddboAjILuwnnnjC/EvatGmTFCxY0L2/Vq1a0qtXL/fzsLAwUxyqZ555RiZOnCjLli2T9u3by+HDh+XJJ5802+TJk92v0eSyWbNmcvZs6u5M5A6XL1+RJau2yd87Ngmo/zMAcqKrV5MlOdkpwfk8/5wFB+eVnXsO+a1dCAAsJJ67EsjTp0+btFGTxpTFo0uRIkVS7UtOTjYJ45kzZyQ4ONjsmz9/vly6dEmGDx+e5vukdR2XpKQkiY+P99gQOFZv3CkJiRfl7lYN/N0UINcrkD9EqlcpIx9/vkZOnTkvV5OTZeXaX2TP3sNy5myCv5sHBKyAKyBjYmLE6XRK9erVr3mupo6FChUyYyS7dOkiRYsWlT59+phje/fulfDwcImMjLTdhgkTJkjhwoXdm46/ROD4YtlmadSgqpQsHu7vpgAQkaee6CxOp8ij/V+T+7q/KIuXbJSmd9SmhwA3hC7sXFZAavGYUcOGDZNt27aZsZINGzY0XdWVK1d2X+d6/0WPHDnSjJN0bXFxcdd1HWQ/R0+ckR9/jpF72tzm76YA+C8d7zhhdE/5ZMZImfHWU/Lqi31N13ZEqaL+bhoQsAJuDGSVKlVM4bd79+5rnluiRAlTMOqmXdY6E/vWW281M62rVq1qij+dZGM3hdREUzcEnsXfbTETahrfVs3fTQFgERoabLaEhD/kp19ipMdDbfzdJORgLCSeyxLIYsWKSbt27WTKlCmSmJiY6nh6k1+0m7lr164mPVTapa3jIXViTVqYRJP76FjZxcu3yN1/vUXy5snj7+YA+K+tP8fIlp9j5NiJM/LT9n3y3Euz5aaoEtK6eX1/Nw0IWAGXQCotHhs3biy33367Waqnbt26cuXKFTPDeurUqbJr1640Xzdo0CCpXbu2bN682SSR2qU9YMAAMwmme/fuZga2zs6eM2eOGTvJUj65yyb9A/X7WenQmskzQHZbSHzOvOVy8nS8hBXKL41uqyGPdP2r5M3Lf+jh+mlY6OvA0BE4AWRgFpC6ePjWrVvlpZdeMot+azd0yZIlzdqQWkCmR7uu27ZtK6NHj5avv/7aLAekXdmvvPKKdO7cWf744w9TRP7tb3+TIUOGZOlngv/95eaqsvGLCf5uBgCLJn+pZTYAWcfhtDPrBNdFE0ydjf3Dr4elUBgzd4Hs5HjCRX83AYBFYsJ56Xx7JTMXQVdE8cff7IoDP5WgkNTLAd6I5KRE2f9WF798Ll8LyAQSAADghmRCF7YEUBd2wE2iAQAAQOYigQQAALBgGR/vSCABAABgCwkkAACABcv4eEcCCQAAAFtIIAEAACyCghxm8yWnj6/nTySQAAAAsIUEEgAAwIIxkN5RQAIAAFiwjI93dGEDAADAFhJIAAAAC7qwvSOBBAAAgC0kkAAAABaMgfSOBBIAAAC2kEACAABYkEB6RwIJAAAAWyggAQAA0pmF7evNjjVr1kiHDh0kKirKpJcLFy5MMyW1bpMmTUr3mmPHjk11fvXq1cUuurABAAAsHJIJXdhi73qJiYlSr1496dWrl9x7772pjh89etTj+TfffCO9e/eW++67z+t1a9WqJd999537ed689stBCkgAAIBsqH379mZLT0REhMfzRYsWScuWLaVixYper6sFo/W1dtGFDQAAkIVd2PHx8R5bUlLSDbf3+PHj8tVXX5kE8lr27t1rusW10OzWrZscOnTI9vtRQAIAAGSh6OhoKVy4sHubMGHCDV9z9uzZEhYWlmZXd0oNGzaUWbNmyZIlS2Tq1KkSGxsrTZs2lfPnz9t6P7qwAQAAsnAZn7i4OAkPD3fvDwkJueFrz5gxw6SJoaGhXs9L2SVet25dU1CWK1dOPvnkkwylly4UkAAAAFkoPDzco4C8Ud9//73s2bNHPv74Y9uvLVKkiFStWlViYmJsvY4ubAAAgGy4jE9GTZ8+XRo0aGBmbNuVkJAg+/btk8jISFuvo4AEAADIhhISEmTbtm1mUzpeUR+nnPSik3Dmz58vffr0SfMarVq1krffftv9fOjQobJ69Wo5cOCArFu3Tjp37ix58uSRhx56yFbb6MIGAADIhrcy3Lx5s1mWx2XIkCHmZ48ePcxEGDVv3jxxOp3pFoCaLp48edL9/PDhw+bcU6dOScmSJaVJkyayYcMG89gOCkgAAIBsqEWLFqY49Oaxxx4zW3o0aUxJC05foIAEAACwyIwxi45MGgPpDxSQAAAA2bALOztjEg0AAABsIYEEAACwyoxldxwSMEggAQAAYAsJJAAAgAVjIL0jgQQAAIAtJJAAAAAWLOPjHQkkAAAAbCGBBAAAsGAMpHcUkAAAABZ0YXtHFzYAAABsIYEEAACwoAvbOxJIAAAA2EICCQAAYEEC6R0JJAAAAGwhgQQAALBgFrZ3JJAAAACwhQQSAADAgjGQ3lFAAgAAWNCF7R1d2AAAALCFBBIAAMCCLmzvSCABAABgCwkkAACAhWaFPh8DKYGDBBIAAAC2kEACAABYBDkcZvP1NQMFCSQAAABsIYEEAACwYB1I7yggAQAALFjGxzu6sAEAAGALCSQAAIBFkOPPzdfXDBQkkAAAALCFBBIAAMDKTKJhJfH0kEACAADAFhJIAAAAC5bx8Y4EEgAAALaQQAIAAFg4/vuPr68ZKCggAQAALFjGxzu6sAEAAGALCSQAAIAFtzL0jgQSAAAAtpBAAgAAWLCMj3ckkAAAALCFBBIAAMAiyOEwm6+vGShIIAEAALKhNWvWSIcOHSQqKspMwFm4cKHH8Z49e7on+7i2O++885rXnTJlipQvX15CQ0OlYcOGsmnTJttto4AEAABIZwykrzc7EhMTpV69eqbgS48WjEePHnVvH330kddrfvzxxzJkyBAZM2aMbN261Vy/Xbt2cuLECVttowsbAAAgGy7j0759e7N5ExISIhERERm+5muvvSZ9+/aVRx991DyfNm2afPXVVzJjxgwZMWJEhq9DAgkAAJCF4uPjPbakpKTrvtaqVaukVKlSUq1aNenXr5+cOnUq3XMvXbokW7ZskdatW7v3BQUFmefr16+39b4UkAAAAFnYhR0dHS2FCxd2bxMmTLiuNmr39Zw5c2T58uXyr3/9S1avXm0Sy6tXr6Z5/smTJ82x0qVLe+zX58eOHfN9F/YXX3yR4Qvec889thoAAACQm8TFxUl4eLhHN/T1ePDBB92P69SpI3Xr1pVKlSqZVLJVq1aSmTJUQHbq1CnDffvpVb0AAAA5RWYu4xMeHu5RQPpKxYoVpUSJEhITE5NmAanH8uTJI8ePH/fYr8/tjKPMcBd2cnJyhjaKRwAAAP84fPiwGQMZGRmZ5vHg4GBp0KCB6fJ20fpNnzdq1CjrxkBevHjxRl4OAACQLTkyabMjISFBtm3bZjYVGxtrHh86dMgcGzZsmGzYsEEOHDhgisCOHTtK5cqVzbI8LppEvv322+7nuoTPu+++K7Nnz5Zdu3aZiTe6XJBrVnamFZCaMo4fP15uuukmKVSokOzfv9/sHzVqlEyfPt3u5QAAAJCGzZs3y80332w2V/Gnj0ePHm26on/55Rcz96Rq1arSu3dvky5+//33HmMq9+3bZybPuHTt2lVeeeUVc4369eubgnTJkiWpJtb4fB3Il156yVStEydONOsIudSuXVtef/118wEAAABysuywDmSLFi3E6XSme3zp0qXXvIamk1YDBgww242wnUDqdPH//Oc/0q1bN1P9uuhK5rt3776hxgAAAGQHQY7M2QKF7QLyt99+M/3rVjoI8/Lly75qFwAAAAKlgKxZs6bpX7f69NNP3X30AAAAgdCF7estUNgeA6mDLnv06GGSSE0dP/vsM9mzZ4/p2l68eHHmtBIAAAA5N4HUKeJffvmlfPfdd1KwYEFTUOo0cN3Xpk2bzGklAABAFsuM2xjm2gRSNW3aVJYtW+b71gAAACAwC0jX2kSaPLrGReraQwAAAIEgOyzjE1AFpN4m56GHHpIffvhBihQpYvadPXtW7rjjDpk3b56UKVMmM9oJAACAnDoGsk+fPma5Hk0fT58+bTZ9rBNq9BgAAEBOxzqQPk4gV69eLevWrZNq1aq59+njt956y4yNBAAAyOnowvZxAhkdHZ3mguF6j+yoqCi7lwMAAECgF5CTJk2SgQMHmkk0Lvp40KBB5ubcAAAAOZ0jk7Zc1YVdtGhRj9g1MTFRGjZsKHnz/vnyK1eumMe9evWSTp06ZV5rAQAAkDMKyNdffz3zWwIAAJBNBDkcZvP1NXNVAam3LgQAAABuaCFxdfHiRbl06ZLHvvDwcL5ZAACQo2XG7Qcdjlw8iUbHPw4YMEBKlSpl7oWt4yNTbgAAAAhstgvI4cOHy4oVK2Tq1KkSEhIi7733nrzwwgtmCZ85c+ZkTisBAAD8sA6kr7dc24X95ZdfmkKxRYsW8uijj5rFwytXrizlypWTDz/8ULp165Y5LQUAAEDOTCD11oUVK1Z0j3fU56pJkyayZs0a37cQAADAT2Mgfb3l2gJSi8fY2FjzuHr16vLJJ5+4k8kiRYr4voUAAAB+WsbH11uuLSC12/rnn382j0eMGCFTpkyR0NBQeeqpp2TYsGGZ0UYAAADk5DGQWii6tG7dWnbv3i1btmwx4yDr1q3r6/YBAABkOZbxycR1IJVOntENAAAAuUOGCsg333wzwxd88sknb6Q9AAAAfpcZy+44AiiCzFABOXny5Ax/MRSQ6ascESbh4WH+bgaAFBreNtLfTQBg4bzqeZc75NAC0jXrGgAAIDcIup6Zxtfg6+v5UyB9FgAAAOSESTQAAACBhjGQ3lFAAgAAWGitF8QyPumiCxsAAAC2kEACAABYBGVCAhmU2xPI77//Xh5++GFp1KiR/Pbbb2bf+++/L2vXrvV1+wAAAJDTC8gFCxZIu3btJH/+/PLTTz9JUlKS2X/u3Dl5+eWXM6ONAAAAfplE4+st1xaQL774okybNk3effddyZcvn3t/48aNZevWrb5uHwAAAHL6GMg9e/ZIs2bNUu0vXLiwnD171lftAgAA8BvGQPo4gYyIiJCYmJhU+3X8Y8WKFe1eDgAAAIFeQPbt21cGDRokGzduNH35R44ckQ8//FCGDh0q/fr1y5xWAgAAZCEdrpgZW67twh4xYoQkJydLq1at5MKFC6Y7OyQkxBSQAwcOzJxWAgAAZKEgh8Nsvr5mri0gNXV87rnnZNiwYaYrOyEhQWrWrCmFChXKnBYCAAAgMBYSDw4ONoUjAABAII7x8/Xt+oIkFxeQLVu29LqO0YoVK260TQAAAAikArJ+/foezy9fvizbtm2THTt2SI8ePXzZNgAAAL/IjEkvDkcuLiAnT56c5v6xY8ea8ZAAAAAIbD7rjtd7Y8+YMcNXlwMAAPCbIPlzFrZPN7EXQa5Zs0Y6dOggUVFRZvjgwoULPXqAn3nmGalTp44ULFjQnNO9e3ezvKI3GvhZb69YvXr16/h+fGT9+vUSGhrqq8sBAADkaomJiVKvXj2ZMmVKqmO6lKLeQnrUqFHm52effWbuFnjPPfdc87q1atWSo0ePuje9GUymd2Hfe++9Hs+dTqd5882bN5sPAQAAkNNlhzGQ7du3N1ta9BbSy5Yt89j39ttvy+233y6HDh2SsmXLpnvdvHnzmjsL3gjbBaQ2OKWgoCCpVq2ajBs3Ttq2bXtDjQEAAAj0e2HHx8d77Ncbsuh2o86dO2e6pIsUKeL1vL1795oub+05btSokUyYMMFrwXnDBeTVq1fl0UcfNf3tRYsWtfVGAAAAEImOjvZ4PmbMGDM28UZcvHjRjIl86KGHJDw8PN3zGjZsKLNmzTLhn/Ygv/DCC9K0aVOzmk5YWFjmFJB58uQxKeOuXbsoIAEAQMDS7mZf33rQ8d/LxcXFeRR5N5o+6oSaBx54wAwrnDp1qtdzU3aJ161b1xSU5cqVk08++UR69+6deV3YtWvXlv3790uFChXsvhQAACDXCw8P95oSXk/xePDgQXMzF7vX1e7uqlWrmttTZ+os7BdffFGGDh0qixcvNtGn9uOn3AAAAAJlEo2vN19yFY86pvG7776T4sWL276GruG9b98+iYyMzJwCUifJ6HTyu+66S37++WczTbxMmTKmK1s3rWDp1gYAAPANLe70bn+6qdjYWPNYZ1lr8dilSxezCs6HH35o5qkcO3bMbJcuXXJfo1WrVmZ2touGgKtXr5YDBw7IunXrpHPnzmaIoo6dtCPDXdg6yPLxxx+XlStX2noDAACAnCYzZ2FnlBaHLVu2dD8fMmSI+am3jtZJN1988UWat5nWWq1FixbmsaaLJ0+edB87fPiwKRZPnTolJUuWlCZNmsiGDRvM40wpIHVgpmrevLmtNwAAAIB9WgS66q+0eDvmokljSvPmzRNfsDWJRtcWAgAACHSO//7j62sGClsFpM7SuVYRefr06RttEwAAgOT2LuyAKSB1HKT1TjQAAADIXWwVkA8++KCUKlUq81oDAACQDZBA+mgZH8Y/AgAA4LpmYQMAAAQ6Dc58HZ45AiiMy3ABmZycnLktAQAAQI5g+17YAAAAgY4xkD6+FzYAAAByNxJIAAAACx2u6Oshi44ASiApIAEAACyCHA6z+fqagYIubAAAANhCAgkAAGDBJBrvSCABAABgCwkkAACAVSZMohESSAAAAORWJJAAAAAWQeIwm6+vGShIIAEAAGALCSQAAIAFC4l7RwEJAABgwTI+3tGFDQAAAFtIIAEAACy4laF3JJAAAACwhQQSAADAgkk03pFAAgAAwBYSSAAAgLQWEvf1GEgJnAiSBBIAAAC2kEACAABYMAbSOwpIAACANLpofd1NGySBI5A+CwAAALIACSQAAICFw+Ewm6+vGShIIAEAAGALCSQAAICFZoW+zgsdEjhIIAEAAGALCSQAAICFLiLu84XEHYGTQZJAAgAAwBYSSAAAgDQETl7oexSQAAAAFtyJxju6sAEAAGALCSQAAIAFC4l7RwIJAAAAW0ggAQAA0kjYfJ2yBUngCKTPAgAAgCxAAgkAAGDBGEjvSCABAACyoTVr1kiHDh0kKirKFJ8LFy70OO50OmX06NESGRkp+fPnl9atW8vevXuved0pU6ZI+fLlJTQ0VBo2bCibNm2y3TYKSAAAAAtHJm12JCYmSr169UzBl5aJEyfKm2++KdOmTZONGzdKwYIFpV27dnLx4sV0r/nxxx/LkCFDZMyYMbJ161ZzfX3NiRMnbLWNAhIAACAbat++vbz44ovSuXPnVMc0fXz99dfl+eefl44dO0rdunVlzpw5cuTIkVRJZUqvvfaa9O3bVx599FGpWbOmKT4LFCggM2bMsNU2CkgAAIB0xkD6elPx8fEeW1JSktgVGxsrx44dM93WLoULFzZd0uvXr0/zNZcuXZItW7Z4vCYoKMg8T+816aGABAAASGcZH19vKjo62hR7rm3ChAlilxaPqnTp0h779bnrmNXJkyfl6tWrtl6THmZhAwAAZKG4uDgJDw93Pw8JCZGchgISAAAgC5fxCQ8P9yggr0dERIT5efz4cTML20Wf169fP83XlChRQvLkyWPOSUmfu66XUXRhAwAA5DAVKlQwRd/y5cvd+3Q8pc7GbtSoUZqvCQ4OlgYNGni8Jjk52TxP7zXpIYEEAACwuJ5ld67F7vUSEhIkJibGY+LMtm3bpFixYlK2bFkZPHiwmaVdpUoVU1COGjXKrBnZqVMn92tatWplZnEPGDDAPNclfHr06CG33nqr3H777WYmty4XpLOy7aCABAAAyIY2b94sLVu2dD/X4k9pAThr1iwZPny4Kf4ee+wxOXv2rDRp0kSWLFliFgh32bdvn5k849K1a1f5/fffzQLkOnFGu7v1NdaJNdficOpCQshUGinrLKvjp87d8JgHAL5V9LY//6scQPbhvHpJkra/K+fOZf3fTdff7Lnr/k8KFArz6bUvJJyXv99R1S+fy9cYAwkAAABb6MIGAACwCBKH2Xx9zUBBAQkAAGChK+74eBUf8fX1/IkubAAAANhCAgkAAGDh+O8/vr5moCCBBAAAgC0kkAAAABaMgfSOBBIAAAC2kEACAACkMV7R18vuOBgDCQAAgNyKBBIAAMCCMZDeUUACAABYUEB6Rxc2AAAAbCGBBAAAsGAhce9IIAEAAGALCSQAAIBFkOPPzdfXDBQkkAAAALCFBBIAAMCCMZDekUACAADAFhJIAAAAC9aB9I4CEgAAwEJrPd93YQcOurABAABgCwkkAACABcv4eEcCCQAAAFtIIAEAACxYxsc7EkgAAADYQgJp06pVq6Rly5Zy5swZKVKkiL+bgywy/dPvZcaC7yXu6GnzvHrFCBnWu720aVzL300Dco2neraVv7WsJ1XKlZaLSZdl0y/7ZezbiyTm4Ik0z5//Rj9pfUct6Tb0P/L16l+yvL3I2VjGJ5snkMeOHZOBAwdKxYoVJSQkRKKjo6VDhw6yfPlyn71HixYtZPDgwT67HnKfqFJFZMyAjrJyznBZMXuYNL21qvmjtGvfUX83Dcg17rilsrw3f4207fWK3DvgbcmXN4989tYAKRAanOrcfg+1FKfTL80EcgW/JpAHDhyQxo0bmyRv0qRJUqdOHbl8+bIsXbpU+vfvL7t3786ytjidTrl69arkzUsoi9TaN6vj8XzUE/fIjAVrZfOOWKlRKdJv7QJyk/uf/LfH8yde+EBilv1T6teIlnU/7XPvr131Junf7a/y1x4TZc+SCX5oKQJnHUjfXzNQ+DWBfOKJJ8ThcMimTZvkvvvuk6pVq0qtWrVkyJAhsmHDBnPOoUOHpGPHjlKoUCEJDw+XBx54QI4fP+6+xtixY6V+/fry/vvvS/ny5aVw4cLy4IMPyvnz583xnj17yurVq+WNN94w76WbFq7aFa2Pv/nmG2nQoIFJP9euXStJSUny5JNPSqlSpSQ0NFSaNGkiP/74o9++I2Q/V68my4JvN8uFPy7JbXUq+Ls5QK4VXijU/DwTf8G9L39IPnl3fE8ZNvETOXHqz78DwPUIEocEOXy8SeCUkH4rIE+fPi1LliwxSWPBggVTHddUMjk52RSPeq4WgcuWLZP9+/dL165dPc7dt2+fLFy4UBYvXmw2Pfef//ynOaaFY6NGjaRv375y9OhRs2k3ucuIESPMubt27ZK6devK8OHDZcGCBTJ79mzZunWrVK5cWdq1a2fakFFahMbHx3tsyPl+jflNyjQbIqUbD5YhEz6W9yf1leoVSR8Bf9AAYMKQLrJh2z6PoSQvD7lPNv0SK9+s2e7X9gGBzm8FZExMjOk2rl69errn6DjI7du3y9y5c01K2LBhQ5kzZ44pEFOmglpozpo1S2rXri1NmzaVRx55xD2GUhPJ4OBgKVCggERERJgtT5487teOGzdO2rRpI5UqVTIp5NSpU013evv27aVmzZry7rvvSv78+WX69OkZ/mwTJkww7+vaUhasyLl04P6aD0fKdzOHSq/7msgTY9+X3fsZAwn4wyvDHzDDR3o/N9NjqImOT372tU/92jYEVhe2r7dA4bcCUovHa9FUUIuvlAWYFnWaTuoxF+26DgsLcz+PjIyUEyfSnpVndeutt3okmToGU8dluuTLl09uv/12j/e7lpEjR8q5c+fcW1xcXIZfi+wrOF9eqRhdUurXKGsm1NSucpNMm7fK380Ccp2Jw+6Xdk1rS4d+b8qRE2fd+7V4rFCmhBxYMUl+X/+G2dScf/WRL6cN8mOLgcDjtxkjVapUMV0Qvpgoo0VeSnpdTSUzIq3u8xulSaZuCGzJTqdcunTF380Acl3xeHeLetLh8Tfk0JFTHsden/2tvL9once+dfOek2cnL5Al3+/I4pYix2MWTfZMIIsVK2bGFk6ZMkUSExNTHT979qzUqFHDpHcpE7ydO3eaY5pEZpR2YesM62vRbmw994cffnDv00RSu8vtvB8CzwtvL5IftsaYP1g6FlKfr92yV+5v/78EG0DmeuWZB+SB9rdJ31GzJOHCRSlVPMxsoSF/hgg6aUbHQ6bc1OFjZ1IVmwBujF/XrNHiUbuLtYtYxyLqJJYrV66YyTI6FlGLRV3ap1u3bvL666+bYzpzu3nz5h5dz9eiXdwbN240s691NrcWr+mlkf369ZNhw4aZc8qWLSsTJ06UCxcuSO/evX34yZHTnDyTIP3GzpHjJ+PNzM9alW+SBW89IS0b1vB304Bco3eXZubnV+94ruv7xAvvy0eLN/qpVQhU3MowGxeQuni4znR+6aWX5OmnnzYzpEuWLGkmzGgBqV3RixYtMguNN2vWTIKCguTOO++Ut956y9b7DB06VHr06GFSxD/++ENiY2PTPVdnZGv3t07E0aWAtFDVdSmLFi3qg0+MnOqtUd383QQg1yt624AseQ2Aa3M4MzKbBTdEl/HR2djHT50za1kCyD4oMIDsx3n1kiRtf9dMRM3qv5uuv9nLtx2SQmG+fe+E8/HSqn5Zv3wuX+O2KwAAABbMocnm98IGAABAzkICCQAAYEUE6RUJJAAAAGwhgQQAALBgGR/vSCABAABgCwUkAACAhcOROZsdeiMUXRPbuvXv3z/N82fNmpXq3NDQUMkMdGEDAABkQz/++KPHrZh37Nghbdq0kfvvvz/d1+j6knv27HE/1yIyM1BAAgAAZMNJ2CVLlkx1t7xKlSqZWzqn+x4Oh0REREhmowsbAAAgvQrS15v8ebeblFtSUtI1m3Pp0iX54IMPpFevXl5TxYSEBClXrpxER0dLx44d5ddff5XMQAEJAACQhaKjo83tEl3bhAkTrvmahQsXytmzZ6Vnz57pnlOtWjWZMWOGLFq0yBSbycnJcscdd8jhw4d9/AnowgYAAMjSZXzi4uI87oUdEhJyzddOnz5d2rdvL1FRUeme06hRI7O5aPFYo0YNeeedd2T8+PHiSxSQAAAAWSg8PNyjgLyWgwcPynfffSefffaZrffJly+f3HzzzRITEyO+Rhc2AABANlzGx2XmzJlSqlQpufvuu8UOncG9fft2iYyMFF+jgAQAAMimkpOTTQHZo0cPyZvXs+O4e/fuMnLkSPfzcePGybfffiv79++XrVu3ysMPP2zSyz59+vi8XXRhAwAAZMNlfJR2XR86dMjMvrbS/UFB/8sCz5w5I3379pVjx45J0aJFpUGDBrJu3TqpWbOm+BoFJAAAQDbVtm1bcTqdaR5btWqVx/PJkyebLStQQAIAAGTXCDKbooAEAADIwmV8AgGTaAAAAGALCSQAAIDFjSy7kx5fX8+fSCABAABgCwkkAACABXNovCOBBAAAgC0kkAAAAFZEkF6RQAIAAMAWEkgAAAAL1oH0jgQSAAAAtpBAAgAAWLAOpHcUkAAAABbMofGOLmwAAADYQgIJAABgRQTpFQkkAAAAbCGBBAAAsGAZH+9IIAEAAGALCSQAAIAFy/h4RwIJAAAAW0ggAQAALJiE7R0FJAAAgBUVpFd0YQMAAMAWEkgAAAALlvHxjgQSAAAAtpBAAgAAWGXCMj4SOAEkCSQAAADsIYEEAACwYBK2dySQAAAAsIUEEgAAwIoI0isKSAAAAAuW8fGOLmwAAADYQgIJAABg4ciEZXwcgRNAkkACAADAHhJIAAAAC+bQeEcCCQAAAFtIIAEAAKyIIL0igQQAAIAtJJAAAAAWrAPpHQUkAABAWj3Yvl7GRwIHXdgAAACwhQQSAADAgjk03pFAAgAAwBYSSAAAAAtuZegdCSQAAEA2NHbsWHE4HB5b9erVvb5m/vz55pzQ0FCpU6eOfP3115nSNgpIAACAdEdB+nqzp1atWnL06FH3tnbt2nTPXbdunTz00EPSu3dv+emnn6RTp05m27Fjh/gaBSQAAEA2lTdvXomIiHBvJUqUSPfcN954Q+68804ZNmyY1KhRQ8aPHy+33HKLvP322z5vFwUkAABAOmMgfb2p+Ph4jy0pKUnSs3fvXomKipKKFStKt27d5NChQ+meu379emndurXHvnbt2pn9vkYBCQAAkIUd2NHR0VK4cGH3NmHChDTb0LBhQ5k1a5YsWbJEpk6dKrGxsdK0aVM5f/58mucfO3ZMSpcu7bFPn+t+X2MWNgAAQBaKi4uT8PBw9/OQkJA0z2vfvr37cd26dU1BWa5cOfnkk0/MOEd/ooAEAADIwmV8wsPDPQrIjCpSpIhUrVpVYmJi0jyuYySPHz/usU+f635fowsbAAAgB0hISJB9+/ZJZGRkmscbNWoky5cv99i3bNkys9/XKCABAAAsHJn0jx1Dhw6V1atXy4EDB8wSPZ07d5Y8efKYpXpU9+7dZeTIke7zBw0aZMZLvvrqq7J7926zjuTmzZtlwIAB4mt0YQMAAGRDhw8fNsXiqVOnpGTJktKkSRPZsGGDeax0RnZQ0P+ywDvuuEPmzp0rzz//vDz77LNSpUoVWbhwodSuXdvnbaOABAAAsLq+db+9s3m9efPmeT2+atWqVPvuv/9+s2U2urABAABgCwkkAABA9gsgszUKSAAAgCxcxicQ0IUNAAAAW0ggAQAALK5n2Z1r8fX1/IkEEgAAALaQQAIAAFgxi8YrEkgAAADYQgIJAABgQQDpHQkkAAAAbCGBBAAAsGAdSO8oIAEAAFLx/TI+EkCd2HRhAwAAwBYSSAAAAAu6sL0jgQQAAIAtFJAAAACwhQISAAAAtjAGEgAAwIIxkN6RQAIAAMAWEkgAAIA0V4H0bWToCKB1ICkgAQAALOjC9o4ubAAAANhCAgkAAGChYSE3MkwfCSQAAABsIYEEAACwIoL0igQSAAAAtpBAAgAAWLCMj3ckkAAAALCFBBIAAMCCdSC9I4EEAACALSSQAAAAFkzC9o4CEgAAwIoK0iu6sAEAAGALCSQAAIAFy/h4RwIJAAAAW0ggAQAALFjGxzsKyCzgdDrNz/Px8f5uCgAL59VL/m4CgHR+L11/P/0hPhP+ZscHUB1AAZkFzp8/b35WrhDt76YAAJCj/n4WLlw4S98zODhYIiIipEom/c2OiIgw75HTOZz+LO9zieTkZDly5IiEhYWJI5Dy61xI/+sxOjpa4uLiJDw83N/NAfBf/G4GFi1NtHiMioqSoKCsn65x8eJFuXQpc3ongoODJTQ0VHI6EsgsoP/jL1OmjL+bAR/SP1D8kQKyH343A0dWJ48paYEXCEVeZmIWNgAAAGyhgAQAAIAtFJCADSEhITJmzBjzE0D2we8mkLWYRAMAAABbSCABAABgCwUkAAAAbKGABAAAgC0UkAAAeLFq1SpzE4izZ8/6uylAtkEBCYjIsWPHZODAgVKxYkUzi1PvaNGhQwdZvny5OV6+fHnzB0S3AgUKSJ06deS9995LdZ2VK1fKXXfdJcWLFzfn1axZU55++mn57bff/PCpgJz5++YLLVq0kMGDB/vsegA8UUAi1ztw4IA0aNBAVqxYIZMmTZLt27fLkiVLpGXLltK/f3/3eePGjZOjR4/Kjh075OGHH5a+ffvKN9984z7+zjvvSOvWrc19ThcsWCA7d+6UadOmyblz5+TVV1/106cDcubvW1bQRUiuXLmSpe8JBAxdxgfIzdq3b++86aabnAkJCamOnTlzxvwsV66cc/LkyR7HihUr5nzqqafM47i4OGdwcLBz8ODBab6H6zpAbpeR37eDBw8677nnHmfBggWdYWFhzvvvv9957Ngx93ljxoxx1qtXzzlnzhzzuxkeHu7s2rWrMz4+3hzv0aOHLk/nscXGxjpXrlxpHn/99dfOW265xZkvXz6z7+LFi86BAwc6S5Ys6QwJCXE2btzYuWnTJvf7uV7H7zHwPySQyNVOnz5t0g9NPgoWLJjqeJEiRVLtS05ONgnjmTNnJDg42OybP3++XLp0SYYPH57m+6R1HSC3ycjvm/5+dezY0Zy7evVqWbZsmezfv1+6du3qce6+fftk4cKFsnjxYrPpuf/85z/NsTfeeEMaNWpkegm010A37SZ3GTFihDl3165dUrduXfN7q7/Ts2fPlq1bt0rlypWlXbt2pg0A0kYBiVwtJibGdGNVr179muc+88wzUqhQITNmq0uXLlK0aFHp06ePObZ3714JDw+XyMjILGg1ELi/bzoOUru1586da7q6GzZsKHPmzDEF4o8//ug+TwvNWbNmSe3ataVp06byyCOPuMdQFi5c2PzHnY5D1iEluuXJk8djOEqbNm2kUqVK5vd56tSppju9ffv2Ztzyu+++K/nz55fp06dn8jcC5FwUkMjV7NyIadiwYbJt2zYzdkv/qE2ePNkkFa7r6AQbADf2+6apoKaFKRNDLeo0ndRjLjqxLSwszP1c/+PtxIkTGWrHrbfe6pFkXr58WRo3buzely9fPrn99ts93g+Ap7yW50CuUqVKFVP47d69+5rnlihRwhSMummXtc7E1j9E+setatWqZrKMdpWRQgI3/vt2LVrkpaTX1VQyI9LqPgdgDwkkcrVixYqZsU5TpkyRxMTEVMfTW/dN0xEdkzVy5EjzXLu0tcts4sSJaZ7P+nFAxn7fatSoIXFxcWZz0RUN9Jj+x1pG6e/j1atXr3medmPruT/88IN7nyaS2l1u5/2A3IYCErme/jHTPzTaZaUD6XU8o3Zdvfnmm2YgfnoGDRokX375pWzevNkUlNqlrYP3e/fubcZrHTx40PxR+sc//iHjx4/P0s8E5NTfN10KS9P9bt26mQktmzZtku7du0vz5s09up6vRbu4N27caJYNOnnyZLrppKaR/fr1M0NUdIKPFqs6+ebChQvmdxlA2iggkevpYsb6h0rXodNFv3VQvg6w1wH5Org+PZpOtG3bVkaPHm2eP/HEE/Ltt9+aRcM7d+5sJgroJBudXDN06NAs/ERAzv19067oRYsWmUlqzZo1MwWlvubjjz+29T76O6cTZ/T3tGTJknLo0KF0z9UZ2ffdd5+ZiHPLLbeYyT5Lly41bQCQNoeu5ZPOMQAAACAVEkgAAADYQgEJAAAAWyggAQAAYAsFJAAAAGyhgAQAAIAtFJAAAACwhQISAAAAtlBAAgAAwBYKSADZWs+ePaVTp07u5y1atJDBgwdneTtWrVpl7pLi7b7menzhwoUZvubYsWOlfv36N9QuvVWfvu+2bdtu6DoAYAcFJIDrKuq0aNEtODhYKleuLOPGjZMrV65k+nt/9tlnGb63eEaKPgCAfXmv4zUAIHfeeafMnDlTkpKS5Ouvv5b+/ftLvnz5ZOTIkanOvXTpkik0faFYsWI+uQ4A4PqRQAK4LiEhIRIRESHlypWTfv36SevWreWLL77w6HZ+6aWXJCoqSqpVq2b2x8XFyQMPPCBFihQxhWDHjh1NF6zL1atXZciQIeZ48eLFZfjw4eJ0Oj3e19qFrQXsM888I9HR0aZNmoZOnz7dXLdly5bmnKJFi5okUtulkpOTZcKECVKhQgXJnz+/1KtXTz799FOP99GiuGrVqua4XidlOzNK26XXKFCggFSsWFFGjRolly9fTnXeO++8Y9qv5+n3c+7cOY/j7733ntSoUUNCQ0OlevXq8u9//9t2WwDAlyggAfiEFlqaNLosX75c9uzZI8uWLZPFixebwqldu3YSFhYm33//vfzwww9SqFAhk2S6Xvfqq6/KrFmzZMaMGbJ27Vo5ffq0fP75517ft3v37vLRRx/Jm2++Kbt27TLFmF5XC7IFCxaYc7QdR48elTfeeMM81+Jxzpw5Mm3aNPn111/lqaeekocfflhWr17tLnTvvfde6dChgxlb2KdPHxkxYoTt70Q/q36enTt3mvd+9913ZfLkyR7nxMTEyCeffCJffvmlLFmyRH766Sd54okn3Mc//PBDGT16tCnG9fO9/PLLphCdPXu27fYAgM84AcCmHj16ODt27GgeJycnO5ctW+YMCQlxDh061H28dOnSzqSkJPdr3n//fWe1atXM+S56PH/+/M6lS5ea55GRkc6JEye6j1++fNlZpkwZ93up5s2bOwcNGmQe79mzR+NJ8/5pWblypTl+5swZ976LFy86CxQo4Fy3bp3Hub1793Y+9NBD5vHIkSOdNWvW9Dj+zDPPpLqWlR7//PPP0z0+adIkZ4MGDdzPx4wZ48yTJ4/z8OHD7n3ffPONMygoyHn06FHzvFKlSs65c+d6XGf8+PHORo0amcexsbHmfX/66ad03xcAfI0xkACui6aKmvRpsqhdwn//+9/NrGKXOnXqeIx7/Pnnn03apqlcShcvXpR9+/aZbltNCRs2bOg+ljdvXrn11ltTdWO7aDqYJ08ead68eYbbrW24cOGCtGnTxmO/pqA333yzeaxJX8p2qEaNGoldH3/8sUlG9fMlJCSYSUbh4eEe55QtW1Zuuukmj/fR71NTU/2u9LW9e/eWvn37us/R6xQuXNh2ewDAVyggAVwXHRc4depUUyTqOEct9lIqWLCgx3MtoBo0aGC6ZK1Klix53d3mdmk71FdffeVRuCkdQ+kr69evl27duskLL7xguu614Js3b57pprfbVu36tha0WjgDgL9QQAK4Llog6oSVjLrllltMIleqVKlUKZxLZGSkbNy4UZo1a+ZO2rZs2WJemxZNOTWt07GLOonHypWA6uQcl5o1a5pC8dChQ+kmlzphxTUhyGXDhg1ix7p168wEo+eee8697+DBg6nO03YcOXLEFOGu9wkKCjITj0qXLm3279+/3xSjAJBdMIkGQJbQAqhEiRJm5rVOoomNjTXrND755JNy+PBhc86gQYPkn//8p1mMe/fu3WYyibc1HMuXLy89evSQXr16mde4rqmTUpQWcDr7Wrvbf//9d5Poabfw0KFDzcQZnYiiXcRbt26Vt956yz0x5fHHH5e9e/fKsGHDTFfy3LlzzWQYO6pUqWKKQ00d9T20KzutCUE6s1o/g3bx6/ei34fOxNYZ7koTTJ30o6//v//7P9m+fbtZPum1116z1R4A8CUKSABZQpeoWbNmjRnzpzOcNeXTsX06BtKVSD799NPyyCOPmIJKxwJqsde5c2ev19Vu9C5duphiU5e40bGCiYmJ5ph2UWsBpjOoNc0bMGCA2a8LketMZi3MtB06E1y7tHVZH6Vt1BncWpTqEj86W1tnP9txzz33mCJV31PvNqOJpL6nlaa4+n3cdddd0rZtW6lbt67HMj06A1yX8dGiURNXTU21mHW1FQD8waEzafzyzgAAAMiRSCABAABgCwUkAAAAbKGABAAAgC0UkAAAALCFAhIAAAC2UEACAADAFgpIAAAA2EIBCQAAAFsoIAEAAGALBSQAAABsoYAEAACA2PH/O/oD9IHkP3IAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = mf.plot_confusion_matrix(\n",
+    "    y_test, y_pred, labels=dataset.target_names, title=\"Confusion Matrix\"\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "df693453",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.214564Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.214481Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.337731Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.337462Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAJOCAYAAACqS2TfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAA1q5JREFUeJzs3QWY1FX///+zhHSIiEmIImIidmIrdnd3C6JiByZ2Y2Nhd3crditix60iNgoGwv6v5/n+z/w+O8zuzi477C48H9c1l+zuzGc+tfe9r/N+nzNl5eXl5UGSJEmSJNW5JnW/SUmSJEmSBEO3JEmSJEklYuiWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKGbkmSJEmSSsTQLUmSJElSiRi6JUmSJEkqEUO3JEmSJEklYuiWJElqgMrKyop6PPPMMyXfl+HDh4etttoqdOvWLb7nrrvuWvB51157baX7OXbs2Eq3X9Xrso8ePXqU8CglqTSalWi7kiRJmgY33HBDha+vv/768Pjjj0/1/T59+pR8X4YNGxb++OOPsOyyy4bvv/++2ucPHTo0zDfffBW+17Fjx0qfv+qqq051XHvuuWd8v7333jv3vbZt29Zq/yWpPhm6JUmSGqAdd9yxwtcvv/xyDN35358enn322VyVu5jgO2DAgLD00ksXvf2ePXvGR9a+++4bv1cfxytJdcn2ckmSpEZqwoQJYfDgwaFr166hRYsWoXfv3uHss88O5eXlFZ5HWD7wwAPDyJEj43NatmwZllpqqfDcc88V9T7du3eP26gJKuOTJ08OdeWXX34Jhx12WFhsscVi8G/fvn0M9++8806F5+2yyy7x+EaPHl3h++uuu26YddZZw3fffVej7UnStDJ0S5IkNUIE64033jicd955Yb311gvnnntuDNSHH354OPTQQwtWqwcOHBgrx7R///zzz/F177//fp3v2+qrrx5DbOvWreM+fvLJJ9O8zc8//zzcc889YcMNN4zHynG+9957oX///rkgjQsuuCDMPvvsMXyn0H/55ZeHxx57LFx00UVh7rnnrtH2JGlalZXnD4VKkiSpwaFSfckll+Sq2Pfee2/YdNNNwymnnBKOOeaY3PNY8OzOO++MQXf++eeP30tV6tdffz1WuPH111/HkE5196677ip6P6gKb7nllnHxs3y33XZbePjhh3Oh+4033oiBlvD95ptvxop8bd/nn3/+Cc2bNw9Nmvy/mtGXX34ZFlpooXj8xx13XO77BGwq25yb7bffPiy++OJhrbXWCnfffXfuOTXZniRNCyvdkiRJjdBDDz0UmjZtGg4++OAK36fdnGBO+M1aYYUVcoEbzNHeZJNNwqOPPlpnbeBbb711GDFiRNh5553jgMDJJ58ct09V/dRTT52mbdM+nwIy+8s2CeYMHBDos9ZZZ52wzz77xIr+5ptvHtvNqXbXdnuSNC0M3ZIkSY3QV199FVul27VrV3A1c36e1atXr6m2seCCC4aJEyeGH3/8sWT7ufLKK4flllsuPPHEE9O0nSlTpsRWeo6DwNy5c+fYRv7uu++G33//farnM7e9U6dO4e233w4XXnhh6NKlyzRtT5Jqy9AtSZKkkqKtnIXLpsVpp50W56rz8WI33nhjrKCzmvsiiywSA3S+t956K4wbNy7+m7na07o9SaotPzJMkiSpEWJFcarHrBKerXZ/9NFHuZ9nFVrM7OOPP47zranwlhKLlk3re9xxxx1xrvjVV19d4fu//fZbrFLnr+q+2267hYUXXjisuOKK4cwzzwybbbZZWGaZZWq1PUmaFla6JUmSGqH1118/zkW++OKLK3yflmkWTmOBtKxRo0ZVmKv8zTffxMXYmP/M3PC6UKhNnbnnLKjGSunTgn3MX//39ttvD99+++1Uzx0yZEhcKO66666LC7n16NEjrmbO4mm12Z4kTQsr3ZIkSY3QRhttFCu1rLTNqttLLLFEXLWbIM1Hg6WVy5NFF100rujNwmvMYb700kvj90866aRq3+v+++/PfX71pEmT4rxnVgYHHwnG6uCgqrzkkkuGpZdeOnTo0CGG/GuuuSa2lx999NHTdLx8tBcLo1HB5n1oGedzx3v27FnheU899VQ8thNOOCH069cvfo/F3VZbbbW4IjlV75psT5KmGR8ZJkmSpIbtgAMOoCxb4Xt//PFH+aBBg8rnnnvu8ubNm5f36tWr/KyzziqfMmVKhefxOl5/4403xue0aNGifMkllyx/+umni3rvXXbZJW6j0GPEiBG55x1zzDHlffv2Le/QoUPcn27dupXvt99+5WPHjq3x8bZp0ya+b/L333+XDx48uHyuueYqb9WqVflKK61UPmrUqPL+/fvHB8aPH1/evXv38n79+pVPmjSpwvY4T02aNImvKXZ7klQX/JxuSZKkGRzt5gcccMBUreiSpNJzTrckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYirl0uSJM3gXMJHkuqPlW5JkiRJkkrE0C1JkiRJUonYXi5J09mUKVPCd999F9q1axc/xkeSJEmNc+rOH3/8Eeaee+7QpEnl9WxDtyRNZwTurl271vduSJIkqQ588803Yd55563054ZuSZrOqHDjq6++Ch07dqzv3VEtOhV+/PHHMPvss1c5qq2Gx2vXeHntGjevX+Pltava+PHjYyEl/W1XGUO3JE1nqaW8ffv28aHG9wfI33//Ha+df4A0Ll67xstr17h5/Rovr11xqpsu6JmTJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKGbkmSJEmSSsTQLUmSJElSiRi6JUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKGbkmSJEmSSsTQLUmSJElSiRi6JUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCLNSrVhSVLVnvt62dD2t7L63g3VUHl5kzB5fO/Q9K8xoaxsSn3vjmrAa9d4ee0aN69f49WYrt0aPcaEhspKtyRJkiRJJWLoliRJkiSpRAzdkiRJkiSViKFbkiRJkqQSMXRLkiRJklQihm5JkiRJkkrE0C2ppHbdddew6aab1uq1zzzzTCgrK4uP2m6j1E488cTcPp5//vn1vTuSJElqYAzd9RBA0h/os8wyS1hggQXC0KFDw3///VenIaBv376hLl177bWhY8eOYXriHN1zzz3T9T0bkxRIf/vtt9AQfPnll3F/3n777Qrfv+CCC+L9My3GjBlTYRvPPfdc2GijjcLcc89d6X2S/V1Lj/XWW6/CczbeeOPQrVu30LJlyzDXXHOFnXbaKXz33XcVnvPuu++GVVZZJT6na9eu4cwzz6zw88MOOyx8//33Yd55552mY5QkSdKMydBdD/jDnz/SP/nkkzB48OAYks8666wwI/j333/rexfUwHTo0GGaB2y6dOlSYRsTJkwISyyxRLjkkkuK+l1Lj5tvvrnCz1dfffVw2223xVB/5513hs8++yxsueWWuZ+PHz8+rLPOOqF79+7hjTfeiL+n/L5eccUVuee0bds2zDnnnKFp06bTdIySJEmaMRm660GLFi3iH+n8Ib/ffvuFtdZaK9x3333xZ//880+snM0zzzyhTZs2YbnllosVzfyKM5W9Xr16xerbuuuuG7755pvcz0866aTwzjvv5Kp7qUL49ddfh0022SSGhPbt24ett946/PDDD7lt8xpCSLt27eLPl1pqqfD666/H999tt93C77//ntsmwQM9evQIJ598cth5553ja/bee+/4/RdeeCFWB1u1ahWrgwcffHAMSkl63XbbbRePk+PNBih+js022yy+X/oaw4cPD/PPP3/sFOjdu3e44YYbKpxfKr/77LNPmGOOOeL5WXTRRcMDDzyQ+znhapFFFonXge2ec845FV7PNRgyZEjcb55DN8LVV1+d+/kHH3wQNtxww3i8nCuOk7CG1VZbLQwcOLDC9miLpuqaXHrppblrxz5mQ16+r776KlZ0Z5111nie2O+HHnooVpW5VuBnnKP0Huw/55ugynusvPLK4bXXXpuqQv7oo4+GJZdcMl6jNdZYI4wbNy48/PDDoU+fPvHYtt9++zBx4sTc6x555JG4Le6/2WabLZ6DdNyYb7754n/ZJtvnXBRqL7/jjjvCYostFt+X7XD/Z++NYgwYMCCccsop8f4o5nctPThXWYMGDQrLL798/F1cccUVw5FHHhlefvnlMGnSpPjzkSNHxoGka665Jp77bbfdNp7bc889t0b7K0mSpJmXobsBIHykCvGBBx4YRo0aFW655ZbY1rrVVlvFah1V8YQgdOqpp4brr78+vPjiizFkEgawzTbbxOo5ASFV9/jelClTYuD+5ZdfwrPPPhsef/zx8Pnnn8efJTvssENskSWgUdUjgDRv3jyGEeaqEsTSNhkYSM4+++xYdXzrrbfCcccdF4MY+7zFFlvEY7j11ltjCOfYsqgaptfxXoccckjcL6SQOGLEiPh+6eu77747Po9jfP/992O4ZkDg6aefjj/nOAlknJcbb7wxfPjhh+GMM87IVSE5LgYbOF/vvfdeHDxgn7OtywwgUBG98MILw+jRo8Pll18eByrw7bffhlVXXTWGuaeeeipub/fddy96egCDGIQ2phRQXSXIsr3KHHDAATFE007N/g4bNizuCwMCDB6A7XCOaOPGEUccEX923XXXhTfffDMOGjAww7XP4tgvvvji8NJLL8VBG84L1/mmm24KDz74YHjsscfCRRddlHs+wfjQQw+Nx/Dkk0+GJk2axNDLOcerr74a//vEE0/E/bnrrrumOh6+z0AL54xzywDA5ptvHsrLy0MpsH0GHxicYYDr559/rvS5nB9CNvc79z34XeT6MMCTcC4557/++mtJ9lmSJEkzlmb1vQMzM4IG4YWK40EHHRQr0YRM/stcVRBuCWZ8/7TTTovfowpHWKIKDsIV1UlCz7LLLhtDWbNmzWJlLyHMEtq++OKLGNhAaCecE2iXWWaZ+L6HH354WGihheLPqcZmW4SpXma3mVAlJQQne+65ZwzwqeLLdgiw/fv3j1Vqqq9YaaWVYtjGggsuGIPyeeedF9Zee+0w++yzx+9TVc2+JwGfyun+++8fvyYEUpnk+1R+CXycBwId20TPnj1zr6dCueaaa8agnd6XYM4AANv9+OOPY7sx54sKbP7rqcZzLhgUScEsvU8xOMdUrKkSUyWnwkpluKrnM3hBZTh/Xzp16jRV6zXBmHPMIAKDD7jyyivj8VCt5/omVIq5Bthjjz3CUUcdFQdM0ntQgWcwg6o/2I8sqr9cJ84f3QTpmlG9LnSfpNDNAAVBm2NHOra6xsAP70MFnuM6+uij4zkhSGdbwTk+fp8YzKLqne2KGDt2bK6Cn9CdkH6WXzmvDAMnPLJt65IkSZo5WOmuB/xRTzAmfBICqDZTdSQUT548OYY4fp4eVKazbbwEakJyQkgmdBE0K8PPCNspcGPhhReu8DoCLIGZsEl1OPueVVl66aUrfE2bOqEvewxUB6mIEvqTFVZYocLr+LqqY0jHkYJiwtfpdSziRbW+siBc2evpJODc83oCGQMEhfBz2slT4K4pBhQImwRbFu2isppt4c5HVTyF4xNOOCF2DlSFa8agTPYY2VcGY/LP7eKLL14hSLZu3bpCqOd7tJwnnCOq1DyHrofU8s/AQLHobGDQg6BNFwcDAqWqGNPNwEJpvBft7fzeMcCUna4BBiLotqCyz7Wn06GuK++nn356HKxJj+zvoSRJkmZshu56QEWW8EaI+euvv2Klmurnn3/+Gf/op2WZn6cHYSm1DpcSwZ/5yhtssEFsnSaU085dHfY9i+Og7Tt7DARxjpe52KVu1S/l66v7OS3X+YEtzQ8G1W1avmlfZ7Xs448/PgbRylYgZxCEaQAEdAZlGODItnxPi+zAAV0M+QMJfC+1joO55bRgE5RfeeWV+Kjp4nnc31TdmTvO/cWx0PqdHYwpFQYLOnfuHD799NMK3+d7DNIwIEIHA3Pm6Z4AFfvsugdIX1dWzS+ELgLWREiPtAaDJEmSZnyG7npASGWeLR9VRNU6oc2YaivVRX6efWT/wKc9l3m1CfNLCW20mIP5p2wni5/xh372j33agnkd4SchfLC4FFU/WnNpa69sm5Xp169f3Hb+MfDIzo1NwSb7dToGEAILHQdt6Fl8nY6B6u3//ve/2CZeSGWv57gJhFRFCZp0FxTC9p9//vkKQTqLFmtaqBP2n7nnWVxzugn46Ckq1yyKxiBHZaiK7rvvvnGONG38hF6kc5k9R2mBuewxsq9UeLPXuaaYC819duyxx8ZKNecxv0JdaH8KIcxTiWfBPyrMvK6YwZ1pxX3BcTDYUZk0yJBawem+YD599nozaMBAQbGt5WANALoDsg9JkiTNHAzdDQjBj7nQtLcSsKj+MT+Z1lQWtsqGUeaAU2mkKs5cZOai0kIM2n55LRXmn376KQYIQh6Bku1TaWW7vA9t1FRPqbiz0Bmtt6yYTWgjqKUQzDapYDMHnW1W1RLNHFkW52J7qaJ/7733TrWQGu9B8CQgM1f69ttvj4ukJbwn78fc2RTwaAWmdZ15y2yXOdqcq7SwG8fDwlfMPyYccR6oqjIvHoRWtsnK6bwvXQbM502v5z132WWXuNAXK8Tzes4J87zBMTAfl9ZlBj7YB1ZPJ5Cm+e1cKx4fffRRXLwrW8WmxZn57ZwXzjPz6gl6hLhCmBfPnH/2g+vGHOt0TWhTJ8CyzR9//DFeHwZ0eE/OE8fM4Mdee+0VrxfztmuLgMlcbT4qi0oxgwRMR8hibjmdALwv1WAquvm4Z1mbgHNHWzrXjn3PDrYUg2NNXRRI93tqdefnnAMGchjU4JqzkGBaVC7tC9c+XQuOifZ5Bi7S1AdWcGdQgHNHFwiLAtJ1kn/skiRJUmUM3Q0MlWXCMOGQIMZcVMIvVfGEubcEWwIBFUPmTBMGEgIni0jRxk7llVZmwhnBl/BEKCWE026bXkeVlyog7034ZyVr5ptTjQQrOlNtZf452yQsV4ZqMJViQi3zn6ng00adFodLOEbCFz9n3jIBOgUi8FFeBGcqvWmxMc4HoYeF01gEjpXFOWfp46nAyt3MeSdAUd1lNe9UfaUKT4CmjZjFv9gvVhLPfqQXgZ5FxFisjfnyhNb0kVYET8IZoY6Az8eqUXlOrdmEdUJ7GtDgHKeP9gJz6AmahHOC5mWXXRavD8dSCPvNCuY8l2vKteEjx8DHrHF9WIyO+ddpUIP5+NwDtKRzvIRkgntNKrOF2uY5ZwzycN7ohsj/bHkq+AwocE241oTcfFR4qRyvv/768VionHOd06JvxUr3TbovCMHpPkv3M10EzOnmfQjNXCu6FKg6p98jrgWVe37XeE66d9NzmH9N1wehntdzz/Ie6aPxJEmSpOqUlZfqs3pUElR5qX5WNge4saCizHHkf6a1lEWXAYMWdDqkFdpnhHuabgkC/b3v9Apt25dNl/1T3SkvbxImj+8dmrYfE8rK/t+6B2r4vHaNl9eucfP6NV6N6dqt0eP/Ok+np/Q3HR2eVU0ftNItqcFjRXo6Fxoi2uXpNqnJKu6SJEmaefg53ZIaLD6LnnnzINg2REy7YDoG0meVS5IkSYmhu5Fh7nF2/nFjxeJWUnVYmI3FzxqyTp06xYckSZJUiO3lkiRJkiSViKFbkiRJkqQSMXRLkiRJklQizumWpHqyardXG/xHoWlqU6ZMCePGjQtdunSJn2GvxsNr13h57Ro3r1/j5bWrG545SZIkSZJKxNAtSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqURcvVyS6sktn68bWrVrWt+7oZoqLwvN/uwZ/hv/eQhl5fW9N6oJr12jskuvl+p7FySpTljpliRJkiSpRAzdkiRJkiSViKFbkiRJkqQSMXRLkiRJklQihm5JkiRJkkrE0C1JkiRJUokYumdyu+66a9h0002ny3v16NEjnH/++bmvx44dG9Zee+3Qpk2b0LFjx/i9srKycM899zSaY6qN1VZbLQwcODA0JvnXbnq59tpr4z3Bo6GesxNPPDG3j/VxjiRJktSwGbo13bz22mth7733zn193nnnhe+//z68/fbb4eOPP47f4+sBAwaUdD+eeeaZXEjKPo499tgwo6jrgYf8azc9tW/fPt4XJ598cu57d911V1hnnXXCbLPNFq8d91BlysvL4z1VaECH41pzzTXjoM+ss84a1l133fDOO+9UuFc22WSTMNdcc8XBob59+4aRI0dW2MZhhx0W92/eeeet0+OWJEnSjMHQrelm9tlnD61bt859/dlnn4Wllloq9OrVK3Tp0iV+b8455wwtWrSYLvszZsyYGJbS48gjj5wu79uY/PvvvwWv3fREWOa+aNeuXe57EyZMCCuvvHIYNmxYta+n+sw28v35559hvfXWC926dQuvvPJKeOGFF+J7ELwnTZoUn/PSSy+FxRdfPNx5553h3XffDbvttlvYeeedwwMPPJDbTtu2beP+NW3atM6OWZIkSTMOQ3cja+ml0kY7a0KYuOqqq8Jmm20WQxEB9r777qvwmg8++CBsuOGGsWJIqFhllVVi4C3kkUceiWGGyh9VRF6XfS4h7MADD4yVv5YtW4bu3buH008/PVdRZN8IMQTnueeeOxx88MEFj4d/E2Suv/76eAxUZtPxZKuR33zzTdh6663j/nTq1ClWHb/88svczydPnhwOPfTQ3P4eccQRcT+KQdAnLKUH4SlVwX/77bfc86ii8r30vl999VXYaKONYmWU6uciiywSHnroodzzn3322bDsssvGc8B5Isz/999/Fd6brzmPHTp0CJ07dw7HHXdchf2+4YYbwtJLLx2vF/u2/fbbh3HjxhV1XbkG1113Xbj33ntzVXyOq5jzmSrkp556arx+vXv3nura8fz86jLnK/s+6Tw++uijYckllwytWrUKa6yxRjyGhx9+OPTp0yfuN8c1ceLEUFM77bRTOP7448Naa61V5fPYx3POOSdcc801U/3so48+Cr/88ksYOnRoPE6u4wknnBB++OGHeI1x9NFHxwr7iiuuGOaff/5wyCGHxKBOpV2SJEkqhqF7BnDSSSfFIEUlbv311w877LBDDBP49ttvw6qrrhoD4FNPPRXeeOONsPvuu08VArMVRELs66+/Hp588snQpEmTGOinTJkSf37hhRfGUH/bbbfFSjGttgQyEKJpGb/88svDJ598EsPzYostVvB9aOslvLDfVJkvuOCCqZ5DtZGqI4Hy+eefDy+++GIMxrwuVWAJVMz7JVRRqeS477777lBKBxxwQPjnn3/Cc889F957771YbWW/0vnmGiyzzDKxTXn48OHh6quvDqecckqFbRCKmzVrFl599dV47Oeee24cPMkeO2GPbXAeCbppYKK660q7M+eV85Sq+ITGYs4nuO5c28cff7xCRbc2GAC4+OKLY8U4BX7C+0033RQefPDB8Nhjj4WLLroolAJhnlB/ySWXxIGLfARtBmq4Phz/X3/9Ff/NgEC6pwv5/fff44CFJEmSVIxmRT1LDRphbLvttov/Pu2002IwJswRpggcVFNvueWW0Lx58/icBRdcsNJtbbHFFhW+JszSWvzhhx+GRRddNHz99dexmk41nEomle6EnxFuqD7yXlS8qfgWwjYJjFRACwUi3HrrrTHsE0ZTe/CIESNilZZKKnN6CXBHHXVU2HzzzePPL7vsslhdLUb+HNxU3awOx8l5SgMKPXv2zP3s0ksvDV27do1Bk31eaKGFwnfffReGDBkSK7MMYoDnMEDBcwh/hHe+3muvveLPCdAJ2+eaEuRpiSYoV3ddOa8MDGTP7Y033ljt+QTVe54zyyyzhGnFYMNKK60U/73HHnvEa0U1Pp2zLbfcMjz99NPx/NS1QYMGxcEGqvmFMPjAcVPZT/PFube5fxgQKYTBJgaMGFiqCa4Fj2T8+PE1er0kSZIaLyvdMwDmnCYEJtp2Uysy7bW0HadgVh0q1AR4QhHbSRU/gmYK+GyToEjrOJXKZKuttorVQl5LeKTiXFlFvRhUeT/99NMYjgiaPKgw/v333zG4UXGkirvccsvlXkNYoi27GFR7OZb0oF28GBx3CpO0I9NhkIwePTqssMIKFeYQ8zzC8v/+97/c95ZffvkKz+E1nHva5UHlmhZ2Bi44/v79+1e4DjW9rsWcz4TBhLoI3Pn35hxzzBGnQGQHKfheftt8XaAbgw6AqlYT515lIIDr8/LLL8fKPwNLG2ywQfxZPgYHmNN95ZVXxlb0mmAKBoMk6cGgiyRJkmYOhu4GjKpo/vzktMBTVn7wIsyldnAqnjVB0KNFm2DB4lI8kNqP+/XrF7744otYGSSY0C5MtRIECdqSqfbyvvvvv39sgS60z8UgqLLQWjYYp5XOaRueVvPNN19YYIEFcg/Od6pEZ897/v7vueee4fPPP4/ziqlQE/LrskWaFn/awBn0oH2fympqmU/XoabXtSbnk4GbqhRzjgrdm9yXVd2rdYnAzUACVXwGYlLlmg4FPrINtLjTtk+1ny4CBkL4Hvc38+GzmKfP7wbdCCykVlNU+BkkSg9a7SVJkjRzMHQ3YLRgU8nNtqQSCGpaaaSiW0zw/fnnn2No5qOz+Bgl5rb++uuvUz2PMLjNNtvEYE4LOHO50xxywiDhhHZoWndHjRoVg2ltEPCp/rLgWTYc80gVQxYqSwMDoLJOlXhazjmy573Qx1ExwLDvvvvGBbUGDx4czwU4ZxxzNpBSQaW6nG1nz+4zqLTS2swK2CzwxbU444wzYjWbFvX8anB115VKdaqaF3s+6/oc1ScWr6MDITu4AEIzITvN+WYAIdtxkL7ODgRwH1P9Zu5+bT82jakU/N5kH5IkSZo5GLobMFZ7ZhVrwhXBdZdddqnxxxKxQjZhfdttt42LoxG62CbhOh/t1SwsdcUVV8Q2ZKqFLKqWxYJfN998cwyGVEhvv/32OG+YiiILmrEQ1fvvvx8rwcwhJoRn533XBAvCsbI3c3I5Bww4EIBo706t2qwmTThlsTH2iep6duXxmiKAEqhZAIxzxWJfLNaWNXDgwDjvl/158803Y9sxYRu8P1XMgw46KO4PFVNa0DmPqUKc2sT5HteB80mlnGMBLeWEZr7HeaRVOvsZ1cVcV6YFEDr5+qefforhvJjzWQyuKVVhzjvt9FSBp/dnnDPIQ5BmrQFwnHw9duzY+DX3JK3i2Uc6t3Q4YO21146DSiyMx3GwGjzt41TFV1999fgcri2Bm3NElZzt80iDTJIkSVJ1DN0NGC2pzOXlY6H4w58Fn/jYopogRBOeaS1mW7QXU5UtNBeYUMjCXFSKCSksRHXWWWdVeA4V2zPPPDO2VNOSS3suH5fFawnebJs5slRin3jiiXD//ffHfagN5v+yQjhBiYXSCLbMwWUOcqoUUmWmzZsBCeZFs3+stl5bnJc0qMAxUN3MX3mcCjJBjf1hsToWMKOlHvPMM088Hyxkt8QSS8RqOPucH0ppUaY9n4Xm2BaBO1VRqSQzgMGAxsILLxzD7dlnn12j68qceubdc53YHtX2Ys5nsVhgj64C3pdBiPxzVGoMRPBRZPxegMEHvmYhvWLRQcD9yeAE9w5dBSx6x8fm0UGRVpmnIs6cbL6XHmnhPkmSJKk6ZeXFfqixJE1nDD4Q6qele2F6obuAfeVRHboUaOkf/sayoVW7mnWvqAEoLwvN/uwZ/mv7Of8vWt97o5rw2jUqu/R6Kfdvpv0w1YopUtnOMTUOXr/Gy2tX3N90rNlTVRHLMyepQeN/xFhpvRQfK1YX+Jg+9i+tLC9JkiRl+Tndkhos5lHzmfBg+kJDxBQCVvHPLjInSZIkJYZuSQ0Wc/R5NGR81jkPSZIkqRDbyyVJkiRJKhFDtyRJkiRJJWLoliRJkiSpRJzTLUn1ZNuejzbYBeJUOT8+pfHy2kmS6oP/jyNJkiRJUokYuiVJkiRJKhFDtyRJkiRJJWLoliRJkiSpRAzdkiRJkiSViKuXS1I9OeejbUPLdv7PcKNTXhbaTewa/vjpmxDKyut7b1QTXrtG4ZhFHqjvXZCkOmWlW5IkSZKkEjF0S5IkSZJUIoZuSZIkSZJKxNAtSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6NZM4cQTTwx9+/bNfb3rrruGTTfdNDQmZWVl4Z577qn0519++WV8zttvvx2/fuaZZ+LXv/32W/z62muvDR07dgyNCdeJY6ju2OtTjx49cvuYzrUkSZKUGLpVJ8aOHRsOOeSQsMACC4SWLVuGOeaYI6y00kph+PDhYeLEifW9ezOFrl27hu+//z4suuiiYUay3nrrxeMaMGBA7nunnnpqWHHFFUPr1q0LDiT8/PPP8XVzzz13aNGiRTw3Bx54YBg/fnyF5zEw0a9fv/gc7l0GJrJOP/30sMwyy4R27dqFLl26xIGaMWPGVHjOa6+9Fu688846P25JkiTNGAzdmmaff/55WHLJJcNjjz0WTjvttPDWW2+FUaNGhSOOOCI88MAD4YknnqjvXWzU/v3336Ke17Rp0zDnnHOGZs2alWxfJk2aFKY3AjHHxX+z52SrrbYK++23X8HXNGnSJGyyySbhvvvuCx9//HEM09yH++67b+45X3zxRdhggw3C6quvHrsDBg4cGPbcc8/w6KOP5p7z7LPPhgMOOCC8/PLL4fHHH4/Hv84664QJEybknjP77LOHTp06lez4JUmS1LgZujXN9t9//xj0Xn/99bD11luHPn36hJ49e8bQ8+CDD4aNNtoo91zabwk2BJX27duHNdZYI7zzzjtTtYFfc801oVu3bqFt27Zx+5MnTw5nnnlmDF9UHKl0ZlW33eo88sgjYeWVV45V09lmmy1suOGG4bPPPqvyNauttlo46KCDYlibddZZY3X/yiuvjIFst912i9VRqqcPP/xwhdcR5JZddtkYIueaa65w5JFHhv/++6/CdqnKst3OnTuHddddN/ezVPFt1apVPMd33HFHpe3lxaATYf755w+zzDJL6N27d7jhhhsq/Jzt8ZyNN944tGnTJp73Qm3qtH7z3Gm9jsU66aSTwqBBg8Jiiy1W8OdcDwL50ksvHbp37x7WXHPN+P7PP/987jmXXXZZmG+++cI555wT71nO+ZZbbhnOO++8CvcFLe6LLLJIWGKJJeKxf/311+GNN96o1X5LkiRp5mPo1jShjZcKN9VAQlkh2TBGdXLcuHExiBJcaO0lEP3yyy+55xB2+TmB5+abbw5XX311rEj+73//i4F12LBh4dhjjw2vvPJKjbZbFYLyoYceGgcOnnzyyVgp3WyzzcKUKVOqfN11110Xg/Grr74aAzhBj32h9fnNN9+MVdGddtop12L/7bffhvXXXz+2LDMoQKDl+E455ZSptksQfvHFF2M4TI477riwxRZbxNfusMMOYdtttw2jR48OtXH33XfHKQGDBw8O77//fthnn33iYMHTTz9d4XkEaM7Fe++9F3bfffeit1+b61gq3333XbjrrrtC//79c9+jG2Ottdaq8DwGOPh+ZX7//ff4XyvbkiRJKpahW9Pk008/DeXl5bFKmkUQpbrJY8iQIfF7L7zwQgynt99+e6xA9urVK5x99tmxapqt2BJ0qZAuvPDCsUpO+y/zaM8///z4PgRD/pvCYbHbrQpBdvPNN4+V6VShJWR++OGHVb6O6ifBkfc86qij4nx2jn2vvfaK3zv++OPjwMS7774bn3/ppZfG+cUXX3xxWGihheIcYaq2VFuzAZ/XUhHmOLPnlkBPRX/BBRcMJ598cjzeiy66KNQG54gqLhVgtsegA+eA72dtv/328ZxTWadqXayaXsdS2G677eK873nmmSd2QFx11VUV1iGgOyGLr5n3/ddffxU8HroPWKugpvPm//nnn7jd7EOSJEkzB0O3SoIQTJszbbkEDlCd/fPPP2P7dgrkPJhbm23lZjVoWrOzQYjgRvU5+z0q2zXZblU++eSTGNAIloQz9gG0Eldl8cUXrzCnmn3ItjynUJf2lar0CiusUKH6T4hj/6kAJ0sttVTB9+O1+V/XttLN63jvLL7O3x7BvjZqeh1LgVZxOg7uvffeeC8wsFBbdHPQEXDLLbfU+LUsyNahQ4fcg4EXSZIkzRxKt+KSZgpUhgmQ+Ss6E17B3OOEYMkcZlaMzpedI9y8efMKP2P7hb6XKsPFbrcqVGKZ+8ucbFa8ZttUM6tbxKy6fU3huro29XyVterXh/x9ITTT3VDdAms1vY6lwNxxHnQV0BK+yiqrxBZ97he+/8MPP1R4Pl8z6JK9b8F8bxYFfO6558K8885b4/2gCyIb+Kl0G7wlSZJmDla6NU2o7K699tqxXTq7onMhzLOmpZdF1wjr2Qct2bU1rdul/ZtBA9rEmQfOolq//vprKAW2zZzhbGhl3jYV4WLCHKto53/NNmu7L7x3Fl9Tja4Ki9X98ccfFa53TRZvqy8p3KfOC7oEmL+fxQrl2W4CrhOBm/nvTz31VFx4rTZYNI8wn31IkiRp5mClW9OMecq0JdOGzKJbtFxTDeXziz/66KNcqzSLVhFomMfMfGXmEbPAFSucs1BXbduYp3W7rHTN4MEVV1wRK6C0lLOieCkwf5o5zSy6Rpgj7J9wwgmxCpptu65MmrfOSusjR46MbfwsUFYbhx9+eFxtno974xzef//9cbGx6j7ibbnllovzpI8++uhw8MEHx4XQ8j/futS4RiySx39ZET2FfgZamFrw0EMPxao1C9bx9QcffBCPl/s0TR3g48MYLOKj7VggjlB92223xfsm21J+0003xfZ0BkYY3AEt4vnVcEmSJKkQK92aZnzkFJ/NTXCjjZbFxdICX4cddlhc8Cu1EhOGVl111biIFuGY1be/+uqrqRa0qolp3S5hl3m6rHpOSzkfRXXWWWeFUmBBL/aVsMx5IvjtsccescpeDBZdY18Z2Lj++uvjquDVVaYrwyDFBRdcEBdOY+795ZdfHkaMGBE/sqwqtGnfeOON8TiYv84+MNgyPbFAHYMFDFgwvYB/82D1eRCImSrA4AQVfa4pH3tGi3hC1ZqATXWba8Fidiy0lv2INlaXZ8VyzgkDMulx6623TtfjlSRJUuNVVp4/OVOSGghWV+cz2Pkc8IaM9QRYnZ1pCcWsI8Ccbqrlx45aN7RsZ8NRo1NeFtpN7Br+aP0N/y9a33ujmvDaNQrHLPL/BkizU4RYeLNLly5FdYapYfH6NV5eu+L+pqNIU9X0Qc+cpAaN6jQt4tkqdUNCl8CAAQPqezckSZLUQFlikdRgMUc/td7T1t0Q0WafVm93gTRJkiTlM3RLarBoZeLRkPFRc5IkSVJlbC+XJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBJxTrck1ZPBC91S1EeMqWHx41MaL6+dJKk++P84kiRJkiSViKFbkiRJkqQSMXRLkiRJklQihm5JkiRJkkrE0C1JkiRJUom4erkk1ZPD39knNG/XvL53QzVUVl4WOv89Z/jp27GhvKy8vndHNTAzXbtL+91Y37sgSfr/WemWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKGbkmSJEmSSsTQLUmSJElSiRi6VStffvllKCsrC2+//XZoLJ555pm4z7/99luYEe26665h0003DTOSE088MV4zHueff35oqOc97eM999xT37sjSZKkBsbQ3Yhl/9jPPj799NMwo6jLILPiiiuG77//PnTo0KFOtjczaAhBfpFFFonXbe+9985974orrgirrbZaaN++fbUDKf/880/o27fvVINE2UCffbRp0yb3nEmTJoWhQ4eG+eefP7Rs2TIsscQS4ZFHHqmw/QsuuCDunyRJklSIobuRW2+99eIf/NnHfPPNV9+71eAQnmaZZZYw55xzxmClxqNZs2bxurVu3Tr3vYkTJ8Z7/+ijj6729UcccUSYe+65p/r+YYcdNtXvzsILLxy22mqr3HOOPfbYcPnll4eLLroofPjhh2HfffcNm222WXjrrbdyz2EQh/2TJEmSCjF0N3ItWrSIf/BnH02bNi1YoRw4cGCsDiZ33HFHWGyxxUKrVq3CbLPNFtZaa60wYcKE+LMpU6bECt+8884b34NKYX6FDx999FGsIFMFXHTRRcOzzz6b+9nkyZPDHnvsEQcBeI/evXvHqmC+a665JlYzeZ+55porHHjggfH7PXr0iP8l5BCU09e49957Q79+/eL79uzZM5x00knhv//+y/2c5w8fPjxsvPHGsXJ56qmnTtVeTqWT48qihTn7Puk8nnbaaWGOOeYIHTt2jOeF9zr88MNDp06d4jkaMWJEldeJ837wwQfHAMhruE68f1Xt+uwn32O/kw8++CBsuOGGscLbrl27sMoqq4TPPvus4HtyDU8//fTc+adKyzUv9vqwf9ddd10816kKzL4UatNnv/kex4Frr702nqsHHnggbpfAvOWWW8awzDY5x7POOms8J+xHTXEvH3nkkWH55Zev8nkPP/xweOyxx8LZZ5891c/atm1b4ffmhx9+iMGac5LccMMNMdivv/768T7bb7/94r/POeecGu+zJEmSZk7N6nsHVD+o6m233XbhzDPPjKH2jz/+CM8//3woLy+PPyd8ESyo8i255JIxGBNgCX29evXKbYfgSVClQnjuueeGjTbaKHzxxRcxxBP6CKS33357/Pqll16KLcIE66233jq+nmB86KGHhjPOOCMMGDAg/P777+HFF1+MP3vttddCly5dYqClqslgAtjPnXfeOVx44YW50Jlaj0844YQKoZHtsn9USz///PNanaunnnoqHsdzzz0X941QxrGsuuqq4ZVXXgm33npr2GeffcLaa68dn1cZwibHymtGjRoVA/1KK60UX1eMb7/9Nr4nAZ59InizP9nBhiwC94033hguu+yyeM3Y/x133DHMPvvsoX///tVeHyrBo0ePDuPHj88NKjBgwPOKQcDmGt1yyy3x/tp8883jvUYYf+ihh+L12GKLLeI52GabbUJdI0TvtddecXpCtkpemauuuiosuOCC8Z7KtqYzsJPFAMULL7xQ5/srSZKkGZOhu5GjkkjFLiG4EqKKCd2ENYJQ9+7d4/eoeidUBocMGRK23Xbb+PWwYcPC008/HQPsJZdcknseVWmCUwrQVMOvvvrqWNFt3rx5rEAnVFQJm7fddlsudJ9yyilh8ODB4ZBDDsk9b5lllon/JRyCkJZt32WbVDl32WWX+DUVyJNPPjm+ZzZ0b7/99mG33XbLfV3b0E3QJDw2adIkVm0ZqCBQptbmo446KoZ7glg6X4Usvvjiuf0jBF988cXhySefLDp0c95pZSbEcm5BSCyEsEh1/oknnggrrLBC7jyxjwykELqruz7cVwRMtlWb9mla+rknmA8NKt1UjgnDbJuBmtVXXz3eV3Uduhk8YlCDdvCll146V4GvzN9//x1GjhwZ76usddddNw4mMdjBcXC97rrrrhpX5zmHPBIGMiRJkjRzMHQ3coQWgk2SXQSqKrQar7nmmjFoEyzWWWedGIpo+SUQfPfdd7ECmcXX77zzToXvpUAHqskEHKqj2aBIlfzrr78Of/31V/j3339zLd3jxo2L78N+1AT7QIWXlvGEEERwIgynqib7UhdofSdwJ7SZ00qfUIGnUszxVIXQnUVFubrXZNHCTRU2Be6qsJge5yI/0HP+6Vwo5vpMK65DCtzpvNFWnh0k4ns1OQfFYg421XUGRIpx9913x+engZyEjg+q5QsttFBsn+d4GMjhnNUEXQfZAQ5JkiTNPAzdjRwhe4EFFpjq+4TE1CqerTxmg+Ljjz8eW4WZ80pIOeaYY2LrMwGyLlCRpUWZNnXCOXOQzzrrrPgeoIpaG3/++WcMMFTp82VbgasbgKjuHCX5IZfwVeh7tGtXparXpFCf3Z/8fanJ+eIc4cEHHwzzzDNPhZ8xd76Y61OZYva1Ls9bbdB+T9U+HWvCQMwOO+wQW/3zW8uZK88gQBbdFrSnM6Dz888/xwXZqIbTNVAThH+mFiQMbHXt2rVWxyZJkqTGxdA9gyIsvP/++1NVSrOhh8BD9ZrH8ccfH9vMqfgRDggXVJNpQ074etlll62wzZdffjm23oJ29TfeeCO3EBrPZ5G1/fffP/f87KJfhDwqn7TsUrEvhP3Nb+VlAbUxY8YUHGyo6TkaO3ZsDI9pRfP6+tzx1EpP23+qROfvC5VywiIBt7pqN63bBE4q2NlrmFXd9QErvuef/+y+0hlRaF/rG9MBmLqQ0FFBRwfz75dbbrkKz2UNAlrc77vvvkq3x2AOgxec+zvvvDM3PaJYXIv8AQBJkiTNHAzdM6g11lgjVi2vv/76WMVkQS1CeAp0VDMJu7SVs1gZX//444+hT58+uQXSmH9MOy3txiykRbBi3msW7cnMT+Z15513Xvj111/D7rvvHn/G93n/Rx99NM4XZj4vi6NlP9KMxc6Yd8s+MB+dFl/C4EEHHRR/nkI5AwOEFkIeAwRUJbt16xZb4qm80nLO8WWDVnVYkIxjZo4222E+Oqtds0DZ9EYVm5W4mRvO+aHlmo+rymIwg44E5o1TOWV+N4MeDIQw1zyLAQ2q2IMGDYqV5JVXXjm3SB3HRxt1MdeH88/PGeSgA4L3ZLCDKi3Xjhb/jz/+eLqv5s1gCY/0mfTvvfdePGbuCebg89+s1NLO/Zy/2B2t4rT6c//l4/eCBez4HeC/HDPnk/UDJEmSpGL4kWEzKKp6xx13XAwHLExGmGXF74TgxWrWfPwRi3ER8AhOKXjwUU5UvFnkjHnfBFIqgdmVy0FI5MEccRbp4jmdO3eOP2NFb1rAWSSL6iLtudmqKgh/LM526aWXxrnThOlPPvkk93P2iTZ4Ql4aMODYWECOtniOjbBK4E8LwhWLgQLel4ED9v/VV1+NQbW+EP7oFlhqqaXiR2LlDyAQemmbpnWc6jXPu/LKKyuterO4HPcA84k5VlaAp908hepirg/zmQn0tGVT4Sa0834333xz/Lg4qu8ssleTwY66wIrs3A/sH+i24OuqqtWFEKD5eDMWXUur42fRVs7vBp0DrLxOtZv7nMX9JEmSpGKUledPapWkBoLKMnOqG1r7eiFMUWB6Bp/rXh3mdNM1sOczW4fm7apfGE8NS1l5Wej895zhp5ZjQ3mZ/xfamMxM1+7SfjeGGQmDpHSB0RmXXdxUjYPXr/Hy2hX3Nx0dpVV1y3rmJDVotI7THk5XQkPE9IjsiuySJElSlnO6JTVYTHPYcccdKyzg1tAMHTo0Ny2BueGSJElSlqFbUoPFomg8GjLarXhIkiRJhdheLkmSJElSiRi6JUmSJEkqEUO3JEmSJEkl4pxuSaonZy1xuZ/53Qj58SmNl9dOklQf/H8cSZIkSZJKxNAtSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqURcvVyS6skurx4emrVtXt+7oRoqKy8L8/zbOXz72U+hvKy8vndHM+i1u3PFS+t7FyRJdcRKtyRJkiRJJWLoliRJkiSpRAzdkiRJkiSViKFbkiRJkqQSMXRLkiRJklQihm5JkiRJkkrE0D2T23XXXcOmm246Xd6rR48e4fzzz899PXbs2LD22muHNm3ahI4dO8bvlZWVhXvuuafRHFNtrLbaamHgwIGhMcm/dtPLtddeG+8JHg31nDWGfZQkSVL9MXRrunnttdfC3nvvnfv6vPPOC99//314++23w8cffxy/x9cDBgwo6X4888wzuZCUfRx77LFhRlHXAw/51256at++fbwvTj755Nz37rrrrrDOOuuE2WabLV477qHKlJeXx3uq0IAOx7XmmmvGQZ9ZZ501rLvuuuGdd97J/fzvv/+O53KxxRYLzZo1K3hOt9lmm7h/K6ywQp0dsyRJkmYchm5NN7PPPnto3bp17uvPPvssLLXUUqFXr16hS5cu8XtzzjlnaNGixXTZnzFjxsSwlB5HHnnkdHnfxuTff/8teO2mJ8Iy90W7du1y35swYUJYeeWVw7Bhw6p9PRV6tpHvzz//DOutt17o1q1beOWVV8ILL7wQ34PgPWnSpPicyZMnh1atWoWDDz44rLXWWgW3z8/Zv1lmmWWajlOSJEkzJkN3I2vp7du3bzjxxBNzXxMmrrrqqrDZZpvFUESAve+++yq85oMPPggbbrhhrBgSKlZZZZUYeAt55JFHYpih8kcVkddln0sIO/DAA8Ncc80VWrZsGbp37x5OP/30XEWRfSPEEJznnnvuGFYKHQ//vvPOO8P1118fj4FqYjqebDXym2++CVtvvXXcn06dOoVNNtkkfPnll7mfE4oOPfTQ3P4eccQRcT+KQdAnLKVH27Ztc1Xw3377Lfc8qqh8L73vV199FTbaaKNYGaU1fpFFFgkPPfRQ7vnPPvtsWHbZZeM54DwR5v/7778K783XnMcOHTqEzp07h+OOO67Cft9www1h6aWXjteLfdt+++3DuHHjirquXIPrrrsu3HvvvbkqPsdVzPlMFfJTTz01Xr/evXtPde14fn51mfOVfZ90Hh999NGw5JJLxmC6xhprxGN4+OGHQ58+feJ+c1wTJ04MNbXTTjuF448/vtIgnL1255xzTrjmmmum+tlHH30UfvnllzB06NB4nFzHE044Ifzwww/xGoPrO3z48LDXXnvF6yBJkiTVlKF7BnDSSSfFIPXuu++G9ddfP+ywww4xTODbb78Nq666agyATz31VHjjjTfC7rvvPlUIzFYQCbGvv/56ePLJJ0OTJk1ioJ8yZUr8+YUXXhhD/W233RYrxSNHjoyBDIRoWsYvv/zy8Mknn8TwTFtuIbT1UmVkv6kyX3DBBVM9h2ojVUcC5fPPPx9efPHFGIx5XarAEqiYU0uoolLJcd99992hlA444IDwzz//hOeeey689957sdrKfqXzzTVYZpllYpsyge3qq68Op5xySoVtEIppV3711VfjsZ977rlx8CR77LRTsw3OI0E3DUxUd10PO+yweF45T6mKv+KKKxZ1PsF159o+/vjj4YEHHpimc8UAwMUXXxxeeumlXOAnvN90003hwQcfDI899li46KKLQikQ5gn1l1xyScHATNBmoIbrw/H/9ddf8d8MCKR7WpIkSZpWzaZ5C6p3hLHtttsu/vu0006LwZgwR5gicFBNveWWW0Lz5s3jcxZccMFKt7XFFltU+JowS2vxhx9+GBZddNHw9ddfx2o61XAqmVS6E35GuKH6yHtR8abiWwjbJDCm1txCbr311hj2CaOpPXjEiBGxSksllTm9BLijjjoqbL755vHnl112WayuFmPeeeet8HWqblaH4+Q8pQGFnj175n526aWXhq5du8agyT4vtNBC4bvvvgtDhgyJlVkGMcBzGKDgOYQ/wjtfU1EFATph+1xTgjwt0QTl6q4r55WBgey5vfHGG6s9n6m6y3Pqol2awYaVVlop/nuPPfaI14pqfDpnW265ZXj66afj+alrgwYNioMNVPMLYfCB46ayn+aLc29z/zAgUpe4FjyS8ePH1+n2JUmS1HBZ6Z4BLL744rl/E5ho202tyLTX0nacgll1qFAT4AlFbCdV/AiaKeCzTYIireNUKpOtttoqVgt5LeGRinNlFfViUOX99NNPYzgiaPKgJZrFrQhuv//+e6ziLrfccrnXEJZoyy4G1V6OJT1oFy8Gx53CJO3IdBgko0ePjgtqZecQ8zzC8v/+97/c95ZffvkKz+E1nHva5UHlmhZ2Bi44/v79+1e4DjW9rsWcz4TBhLqan5y9N+eYY444BSI7SMH38tvm6wLdGHQAVLXiOvcqAwFcn5dffjlW/hlY2mCDDeLP6hJTMBgkSQ8GXSRJkjRzMHQ3YFRF8+cnpwWesvKDF2EutYNT8awJgh4t2ldeeWVcXIoHUvtxv379whdffBErgwQT2oWpVoIgQVsy1V7ed//9948t0IX2uRgEVRZaywbjtNI5bcPTar755gsLLLBA7sH5TpXo7HnP3/8999wzfP7553FeMRVqQn5dtkjT4k8bOIMetO/Tip9a5tN1qOl1rcn5ZOCmKsWco0L3JvdlVfdqXSJwM5BAFZ+BmFS5pkOBj2wDLe607VPtp4uAgRC+x/3NfPi6RIWfQaL0oNVekiRJMwdDdwNGCzaV3GxLKoGgppVGKrrFBN+ff/45hmY+OouPUWJu66+//jrV8wiDfEwSwZwWcOZypznkhEGCO+3QtO6OGjUqBtPaIOBT/WXBs2w45pEqhixUlgYGQGWdKvG0nHNkz3uhj6NigGHfffeNH101ePDgeC7AOeOYs4GUCirV5Ww7e3afQaWV1uamTZvGBb64FmeccUasZtOinl8Nru66UqlOVfNiz2ddn6P6xOJ1dCBkBxdACz8hO835ZgAh23GQvq7rgQCmUvB7k31IkiRp5mDobsBY7ZlVrAlXBNdddtklhrKaYIVswvq2224bF0cjdLFNwnU+2qtZWOqKK66IbchUC1lULYsFv26++eYYDKmQ3n777XHeMBVFFjRjIar3338/VoKZQ0wIz877rgkWhGNlb+bkcg4YcCDI096dWrUPOeSQGE5ZbIx9orqeXXm8pgigBGoWAONcsdgXi7VlDRw4MM77ZX/efPPNOCeZsA3enyrmQQcdFPeHiikt6JzHVCFObeJ8j+vA+aRSzrGAlnJCM9/jPNIqnf2M6mKuK9MCCJ18/dNPP8VwXsz5LAbXlKow5512elZrn96fcc4gD0GatQbAcfL12LFj49fck7SKZx/p3NLhgLXXXjsOKrEwHsfBavC77bZbrIqvvvrquffiPdg270mVOhviJUmSpOoYuhswWlKZy8vHQjHPlAWf5p9//hptgxBNeKa1mG3RXkxVttBcYEIhC3NRKSaksBDVWWedVeE5VGzPPPPM2FJNSy7tuXxcFq8leLNt5shSiX3iiSfC/fffH/ehNpj/ywrhBCUWSiPYMgeXOcipUkiVmTZvBiSYF83+sdp6bXFe0qACx8DK5Pkrj1NBJqixPyxWxwJmtNRjnnnmieeDheyWWGKJWA1nn/ND6c477xzb81lojm0RuPfee+9cJZkBDAY0Fl544Rhuzz777BpdV+bUM++e68T2qLYXcz6LxQJ7dBXwvgxC5J+jUmMggo8i4/cCDD7wNQvpFYsOAu5PBie4d+gqYNE7PjaPDoqE1ejZNs9lkIJ/85AkSZKKUVZe7IcaS9J0xuADoX5auhemF+aK9+3bt8rF2xK6FGjp3/jRPUOztsUvhqeGoay8LMzzb+fw7Sw/hfIy/y+0MWlM1+7OFf9vMFf/h2k/TLViilS2c0yNg9ev8fLaFfc3Hd2QVRWxPHOSGjT+R4yV1kvxsWJ1gcXu2D9a9iVJkqR8fk63pAaL1cb5THgwfaEh2njjjXMfW9dQ91GSJEn1x9AtqcFijj6Phqwx7KMkSZLqj+3lkiRJkiSViKFbkiRJkqQSMXRLkiRJklQizumWpHpy3bJnufhaI+THpzReXjtJUn3w/3EkSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYihW5IkSZKkEnH1ckmqJxs8e3xo2rZFfe+GaqisPIT5JncKXzT9JZSX1ffeqCaeWX1Yfe+CJGkmZKVbkiRJkqQSMXRLkiRJklQihm5JkiRJkkrE0C1JkiRJUokYuiVJkiRJKhFDtyRJkiRJJWLoVq18+eWXoaysLLz99tuhsXjmmWfiPv/2229hRrTrrruGTTfdNMxITjzxxHjNeJx//vmhoZ73tI/33HNPfe+OJEmSGhhDdyOW/WM/+/j000/DjKIug8yKK64Yvv/++9ChQ4c62d7MoCEE+UUWWSRet7333jv3vSuuuCKsttpqoX379tUOpPzzzz+hb9++BQeJHn300bD88suHdu3ahdlnnz1sscUWcUApf7CmX79+oUWLFmGBBRYI1157bYWfX3DBBXH/JEmSpEIM3Y3ceuutF//gzz7mm2+++t6tBmfSpElhlllmCXPOOWcMX2o8mjVrFq9b69atc9+bOHFivPePPvroal9/xBFHhLnnnnuq73/xxRdhk002CWussUYM4wTwn376KWy++eYVnrPBBhuE1VdfPT5n4MCBYc8994zPTRjEYf8kSZKkQgzdjRzVN/7gzz6aNm1asEJJYKA6mNxxxx1hscUWC61atQqzzTZbWGuttcKECRPiz6ZMmRKGDh0a5p133vgeVAofeeSRqd7/o48+ihXkli1bhkUXXTQ8++yzuZ9Nnjw57LHHHnEQgPfo3bt3rArmu+aaa2I1k/eZa665woEHHhi/36NHj/jfzTbbLAbl9DXuvffeWH3kfXv27BlOOumk8N9//+V+zvOHDx8eNt5449CmTZtw6qmnTtVeTusyx5VFC3P2fdJ5PO2008Icc8wROnbsGM8L73X44YeHTp06xXM0YsSIKq8T5/3ggw+OAZDXcJ14/6ra9dlPvsd+Jx988EHYcMMNY4WX6uwqq6wSPvvss4LvyTU8/fTTc+d/iSWWiNe82OvD/l133XXxXKcuCvalUJs++833UpWYajDn6oEHHojbJTBvueWWMSyzTc7xrLPOGs8J+1FT3MtHHnlkrFJX5eGHHw6PPfZYOPvss6f62RtvvBHf+5RTTgnzzz9/vJ8OO+yweCwM0uCyyy6L5+ecc84Jffr0ifcmx3HeeefVeJ8lSZI0c2pW3zug+kFFfLvttgtnnnlmDLV//PFHeP7550N5eXn8OeGLoHH55ZeHJZdcMgZjAiyhr1evXrntEDwJqgsvvHA499xzw0YbbRSrg4R4Qh+B9Pbbb49fv/TSS7FFmGC99dZbx9cTjA899NBwxhlnhAEDBoTff/89vPjii/Fnr732WujSpUsMtFQ1GUwA+7nzzjuHCy+8MBc6U+vxCSecUCE0sl32j2rp559/Xqtz9dRTT8XjeO655+K+EVQ5llVXXTW88sor4dZbbw377LNPWHvttePzKkPY5Fh5zahRo2KgX2mlleLrivHtt9/G9yTAs08Eb/YnO9iQReC+8cYbY3DkmrH/O+64Y2yj7t+/f7XXhwA6evToMH78+NygAgMGPK8YBGyu0S233BLvLyrI3GuE8YceeiheD9q5OQfbbLNNqGs//PBD2GuvveL0hGyVPFlqqaVCkyZN4rFxLf78889www03xMGn5s2bx+dwnfg6a911142hX5IkSSqGobuRo5LYtm3b3NcEV0JUMaGbsEYQ6t69e/weVe+EyuCQIUPCtttuG78eNmxYePrpp2OAveSSS3LPo/JHcEoBmmr41VdfHSu6BBcq0AkVQ0LMbbfdlgvdVBkHDx4cDjnkkNzzlllmmfhfwiEIadn2XbZJlXOXXXaJX1PpPvnkk+N7ZkP39ttvH3bbbbfc17UN3QRNwiMBjaotAxUEytTafNRRR8Vw/8ILL+TOVyGLL754bv8IwRdffHF48skniw7dnHdamQmxKRQuuOCClc5jpjr/xBNPhBVWWCF3nthHBlII3dVdH+4rKuBsqzbt01SLuSeoIoMKMaGWMMy2GaihbZv7qq5DN4NHBOl99903LL300lPN007HSxWcY2XQhKo354oBgWTs2LGxwyGLrxmI+Ouvv+L5KQbnkEfC6yVJkjRzMHQ3coQWgk1CK3UxaDVec801Y9CmcrfOOuvEUETLL4Hgu+++ixXILL5+5513KnwvBTpQTSbgUB3NBkWq5F9//XUMKf/++2+upXvcuHHxfdiPmmAfqPDSMp4QmP7+++8YhlNVk32pC7S+E7izoYtW+oQKPJVijqcqhO4sKsrVvSaLtmcq+ylwV4XF9DgX+YGe80/nQjHXZ1pxHVLgTueNtvLsIBHfq8k5KNZFF10Uq+sMiFSGQE0lnMEbuj54/vHHHx9/Dx5//PE6nftP10F2gEOSJEkzD0N3I0fIZkXlfITE1CqepHmqKSgSLGgVptpHSDnmmGNi6zMBsi5QkaVFmTZ1wjlzkM8666z4Hii2SpiPNmACTHbBq4Q53sUOQFR3jpL8kEsYK/Q92rWrUtVrUqjP7k/+vtTkfHGO8OCDD4Z55pmnws+YO1/M9alMMftal+etNmi/p2qfjjVhIGaHHXaIrf6pc4DOhYR2/K5du8ZzwHxxKvxU5rP4mtb+mlwPwj9TCxIGtngfSZIkzfhcSG0GRWt2/scY5X9cEoGH6jUB9q233oqre999990xULDac5pbnfA1LcFZL7/8cu7ftKuzOBULTqXns8ja/vvvH6urDA5kF/0i5FH5pMW6MoS0/IW2WPBqzJgxcXv5j2xFuphzRLUzGx7r63PHUyt99prl7wuVcuazFwq4+bhOBE4q2PnnKIW96q4PuCfyz38x+1rfmA5ARwT7xSO1jDP/PnVI0AmQf7+kdQPSQACDEfn3J4NV2Q6PYnAt+L3KPiRJkjRzsNI9g+JjkKhaXn/99TEgUMF7//33c63FVPIIE7SVs1gZX//444+5wMwCacw/pj2YdmMWmyK8jBw5ssL7UC1kfjKvY0XnX3/9Ney+++7xZ3yf9+fjlZg/y3xeFkfLfqQZi50x75Z9YD46Lb6EwYMOOij+PIVyBgcILrS/0wLMCt7dunWLrcAEJwIWx8cc8WKxIBnHTKWT7TAfndWu6yMQUTWlssrccM4PLdfHHntshecwf56OBOaNUzmlSsugx7LLLhvnmmcxoEEVe9CgQTFArrzyyrlF6jg+WqqLuT6cf37OIAcdELxnCu5cOwLsxx9/HKvl0xODJTzSZ9K/99578Zi5J5iDz3+zUks793Na7I6PAuOeZTX61F7OPH3WOEi/J9ybzL1nvQDuayrozHmng0CSJEkqhpXuGRTztI877rgYFliYjEDBit8JwYvVrNdff/24GBcBj+BE8AUf5UQ7LIucMe+bQHrfffdVWLkchEQezBFnkS6e07lz5/gzFqeiBZxFspZbbrnw888/x6pqFuGPxdkuvfTSOHeaMP3JJ5/kfs4+UVkk5KUgxLGxgBxt8RwbYZXwlBaEKxYDBbwvAwfs/6uvvhqDan1hbjXdAqyqzerY+QMIhF5CH63jLITG86688spK53izuBz3APOJOVZWgCcsplBdzPVhzjOBnrZsKtyEdt7v5ptvjh8XR/WdRfZqMthRF1iRnfuB/QOruvM1919NBqZuuummuLo5r+X8MLDDvZ5axzlXnDPuQe4R7serrroq3oOSJElSMcrK8ye1SlIDQTWdUNzQ2tcLYboG0zP4XPfqMKebroEV7zkoNG1bcd65Gr6y8hDmm9wpfNH0l1Bed+vtaTp4ZvVhsZOI7qqaTEdS/aNry2vXeHn9Gi+vXXF/09FRWlW3rGdOUoNG6zjt4XQlNES0oGdXZJckSZKynNMtqcFimsOOO+5YYQG3hoY54WlaAh8DJ0mSJGUZuiU1WCyKxqMho92KhyRJklSI7eWSJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCLO6ZakevJg/6GhY8eO9b0bqiE/PqVxXztJkqY3/1qQJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKGbkmSJEmSSsTVyyWpnqzyyOmhrE2L+t4N1VCT8hB6hQ7hk/B7mFJW33sjvLvR0PreBUmSKmWlW5IkSZKkEjF0S5IkSZJUIoZuSZIkSZJKxNAtSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6J4BPPPMM6GsrCz89ttvRb9m4sSJYYsttgjt27fPvbZHjx7h/PPPDw1N/n6NHTs2rL322qFNmzahY8eO9bpvjcFqq60WBg4cWOn55Prfc889oSHf2zw23XTT0BBde+21uX3MnmdJkiQJhu4a2nXXXXN/YM8yyyxhgQUWCEOHDg3//fdfaEyuu+668Pzzz4eXXnopfP/996FDhw6hoXrttdfC3nvvnfv6vPPOi/v89ttvh48//rik792QA2mx7rrrrnDyySeHxmzMmDEx3CbPPfdc2GijjcLcc89d6TXK/q6mx3rrrVcw0Oc/uOeS2267LfTt2ze0bt06dO/ePZx11lkV3mebbbaJ9+MKK6xQsuOXJElS49WsvnegMeIP9xEjRoR//vknPPTQQ+GAAw4IzZs3D0cddVRoLD777LPQp0+fsOiii4aGbvbZZ59q35daaqnQq1evSl8zadKkeE0aivrcn06dOoXGrkuXLhW6GiZMmBCWWGKJsPvuu4fNN9+82t/VpEWLFrl/r7jiijEsZx133HHhySefDEsvvXT8+uGHHw477LBDuOiii8I666wTRo8eHfbaa6/QqlWrcOCBB8bn8G8eDMJJkiRJ+ax01wJ/uM8555yx6rXffvuFtdZaK9x333256tmyyy6ba31eaaWVwldffZV77b333hv69esXWrZsGXr27BlOOumkXJX8yy+/jFU2KrgJbd98j+0mBP0FF1ww/qG/+uqrx9flu/POO8MiiywS95V24nPOOadCuzFfUy1k23xdyLnnnhsWW2yxeCxdu3YN+++/f/jzzz/jz8aPHx/fn1CSdffdd4d27drF9nW89957YY011ojPnW222WLFOm0jVSNpGz777LPDXHPNFZ/DIAYhtVA7NP/m2K6//vq477we/Hv48OFh4403jvt76qmnhsmTJ4c99tgjzDfffPH9e/fuHS644IKpjvOaa67JnSv2IYUp3gubbbZZ3H76GrzX/PPPH4MW273hhhsqbLPQ/hTCwM2QIUPi+eX96Zy4+uqr48+K2f90/riPGJxgusC+++4b/v333wrXuyZtz9Vds6ru8bQ/Wbx39h6744474n2Vts/vDyG6JgYMGBBOOeWUeG2K+V1Nj1lnnTX3M65d9mfsC7+fu+22W7x+4LpyPJxTfl832GCDOLg2bNiwUF5eXqN9liRJ0szJ0F0HCA+EHMIzf6D3798/vPvuu2HUqFExsKQ/4Gnn3nnnncMhhxwSPvzww3D55ZfHltnKAlkh33zzTazs0VpLON9zzz3DkUceWeE5b7zxRth6663DtttuGwPUiSeeGCt4qT2XdmOqdbTDUunj60KaNGkSLrzwwvDBBx/EdvSnnnoqHHHEEfFnhLsNN9ww3HTTTRVeM3LkyHgOaMUlSK277rox6NCue/vtt4cnnngiF2qTp59+Olav+S/vw35mW4mz2A7VS46Pfc+GUI6TEMYxUwGdMmVKmHfeeeP7cr6PP/74cPTRR8d24YRgTMjnOvE6Bk8Ivum9QKWU90pfM7DANRw8eHB4//33wz777BODGvuflb8/hXA/3HzzzfE8U0Xlnmjbtm38WTH7DyqzvJYwzLa4noTw2qjumlV3j1eH87jddtvF85H2mfu5VAGW7VMlZ8CCAbKff/650udy7fk51zI7KMIAWf7v+//+978Kg2mSJElSZWwvnwYEBQLPo48+Gg466KBY/f39999jGKUKClq4E4IQAXmXXXaJX1M5Y64tQfaEE04o6j1ThTVVrgkThDoqb9kK9ZprrhmDNqiKE9qYi0olknZjQnGq9FUmf/EtKotU/C699NL4Pdpud9ppp1jVZnsc/4MPPhhDKQjkf//9d6xKUxXFxRdfHAcM2N855pgjfo+Ax/ebNm0aFlpooVhN5LwyMJCPai7VS4JP/r5vv/32FQJTOucJFWNCIqGV0A6OifBMiE6WWWaZ3HuBam72vajKcx6p/OPQQw8NL7/8cvw+nQdV7U8W89HZl8cffzxWe9M9kdCOXt3+g+tItZ5rQMWeNQYOP/zweG8xcFIT1V0z9qmqe7yY0E1wJ2jTKQKq3qXA4Azvw3ljUIcBCyrknEPutXx0GDDgwEBHwteDBg2K15tr++mnn+Z+9ziWbPdDVQjvPBJ+VyRJkjRzsNJdCw888ECsRlIB4494FlKiqkmY5Y9z/lAnpFCFzc4Zfeedd2Ig4rXpQbDkOakduzpUB5dbbrkK38tfwInn0PKbxdeffPJJbFkuFhVOwvs888wTW8YJ2FQC076uv/76MYSl1nravqmApwDJfjDvNoW3tB9UcFkYKyEoZkMQLd7jxo0LNZXm4WZdcsklcf43AZrzfcUVV4Svv/46/oz3+O677+Ix1kRl55fvV7c/WXQqcNxUjStT1f4nnGMCd/Z+oB2croiaqu6aVXePV4dtc74J2ltttVW48sorw6+//hpKgU4P2vt5L6rz/N5Svc9O1UioXDN4Rjt/Fr+fVPkZZGBwY/nll4/bRU0GNE4//fS4WGF6MJ1AkiRJMwdDdy1Q8SIwEWL/+uuv2BKdQgqtyFTSWKTp1ltvjVVmqqAgCFG55LXpQZWa7RDg0x/x2Vbb7Nzm6Yl54gSNxRdfPIZpWtYJgEjzhQkhW265Za7FnP8yANGsWc0aKPIXGKNVmZBXU9mgiFtuuSUcdthhMUg99thj8XxTeU77T7W8lPL3J19171/d/teXqu5x7uH8VvHsPcwgA5V91gJYeOGF4wJldGt88cUXJd9vugg6d+4cq9WFjok53YT0/HuRCj+/u7ST83F1zGdP2ysW88DpEEiP2gyISJIkqXEydNcyTDHvt1u3bgUD5pJLLhn/yObjuFgdPIVSFlCjWshr8x+EldTOnK0cZhdVS628r776aoXvpcCTfc6LL75Y4Xt8TTgq1FZbCCGb4EsrLdU9XktVOB8t5o888kic982cb77O7gfV/ewiWewHx0rQKjXei2BIGzjXhPNMm3FC9Z72YFrZqxoQyO8OqOz8EiJrggos5/jZZ5+t1f4nnGMGf7L3A1Xx2lRTi71mld3j3MP5le/8e5ggS/WcAai33norDt6kKQmlRDWbTg06KbIYJCB0M7++shXm+b2h44N9Zd483QT5q+pXhSkRdIFkH5IkSZo5GLrrENU6gghVQKpiVCepYqc5ryyExVxZwgYhlVZeqpnHHntsrvJJwD3jjDPizwhj6WcJc6rZJnN2CfCEnfxFx5ijTJBkTi/zhqnEMy+XqmmxCHhUKKlEfv7553EV58suu2yq56266qpxvjNhm7mz2dZ3vkcFnznsLDjGQmPMfadNPc3nLiU+Uuz111+PbcOcB+a4Zz9/GUwLYGCBhcw4r2+++WY85iSFciqcqQ2ac885Z349r2EOPYuX1eT8pm1zblhUjM+Z5v6h9TktlFbM/oPKN9Vw5u2zsj3rA9ASXdP53MVcs+rucVY9Z5+5z/k++8J2kldeeSWcdtpp8Tm0yXPefvzxxxrNCweV59QtAvaLf6fWe37OdWIAgq4NruEmm2wS72ta47MYLOL1LEqY76effor3/UcffRS3z9x/FpdLq+lLkiRJ1TF01yHm1fLH+RZbbBErw6zqzMrYrG4N/thnXilBhcW6CNjnnXdebkEpsCAWC00xj5eFzFjoK4vqOu3ehDTmxxIICDFZVNQJbgR6qpCEfeaSp4/XKgbbJkzSWss2WJWcean5qFqyGjXV0WyVO50PAuMvv/wSj5dWdObzMgAwPXDeWUiLlncGA6hypsXPEsIlAYrF4ZhbTks9YTEhkNMOTdWY6i6YH8xcZhZO4zWsOE6ltLKPXqsKwZ3zwn6xiBxziFOVuZj9B+eUgM4ACM+lRZrBhNqo7poVc48zOMDigLz+jz/+iBXkhAovH1XHegC8nkElzjFrI9QEoZ3rka4Ji9nxb+71VJlmdXXOBe/DoAS/U3yCQPazutMCanQUcP4LYdCK+flU5xksSx+ZJkmSJBWjrNwPm5UaLQZS+Cx3BmFmRARc1lCgy4BV5BsyBl369u1bVBWc1ctZUG3Rm48IZW0qDgKo4WtSHkKv0CF8En4PU4r7tDyV2LsbDS3qeUzpYRFNPkqwNt1Aqj9eu8bN69d4ee2K+5uONXuqmj7omZPU4PExXnRUNER0gTCHniq6JEmSlM/P6ZbUYNFWn9r9CbYNES3saS2Dhl6NlyRJ0vRn6JYasfxF9GY0LC7I4mcNGavg85AkSZIKsb1ckiRJkqQSMXRLkiRJklQihm5JkiRJkkrEOd2SVE+eX+8oF19rhPz4FEmSVBP+tSBJkiRJUokYuiVJkiRJKhFDtyRJkiRJJWLoliRJkiSpRAzdkiRJkiSViKuXS1I9Weruc0Jo3bK+d0O1GK1eqEm78NGUP8KU+t6ZGdRn2xxT37sgSVKdsdItSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYihW5IkSZKkEjF0S3WoR48e4fzzz6/yOWVlZeGee+4p2T589NFHYfnllw8tW7YMffv2DdP7mLPH9+WXX8av33777Vpte7XVVouvn5ZtTI/jT/v422+/1ffuSJIkqYExdKte7LrrrrmgwmO22WYL6623Xnj33XenewiuS6+99lrYe++9Q3064YQTQps2bcKYMWPCk08+Wa/H3LVr1/D999+HRRddtNbb32uvvabaxsEHHxyWWmqp0KJFi0oHFriXVllllTj4wH6ceeaZFX4+adKkMHTo0DD//PPH5yyxxBLhkUcemWo7l1xySbyPeM5yyy0XXn311amO/84776z18UmSJGnGZuhWvSFkE6Z4EA6bNWsWNtxww9AQ/fvvv0U9b/bZZw+tW7cO9emzzz4LK6+8cujevXsczCiEwFlXqjrmpk2bhjnnnDNe29pi24W2sfvuu4dtttmm4GvGjx8f1llnnXgO3njjjXDWWWeFE088MVxxxRW55xx77LHh8ssvDxdddFH48MMPw7777hs222yz8NZbb+Wec+utt4ZDDz00DmS8+eabMZivu+66Ydy4cRWOv1OnTrU+PkmSJM3YDN2qN1QpCVM8qFYeeeSR4Ztvvgk//vhj7jlDhgwJCy64YAxePXv2DMcdd9xUgfH+++8PyyyzTKxEdu7cOQan1Jr81VdfhUGDBuUq6skLL7wQq6CtWrWKVVAqpxMmTMj9nMrmySefHHbeeefQvn37XCWXiuYiiywS953nnHPOOVVW1j/55JOw6qqrxn1beOGFw+OPPz7VeeCYt95669CxY8cY3jbZZJPYlp0888wzYdlll43Va56z0korxeMqhGMkZFLB5d8EzdTiTYDs379/3JeRI0eGn3/+OWy33XZhnnnmied3scUWCzfffHOF7f3xxx9hhx12iO8911xzhfPOOy+e14EDB1Z6zFn57eW//vpr3B5BlXPfq1evMGLEiFBTF154YTjggAPiPVEIx8dAyTXXXBOv17bbbhuv8bnnnpt7zg033BCOPvrosP7668ft7LfffvHf2WvK86m077bbbvH6XXbZZfFcsV1JkiSpGIZuNQh//vlnuPHGG8MCCyxQoTrbrl27cO2118ZK5AUXXBCuvPLKGPySBx98MIZswhIVSirmBFTcddddYd55540BNFXUUyWYKvsWW2wRW5AJo4TwAw88sMI+nX322bGyyXYJ+4RZwjEB7r333ouBlu+zf4VMmTIlbL755mGWWWYJr7zySgxsDCJkMYBA5ZTjfP7558OLL74Y2rZtG/eP0Pjff/+FTTfdNIZl9nXUqFFxACA7gJDFMRIyBw8eHP992GGH5X7GoMYhhxwSRo8eHd/z77//ji3anMP3338/bnennXaq0D5NlZd9uu++++KAAftIxbe2OF9cy4cffjjux/Dhw+NASV3jPDHYwblPOGZa7gn++Oeff+IARBYDAdwL4Pxzzddaa63cz5s0aRK/ZvuSJElSMWrf8ylNowceeCAGTFBlppLK9wg22RbgbEWVEHnLLbeEI444In7v1FNPjSH4pJNOyj2PoAyqxrQ3E2ippienn356rLamai3VViqnBFtCYApia6yxRgyvCa9Zc801Y3AEFXgCJK3LzFHP98QTT8RFzR599NEw99xzx++ddtppYcCAAbnnEPgJ51dddVUuSFP5paJNhXvppZcOv//+e2y7Z+4x+vTpU+k5TW3YnNd0zD/99FP8L8fLIEBWNpQfdNBBcV9vu+22OHBBlfu6664LN910UzzutG/pWGrj66+/DksuuWQ8rnRNS2Hs2LFhvvnmq/C9OeaYI/ezWWedNYZwKtmEc84tAzYM1EyePDl33vh3el12O1zXmiDg88i2v0uSJGnmYKVb9Wb11VePbcc8qK4Sggik2dZpQint1ARIgiQhnOCW8NoUCIv1zjvvxOo020sP3pvw+8UXX+Sel4JhQmWWfcnia1rIU1DLfz6t69mQusIKK0y1L59++mkcGEj7wmABVWgq8vybQM/+bbTRRrHanyr2NZV/POwzLfS0lfM+vDehO53fzz//PFbiU+cAOnToEHr37h1qixZuBk2YTsDAyUsvvRTqC+eSAZeFFlooVsTpdKCNPDvoU1cY6OHcpQf3hSRJkmYOhm7VG+YJ007OgznZVHupeNNCDlp4qS7TOk4FnDbvY445psKiZrQD16aVfZ999skFfh6EX8Jzqian/Ss19oUW7+y+8Pj444/D9ttvn6sucy5WXHHFOAhBhf3ll1+u8XvlHw8VeoInLe9PP/10fF/CfbGLxtVGGlRhnv13330XB0yy1fa6wiDNDz/8UOF76evUAcC8cj7ajHuOfaJ6zcBDmidO2zudEoW2k+2cKMZRRx0VOxbSg3n8kiRJmjkYutVg0F5NlfGvv/6KX1MFZfVpgjZVWqqS+QuILb744lV+LBYVzPwqdL9+/WJbeAr82Ud2DnA+2rqZ35zF14Rgwlmh5xOuspXp/LDMvhD2u3TpMtW+UBFNaMkmuHFO+OgsWr6nFfvOom077rhjbMknbBL2E75u3rx5/EishMCYfU5tEHZ32WWXOIefBdiyK4rXFToKnnvuuQqL7jEnnSo9reVZTCdgMTnmz7NQHucE3AsMiGTvL7oh+Dq/Y6E6LLzHgnzZhyRJkmYOhm7VG+a4Mr+WB63YzCmm8ksbNQjZtDrTjkyrNfOu77777grb4KOcWHGb/7INFjgbNmxY7ufMGSZ8ffvtt7m5zVR2Ca+0E1PdJfTee++9Uy2klo/53QQuWrIJnsx3vvjiiyut1LLgFoGcgEklnUXIGEDIopJPRZWgx89pb2cuNytt/+9//4tfE7apdDPg8Nhjj8X9rWped7E4vwRRzgXnjup/tqpLyzv7fvjhh8dK+AcffBD22GOPODBS2UJu1Tn++OPjuaalnu3RwVCbY+H1XDvuHQZpUodAqtLTJUBoZn95HzoEqOqzMFzC4nbM4aaNnnPP4nWE6rReAHg+nRdca84R7fFUxmlDlyRJkoph6Fa9eeSRR+LiaTyWW265WFG9/fbb40dSYeONN45tyIRh5gATDtMiZgnP5TWsrs1zWPwsu/o2K5fzsVW0jVNhTdXxZ599NgZnPjaMKjJhsLoFwqhKs8gYgwBUm3kN2y+0iBoIpwwSEAqZF73nnnvGhd+y+PgpBgW6desWFzkjgBIUmdNNNZSf0/bMSusEeFYY56OyCMjTivnxHBMt5ZxHWqZZKT2Lhcao6rKQG4MIzGFnH/NX/S4WQZhBBK4BC5jRIcD5rCnOJdeNz9nmOvJvHrSsgy4BBigYtKBazYAJ1yt99Bs4x5wDPgqMFfCpdrNyOYvYJXwOOKvY81ruL4I9923+4mqSJElSZcrKy8vLK/2pJGVQ5SWc8lnWDA6UGoMBhN3KPge8oaA7gYUB+TiybGivDKuXMzDQ85pjQ2hduwEM1e9o9UJN2oWPpvwRptT3zsygPtumYldQXaGbZdy4cXFKTykWTVTpeO0aN69f4+W1K+5vOqZgVjV90DMnqVIsXkf7Pu39fD437fBI856nh0svvTQucMbUgYaIz0XPfgycJEmSlOXndEuqEu3VY8aMyS0sxvxn5qFPDyNHjswtrEcLfkP00EMP5RZsc4E0SZIk5TN0S6oU86TfeOONent/WtkbOlbYlyRJkipje7kkSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYhzuiWpnryx2eCiPmJMDYsfnyJJkmrCvxYkSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYihW5IkSZKkEnH1ckmqJ31vujCEVi3rezdUi9HqPs3bhNGTJoQpYcby5W5H1PcuSJI0w7HSLUmSJElSiRi6JUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuqU7vuumvYdNNNc1+vttpqYeDAgbXa1rXXXhvKysrio7bbmB7Hm/bxnnvuqe/dkSRJUgNj6Fb0448/hv322y9069YttGjRIsw555xh3XXXDS+++GLuOdM7VOSHN5XGiSeeGPr27Vuy7d91113h5JNPrvXr27dvH77//vsK22Cb66yzTphtttniffn2229X+vry8vIwYMCAqe7fd955J2y33Xaha9euoVWrVqFPnz7hggsumOr1zzzzTOjXr1/8vVhggQXiQEAWr2H/JEmSpEKaFfyuZjpbbLFF+Pfff8N1110XevbsGX744Yfw5JNPhp9//rlG22Ebs8wyS8n2U/Vn0qRJoXnz5jV+XadOnabpfQnLDAJlTZgwIay88sph6623DnvttVeVrz///PPjNvK98cYboUuXLuHGG2+Mwfull14Ke++9d2jatGk48MAD43O++OKLsMEGG4R99903jBw5Mv5O7LnnnmGuueaKg1Lo0KFDfEiSJEmFWOlW+O2338Lzzz8fhg0bFlZfffXQvXv3sOyyy4ajjjoqbLzxxvE5PXr0iP/dbLPNYoBJX6cq6VVXXRXmm2++0LJly9w2CSezzz57rFSuscYasbKYpNddfvnlMfC0bt06Bqjff/8993MGAO69995c6y4VR7z33ntxe1QnqXQSlP78888Kx3TNNdeERRZZJFYnCUgpROHrr78Om2yySWjbtm3cN96XQYas+++/PyyzzDLxeDp37hyPO/nnn3/CkCFD4n6n6ufVV18df0YVtGPHjhW2RXU1G/o4D5zndu3axfdfaqmlwuuvv17p9Tn33HPDYostFtq0aRPfc//9969wvIUq1QTNdI3AueOasg32b6WVVgpfffVV3N+TTjop7lM6z6mSy7+HDx8e7wFed+qpp4bJkyeHPfbYI15rzn/v3r0LVoez8tvLL7300tCrV694bueYY46w5ZZbhpraaaedwvHHHx/WWmutKp9HBfycc86J90O+3XffPe57//7940DTjjvuGHbbbbdYRU8uu+yyeKxsg0o49xH7e95559V4nyVJkjRzMnQrhk8ehEMCZSGvvfZa/O+IESNiK236Gp9++mm48847Y1hJbb5bbbVVGDduXHj44YdjRZH23DXXXDP88ssvFV532223xYD7yCOPhLfeeisGShx22GExDK+33nrx/XisuOKKscJJhXHWWWeN+3D77beHJ554okKoJigecMABMYwT0O+7774YjDFlypQYuNmPZ599Njz++OPh888/D9tss03u9Q8++GAM2euvv37cJ6qbBNZk5513DjfffHO48MILw+jRo+PAAeevWDvssEOYd9554/5zbo488sgqK8hNmjSJ7/XBBx/EgYinnnoqHHHEEUW/33///Rfb9AmX7777bhg1alQ8N4Rqjnvw4MFxgCKd5+y5INBzLjiPhFTOH/vOef/www9j8D366KPjdSwGgwsHH3xwGDp0aBgzZky87quuumoohYkTJ4btt98+XHLJJVNVyivDoE+2Ms+5yg/23H98X5IkSSqG7eUKzZo1i9VN2nSp7BGQCWjbbrttWHzxxeNzqFiDKml+gKGl/Prrr88954UXXgivvvpqDN1UgnH22WfHUH/HHXfEwIe///47vm6eeeaJX1900UWxlZeqIu9BJZVBgOz7ETrT66i+4uKLLw4bbbRRrNRTOT3llFNikDzkkENyr6NqDQI0AZK2YarGYFuETkIwz6Oiy7FTAU6WWGKJ+N+PP/44BkzCegpjVElrgkr74YcfHhZaaKH4NVXfqmSrxFSvOT7anakYF2P8+PExTG644YZh/vnnj9+japswYMA9UCiYElqp/mZlzwtVYAIo54RBkmKOnevGvlDpp6tiySWXDKUwaNCgOFDDIEsxaC+/9dZb46BLMnbs2HhPZfE15/Svv/6K92gxuI+zA1q8XpIkSTMHK93Kzen+7rvvYlWY6nJaPCp/0ahCCE4pcINWZdqfaf1OVXQeBN3PPvss9zwWbUuBGyussEKspFIBrQyVZQJwCtygVTq9jqDPcVBVr+z1hO0UuLHwwgvHwQR+Bqr1lb2enzHnl0GJ2jr00ENj6z2h/YwzzqhwTgqhks/+cK4IqrRWM9eeSm4xqNyyKB0VWgYnarLw19JLLz3V96gc0xLPNee6XnHFFTFMF2PttdeO9wsDFRwH86SLPY6a4D6mI4A2+2K8//77MZyfcMIJcYG2unb66afn5n7zyN5/kiRJmrEZupXDHFtC0XHHHRerfgQ1Qkh1sgEYBG7mURNQsw9CMRXeUiq28ljbbVS3fVrBWS07fwGyLFq2aRWnqk8wJPTffffdBbf35ZdfxqowHQe08NOOTuhNHQbFvifTAqhIU/mlmrvggguGl19+OdT02t5yyy2x9Z953Y899li8rlTC075Uh0GDN998M7bnc4/Qns4gCmsA1CXOK4MZDKZQxeeRBpeYY55FmzyDGnRgHHvssRV+RvU/f74/XzMXvyb3Gusj0G2QHt988800HZ8kSZIaD0O3KkUYZA51wrxjFtKqDhVy2nIJOsylzj5YlCyhOkpVOiEEEiBZnAusgp7/frRFU0nP7hcfa5ZeR6ijBZs28kJ4PYEnG3oIXYQ+jhcE3Mpez4JmVNWZD14I1d8//vijwv4V+jgrQi/tzwTXzTffPIbiQgjZvB8t98svv3x8XfacpffkfGeDd6H3pI2b8MeAyqKLLhpuuummSs9zZTjXBHfm3rM9rml1lfp83BdU+c8888w4x5yBBUJyXWKePNvODvqABdCy55rBDxa122WXXeK0gnx0X+TfC0wt4Ps1wTQLgnr2IUmSpJmDoVuxVZnVwPnoJIIKbeAslEUoys6HTWGWgPfrr79Wuj0CFaGExbsIlYQqgt4xxxxTYZVuKuuEHUI0q6ezwBbzgtPcYt6P/aFC/tNPP8XqLYuQpdfREvz000+Hgw46KLYqp7m3VJIJqSw+9sknn8TKKvPF074RnNkO32fuOQuj0S6eWqmp7lOJ5b+0nDMHnPniaZ94bxYVY44654pW/LSQ2HLLLRdXYmdxMcIowTbbos88YBZ94zWsHk6IZS55do51FqGW42b/WfDthhtuiPPus6jc8jnrXC/ek0o4C9gl7CNhm0o378k14byk9+SYeA7BlPNc2WJ6af451/DRRx+N89vpisguqledBx54IF4X3ot9YT49gwppoKVYLITHNhgwAfcIX3NvgnuIgYXsI01pYB46uH8I3LST0/LPa3lwLhPmznPeWbjuo48+ivPoudYMmEiSJEnFMHQrzsslLFIFZCVpAgphioXVWKQsIchS5WM+alWLX7Eq9kMPPRS3Resx1VkWJiNkZRelIlBS5WWVcIIPFebs4mC8P2GMMEw1l4BKoCXwEbpY9IyPb6I1OLufhGLm8rItFkijPZuQmfaNjyFj9XP2jxDO/GJarrMhlkEH5gXzUVwMSBDOs6uj875Ue1kMjf1MlW3mTzN4wfET7gnvDAIkzAdnkIOgz3lhkGHAgAEVFifLovWajwwj9HNdmAPN/OAswjPHStjm+ewrLeAJ54zASGs170kbNau777PPPvHnfJ95/ARQzjP7XBlewzVjhXPuGY4lrThfDNq9WeWec8p+M4DA+3GdaoJrwz1Iiz64v/g6f0CiKizqR8DmetHqnh5p0T0Q0FlYjfuec8vvAB+Plz6jW5IkSapOWXn+ZFBpOiCIUiku1AYtJXQJsHp7Xc/5LgUGdJibT4dHdVi9nAXVul9yUgit/u+z7dW4Rqv7NG8TRk+aEKaEGcuXuxX/cYSNEZ01LLjZpUuXOC1JjYfXrnHz+jVeXrvi/qZjzZ6qpg965iQ1aPyPGN0YQ4YMCQ0RLeg1+Zx2SZIkzVz8nG5JDRat7yuvvHKuNb0hGjp0aK6dn/Z0SZIkKcvQrXprL8/OdZYKYTV6Hg0Z7VY8JEmSpEJsL5ckSZIkqUQM3ZIkSZIklYihW5IkSZKkEnFOtyTVk7e3P7jBLhCnyvnxKZIkqSb8a0GSJEmSpBIxdEuSJEmSVCKGbkmSJEmSSsTQLUmSJElSiRi6JUmSJEkqEVcvl6R6suSVl4TQqmV974ZqMVrdp2XrMPrviWFKmHF8ceDg+t4FSZJmSFa6JUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKGbqmR23XXXcOmm26a+3q11VYLAwcOnKZtfvnll6GsrCy8/fbb07x/PXr0COeff36tXnviiSfG/eBR221Mj/Of9vGee+6p792RJElSA2PoboR+/PHHsN9++4Vu3bqFFi1ahDnnnDOsu+664cUXX8w9Z3oHgPzgp7pXWRC+4IILwrXXXhsaqtdeey3svffetX79IossEr7//vsK27jiiivi4EL79u3jOfntt9+met3GG28cf0datmwZ5pprrrDTTjuF7777rmCgzz7atGlTYTts+4ADDojb4PdtwQUXDA899FCF88/+SZIkSYU0K/hdNWhbbLFF+Pfff8N1110XevbsGX744Yfw5JNPhp9//rlG22Ebs8wyS8n2U9NHhw4dQkOU7q/ZZ599mrbTrFmzOLCUNXHixLDeeuvFx1FHHVXwdauvvno4+uijY1j+9ttvw2GHHRa23HLL8NJLL8Wf8/W+++5b4TVrrrlmWGaZZSocw9prrx26dOkS7rjjjjDPPPOEr776KnTs2LHC+W+o10CSJEn1z0p3I0PV7fnnnw/Dhg2LoaJ79+5h2WWXjcGDyl5q58Vmm20WK3fpayp7ffv2DVdddVWYb775YgUwbXPPPfeM4YjK4RprrBHeeeed3Hum111++eWha9euoXXr1mHrrbcOv//+e+7nDADce++9uWrhM888E3/23nvvxe21atUqzDbbbLFa+eeff1Y4pmuuuSZWM6kiEpAOPPDA3M++/vrrsMkmm4S2bdvGfeN9GWTIuv/++2NQ4ng6d+4cjzv5559/wpAhQ+J+s/0FFlggXH311fFnVIez4Ql0B7D/CeeB89yuXbv4/ksttVR4/fXXC16b7bffPmyzzTYVvjdp0qS4T9dff338esqUKeH000+P559zssQSS8Qwl/z6669hhx12iNeCn/fq1SuMGDEi/ozXYMkll4z7SKW3si6D//77L55HwiDvf9xxx4Xy8vIqOyE4F5VVzCdPnhz22GOP3H737t07Vniz0n6ceuqpYe65547PyW8vZx+4X1KXBs87+OCDQ03RPn/kkUeG5ZdfvtLnDBo0KP6c35EVV1wxPv/ll1+O1wTcU4T59OC++vDDD+NxZu/NX375JZ6rlVZaKR5L//7943WTJEmSimGlu5EhKPAgBBAoCC6F2nmpzBHWqAQ2bdo097NPP/003HnnneGuu+7KfX+rrbaKQerhhx+OIY1wTcXv448/Dp06dcq97rbbbosBd/z48TGY7L///mHkyJGxYjh69Oj4/RQQed2ECRNi2/sKK6wQ92ncuHEx3BMGU7gbPnx4OPTQQ8MZZ5wRBgwYEIN8apMnoKbA/eyzz8YgSZsvwTaF+gcffDCG7GOOOSYGWyqT2dbfnXfeOYwaNSpceOGFMSh98cUX4aeffir6fBOACbnsJ+eL1u7mzZtX+lzOJYMK7DMeffTRWJVNAwEE7htvvDFcdtllMVA/99xzYccdd4whmzBHOCb4cS0Iy5z3v/76K7721VdfjQMsTzzxRBykqKpLgUEQrhGvYZCAwQ6C7l577RVqg2sx77zzhttvvz0OnlAtZpsMkjAQktBxweDE448/XnA73HvnnXdeuOWWW+IxjB07tsIAT6kQnLlXCd+VXT8Go2gdX2WVVXLfu+++++L9y33HoBLXicEVBnKyv1fVYfCHR8LviiRJkmYOhu5GhlZbAivhieDWr1+/GNa23XbbsPjii8fnpHZeKpf5bbmEUsJpes4LL7wQgxmBOAX4s88+O4Z6KrBpHu3ff/8dX0d7LS666KKwwQYbhHPOOSe+B6GdUJF9P4Jfel2aJ3vxxReHjTbaKFbq55hjjnDKKaeEwYMHh0MOOST3utTeS4CjUk5QplINtkVYI8TzPKqqHPtJJ52Ue32qQjJowEABAXCttdaK36MdvyaotB9++OFhoYUWil8TlCvDAAPHeffdd8f5w7jppptiBwKVcs7PaaedFkMzQS7tD9eAgQ6uI+9HyF966aXjz1OXQva6Enrzr2s+zhfhloo2FWfOI1/XNnQTVLPnmIo3gxmc32zo5vgJr5UNCHB87DvXg20yEMBAQqkQjrnnGPhgkOqBBx4o+DzuU0I51fCszz//PDz11FNxQIXBHAZBGGyiWn7CCScUvR8MtmTPnyRJkmYetpc30jndLAhFFY5KNlVfwncxi2nRapudY0uVkcosQS5V0XkQdD/77LPc8whHKXCD0Ej1c8yYMZW+F9VvAnB2YSpadNPrCPocB1X1yl5PeEyBGwsvvHAcTOBnoPJc2ev5GdVIwmxtUYWnOk9IpBqfPSeFBkQIoIQ3UOmnOkpgA4GN8Mcc4ey5ZiAhbZcF8qgC085/xBFH5OYf1xQBM9smz/X65JNPYpt4bV1yySWxvZ77h/1mMTNCdNZiiy1WZQWeTgAq9ww2MADAAAUdDKXCgMlbb70VHnvssXgv0PmQbbNP2I8//vgj7LLLLhW+z71K1wjHyrHTZUFXBQNeNcH0D7o40uObb76Z5mOTJElS42Clu5Fi/jLhjQctyQRDKm/Mq61K/srMBG5ahFO7dlb+fOe6RnW8lNuobvtNmjSZKoCl+b4J849pJ6aNnZZvzjGhODtvPIuATchnQIEKO/vAwAjSXHa2lR3AQOoyoMWehbqoqvJ6BhRobab7oC4RyKs79iyOmWkEdDYQ4Kncn3XWWeGVV16p8v7KxwAKAy5U+zk+qsZsh+kDlbV9Twta9HnQNt6nT5/4/szrTp0GCdX5DTfcMHZfZPG7wX5lW8nZDm3xNVmIkOtbaCqIJEmSZnxWumcQVICprCYEhWKqmlTICRBUaVlkLPsgrCRUNLMft0RwIbSmxbIIH/nvRzihkp7dL+Zrp9cR3Gifpo28EF5PRTBbFWS+Mwu/cbygpb6y11N1pVJJoCuEii3Vzez+FfpcagIbi3JRLd18881z89YLYc4wwe7WW2+NFW8quylMss8EL85l/rnOVvPZLyquzP1mATKqrEgBr5jrmh+GuV60xqfwyHtkP+aKKjhV+Mpw3Tg2QjLt7+xzVVX/qjAQwRQD5tkz2EObOu3vpca9gOzcatDV8fTTT1dYQC3bmUGHQnptmrZAGHflf0mSJBXD0N3I8LFgrAZOIHv33XdjYGBxqzPPPDMuOpakMEugZkXsytA2TdWPVacJlXwWNC3NtNBmV+mmsk4QJESzejorTtNKneYW837sD1VMFiqjakrVN73u/fffj8HmoIMOivOdU0WRSjLVUwIYwe/NN9+M88XTvhGc2Q7fZ+457cFUktOcZyrPN998c/wvLeeEN+aLp33ivXffffc4R51zRchjHjKWW265uBI7HytFgGT+dbZFnzZoFn3jNVSfCZ7MJWcwoCpUxmk/ppKbWsvBIAPVYgI88915z3S8fI3jjz8+tqQT9D744IM4Bzm9H23OBNZHHnkkrrSdVo8vhGBPazzXg/PDe2TnzXMPMdeZ1muuMx+dVVWlmcDO81gYjtBJdwXnoqY4v6wez/3AfGnuY46JaQ81wX3NAAnnCVx3vmbBtDTowPHxPa4d87K32267MP/8809V5WaFckI0XQb5aPdnm5w7jpsuBebl030gSZIkFcPQ3cgwl5awyKJYq666alh00UVjAGJ+LCEjIcgS+qigUpmsqs2YVma2tdtuu8WqLguTEVSyrbZUNqnyrr/++mGdddaJFeZLL70093Pen+o1YZgqKgGVQEtII7Sw6BmfkUy7dHY/CcVUc9kWC6TR4kv4TvtGAJ111lnj/hHCmQtMFTnhY7MYdGB+O/OgCZOE84RVx3lfKrQshsZ+pso2K6wT+jh+wj3hlEGAhKowgxwEfc4LgwwEs+oWxCJoU5GnhZxKadbJJ58crxcLaxGmaT0nyKWPA6N6yvxfzi/HzD7Q2g26ERicYNE1PmorO8iSj31m0IBFygiIhMa0KF66P7g3WKmbQQIGA7heldlnn33i9WdOM/cf54VzWlNMWbjyyivjeeEYaTNnRXzWFKgJBjW4r9PCcJwrvuY+AMfCCv3cb9yXVLF5P7oesm3eVLAZCGBaRqHVyDlH3MMMMPB6Bps4l/kLrkmSJEmVKSsvtKqQlEEQpVJcqPVaKqXGdO8xSMSCbPmfmV4IHxnGx/P1OPOUEFq1nC77p7odre7TsnUY/ffE8P8mHjR+Xxw4OMzoGGhjzQ06h5jqpMbDa9e4ef0aL69dcX/T0YHKx+ZWxjMnqUGjdZwOj2xnRUNCa376XHZJkiQpn6uXS2qwaOfecccd47+zH3XXkAwdOjS254O54ZIkSVKWoVtFtfhm5zpL0wvz7nk0ZLRb8ZAkSZIKsb1ckiRJkqQSMXRLkiRJklQihm5JkiRJkkrEOd2SVE/e2uuA+Nnlalz8+BRJklQT/rUgSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYirl0tSPVnqwuGhrGXL+t4N1WK0eqE2rcNHEyaGKaHh+/SIQfW9C5IkzdSsdEuSJEmSVCKGbkmSJEmSSsTQLUmSJElSiRi6JUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEDN2qkR49eoTzzz+/yueUlZWFe+65J0xPu+66a9h0001DfXjmmWfiMf/222+hsVpttdXCwIEDQ0Pz5ZdfxnPLo2/fvqEhStefR33dg5IkSWq4DN0lDIHpD3Ees802W1hvvfXCu+++O91DcF167bXXwt577x3qO4S9/fbbdb7ta6+9NnTs2LHGr1txxRXD999/Hzp06NBgr1t17rrrrnDyySeHhuqJJ54ITz75ZO7rDz74IGyxxRbxPHI/VHYuL7nkkvicli1bhuWWWy68+uqrFX7+2Wefhc022yzMPvvsoX379mHrrbcOP/zwQ4X7bY899gjzzTdfaNWqVZh//vnDCSecEP7999+prj+vlSRJkvIZukuIkM0f4zwIDM2aNQsbbrhhaIiyIaIqhJPWrVuXfH8ak1lmmSXMOeecMfw1Vp06dQrt2rWr1WvLy8vDf//9F0qJQSseycSJE0PPnj3DGWecEc99Ibfeems49NBDY0h+8803wxJLLBHWXXfdMG7cuPjzCRMmhHXWWSdet6eeeiq8+OKL8fdgo402ClOmTInP+eijj+K/L7/88hj0zzvvvHDZZZeFo48+eqrrTyiXJEmS8hm6S6hFixbxj3EetMYeeeSR4Ztvvgk//vhj7jlDhgwJCy64YAyyhIjjjjsuTJo0qcJ27r///rDMMsvEal3nzp1jZS61BH/11Vdh0KBBuYp68sILL4RVVlklBoGuXbuGgw8+OIaMhOoflc2dd945VvhS9frOO+8MiyyySNx3nnPOOedUWaH95JNPwqqrrhr3beGFFw6PP/74VOeBY6YKSBWZcLfJJpvECmK2PXfZZZcNbdq0ic9ZaaWV4nEVQsURSy65ZDxezkHW2WefHeaaa64Y0A444IAK5/Kff/4Jhx12WJhnnnnie1H55L3TPuy2227h999/z53LE088Mf7shhtuCEsvvXQMpVzL7bffPhfcKmsvr+o8Vnbdfv7557DddtvF/eN+WGyxxcLNN99c4fg4Bq5lly5d4jlfeeWVY/dB/r48+uij8Rxx/ddYY424vw8//HDo06dPvN4cA8G1svZy3od7k3uHY1hggQXC1VdfXeE92N5SSy0Vf879Vuy+MQDF+eQYqRKPGTMm1BS/D2eddVbYdttt4/sXcu6554a99torXlfuTcIy73nNNdfEnxOyuQ/pcOBc87juuuvC66+/HkN4GjgbMWJEDOf8fm688cbxHqIzQJIkSSqGoXs6+fPPP8ONN94Yw0u2YkeQ44/+Dz/8MFxwwQXhyiuvjNW05MEHH4whe/311w9vvfVWDCwEVPCH/7zzzhuGDh2aq6inllnCAu23tLNT8SMUHXjggVMFVKp/bJew/8Ybb8RwTJB57733Yujk++xfIVQAN99881jpe+WVV2KoIahlEXqpLnKczz//fAw6bdu2jftHVZEKKfNg+/fvH/d11KhRcQCgsqpxag+m3ZjjzYafp59+Oh47/yU8sd/Zfef42f4tt9wS32urrbaK+8HAAeGPwQQCaTqXhKt0DAxQvPPOO3GuOkGN6QOVqe48Vnbd/v777xhiuebvv/9+PA877bRThZboI444IgZ6jo/qLfcT5/eXX36psA+858UXXxxeeuml3KAHx3fTTTfF7T/22GPhoosuqvQYGIwh8F944YVh9OjRsdLLdctiEIlKMz9ffPHFi963Y445Jg5CEG7p/th9991DXePe4jqstdZaue81adIkfs09AAYJuM+yoZ3BAp7H70tlGJhh8KgmeK/x48dXeEiSJGnm0Ky+d2BG9sADD+SCClVmKrB8jz/qk2OPPTb3byqiBD1CIQEGp556agxvJ510Uu55BGXwh3/Tpk1zFdjk9NNPDzvssEOuctmrV68Yngi2w4cPj8ECVEAHDx6cex2vWXPNNWNABBV4BgOoKBYKmQRf2m+pqs4999zxe6eddloYMGBA7jkEfsL5VVddlQvSVA6paFP5pOJJiKHtnvmyoBpbVXs7GLjIbyueddZZY9DknCy00EJhgw02iIMUVDu//vrr+L78N+0r5/qRRx6J32e/mZPNPuZvNxsKqXZyLqm0MpCSH0RThbWq81jZdaPCnYI+DjrooHhub7vttjjQwj3E9SO8p3PMIA3dBVShDz/88NxrTznllNgxAOYkH3XUUXFAgv3HlltuGQcn8gdJ8PHHH8f3ZLsptKbXZTFosPbaa8d/12TfuKe5F1Nw5zox4JDuy7rw008/hcmTJ4c55pijwvf5mnsWyy+/fOx44Bxw/WmTZ394XRoIyffpp5/GwQoGrGqC38ns77AkSZJmHla6S2j11VePC37xoFpJ1Y9Akm2dJpQSjghfBDhCOMEw4bUEuJqgIkv4YXvpwXsTfr/44ovc8wi8WVQsU1BL+JpKMEEkH8+n/TiFWKywwgpT7QtBhYCZ9oXQScgiBPJvgij7x1xaqv2VBZ7q0M5NmE0Y5Eht4FScOQYCcPa8PPvss3E/qkLFlH3r1q1bPI4UGLPXaVrOY8LPqKjT5sx5Yf8I3el92E+q7tltN2/ePAZy3jOLynM2aKbpC9nvZVvks7jnOI/pOCuTvX9qu29cI1S2L6XEAM7tt98ep29wrhl0YYpAv379KgyMJd9++23sjKBDgoGcmmDQg8Gl9KD7QJIkSTMHK90lRBWNFtuEai9/2FMBpBJJmyvVZSpghE5+RpU7O/+3NoszUYHdZ5994vzafATH7P6VGvtCy/TIkSMrrVpTaWZfqTozCMHAAxVSKpE1QcjLomqdFsRiPwiSBOhsMEehanVCBZdrw4NjYJ8JwXxd7OJzxaISzqADbeAEb64P3Qq1eZ/sueA8VHVu8hV7z9X2/snfN1S2L7XF2gdc5+xK5ODrbHcBc7UZMKAyTqs7HRj8PL+y/91338VBNKYhXHHFFTXeH1rYK5t7LkmSpBmble7piIBBBe2vv/6KXzPftnv37nGOK1VD2sDzFxCjKpj9qKR8zKfOr55SqaOdmcCf/+D5laGtmznXWXxNdTg/qKbnU7HLVqZffvnlqfaFCi+La+XvS/Yjtlj0i2og52TRRReNc48rO15UVTEuhO3zGiqq+fuRQlihc0krMgucMXeZheloW6+uKlvMeSz0XjyHReZ23HHHOIWA4Eerd0L7Pa/LbpvqMouVsVBYXSHwE4LpAijW9Nq3YrEvDPZkf3c4Jr7O78ZIIZ3AzQJqXF8WTMtWuFloju0xQFSoCi5JkiRVxr8eS4jFk8aOHRsftNgyR5eKK63KIGRTNaW6TbWNucJ33313hW3wcUcsaMV/2QZt0sOGDaswD/y5556LwYBqHZijSnhl4TBahQm9995771QLqeVjfjehhBZnwh4LYjFHOjvPOIv5vgTJXXbZJbaRs1AaAwhZVPIJNIRJfk57O3O5qWz/73//i18Ttqn6M+DAAl/sb2XzugnvVGKpilO1pFW3GOwn+8ICYSxkxvvS8s9cWxYWS+eS68M54FyyujedAQQ45vF+/vnn4b777qv286yLOY+Frhv3AxV+rh3Xmm6FbKWWyvJ+++0X50dz/Ays0ObMfjJvu66wb1xT5rKzcFy6Zszzrsz02reE6n+ausG/OY/8m6kMCR8XRlcJ55/zyf7RucBq5gkhmoEifv9Y6JDWcVaV7927d4XAzX3APG4+eSD9TkuSJEnFMHSXEOGDOas8+Hgqqn7MIU0fc0U1jT/wCcN8pBhhKy2+lfBcXkPY4zksfpZdzZrFrFhNm0pjatemOk6VksBHdZYq7/HHH19h7nUhVKUJVgwCUG3mNWy/spW6qfgxSEDlnrm7e+65Z1wkK4u5xIRLQgsrnROmCWHM6WalcH5ONZmV1gnGrNjNR30ROAuhBZjBCVbT5ngI88UiYBG6CcWEKlZN55qklntah/fdd9+wzTbbxHN55plnxv8yP55rQMWWind1i2gVcx4LXTfa6nktretcdyrw7GMW78+5YlVznkvIZN43i8jVJRZFY7G1/fffP1b3CdDZj5wrZHrtW2r35r7mQacF14R/cw8mXEe+z/nnd4dQzu9kdnE1Pq6Mc8x9yTVh0Ch7fRkE4TgYRGHF+fT7nOaiS5IkSdUpK2fJXklqgBiY4LPZ+Vg7gnNDxqAKC7HRHVAdPjKM6RU9TzotlNXhqu2afqPVC7VpHT6aMDHU7WoEpfHpEYPqexcaDKaZMIWErimnijQuXrvGzevXeHntivubju5bCoqV8cxJavDoQuDREDFtgsX4Ci0WKEmSJLl6uaQGi5Zu5vijoa7+zSKItK5XtxK+JEmSZk6GbkkNFnP4sx+71xCxsF9D30dJkiTVH9vLJUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEnNMtSfXkjYP3Cx07dqzv3VAN+fEpkiSpJvxrQZIkSZKkEjF0S5IkSZJUIoZuSZIkSZJKxNAtSZIkSVKJGLolSZIkSSoRVy+XpHqy3LDhoaxFy/reDdVitLp3+9ZhzPiJYUpoOD46cVB974IkSSrASrckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYihW5IkSZKkEjF0S5IkSZJUIoZuSZIkSZJKxNBdhB49eoTzzz8/NDTPPPNMKCsrC7/99lt974oayT3T2KR7nMemm24aGqITTzwxt49ec0mSJOUzdNfxH93NmjWLgWvQoEHhzz//LOn7rrjiiuH7778PHTp0KOn7qO7tuuuuDTZEFrLPPvuE+eefP7Rq1SrMPvvsYZNNNgkfffRRhec8+eST8Z5s165dmHPOOcOQIUPCf//9l/v5mDFjwuqrrx7mmGOO0LJly9CzZ89w7LHHhkmTJlX7/rz22muvzX393HPPhY022ijMPffc8ffunnvuKXiO0+9leqy33noVnvPLL7+EHXbYIbRv3z507Ngx7LHHHhV+b7O/29lHmzZtcs857LDD4u/hvPPOW4MzKkmSpJmFobuOLLLIIvEP7y+//DIMGzYsXHHFFWHw4MG12lZ5eXmFsFKZWWaZJYYbQoBKr9jrMiNaaqmlwogRI8Lo0aPDo48+Gs/FOuusEyZPnhx//s4774T1118/htq33nor3HrrreG+++4LRx55ZG4bzZs3DzvvvHN47LHHYoimKnzllVeGE044odr379KlSwzFyYQJE8ISSywRLrnkkipfx/7we5keN998c4WfE7g/+OCD8Pjjj4cHHngghvm99957qkCdfSy88MJhq622yj2nbdu28fewadOmRZ5NSZIkzUyaTGvLbN++fWM1KCEAXnXVVWGzzTYLrVu3Dr169Yp/fOe3i1IVW3rppeNzqI7xR3jy2WefxUoaFTH+oF1mmWXCE088MdW+nHLKKfGPeJ7TvXv3+D4//vhjfC3fW3zxxcPrr79e4XUvvPBCWGWVVWLFrmvXruHggw+Of8An48aNixU0fj7ffPOFkSNHFnVuqHDzhzfVrm222Sb+MZ+O+4YbbojHmiqA22+/fXyf/HPy8MMPx3DTokWLcM0118Tv5VcTzzvvvFhxLNReTiWQYEJ46N27dzy3W265ZZg4cWK47rrr4jmbddZZ4zGnsIRff/01nkd+xmsGDBgQPvnkk9zP03YJW3369InnNoWZ5LXXXgtrr7126Ny5c6y89+/fP7z55pu5nxPSuE+6desWj48KJftRGUIcVVHOGVVIzku6lml/qG5yf1E1XXfddcM333wTauKff/6J+0CgYxsrr7xyPI6qrgv3TzH3Z1U4D1yPe++9N1c55b1AdXjBBReM14FK8HHHHZerBHMO11prrXis/DtVarnnjj/++Pj1lClTwtChQ+P32F9+Px955JHcezMoxPvddddd8fzyPoTXUaNGVbnPBNFVV1013kP9+vWLv3ucb7YHQja/b+zHAgssEK//mWeeGUPxH3/8EZ/D8ey2227x/fh93XjjjePvyfPPPx9qinuUfeB/Z6rCOeB3Lj24xxMGEDg3/O/VcsstF6//RRddFG655Zbw3XffVQjU6fHDDz+EDz/8MFbEJUmSpHqrdJ900klh6623Du+++26sfvGHNeEg65hjjgnnnHNODFIE1t133z33M9o7eR3BnKoZAY8g/PXXX08VQFdaaaX4nA022CDstNNOMTzuuOOOMfARTvk6BRTCEtvaYost4r4RFAhRBx54YIWWVMLE008/He64445w6aWXVgjIxSK0//vvv/HfhKaTTz45BkmCIkGF98lHVfCMM86IYYCwTFDPD/18TWivDAH7wgsvjMGBQEGYI5g89NBD8cEAwOWXXx6PLXvMXAcGCQhfnC/Of7btl+2effbZ8fVUA7kWVAETgtUuu+wSz+fLL78cwzDbSIHrzjvvjNeL9ybQcx4WW2yxSo+De4bgSAh+44034rmhUprdn1NPPTVcf/314cUXX4wDD9tuu22oiSOOOCLuFwGY+4WwSKDNv1ez14VgWez9WRnOG78f2SosA09gkIFBBYLdBRdcECvBnDcQltlXzgnXGPvuu2+YZ555cqGb1/B7xbXiHud4CLfZQZT0+8d+vP322zHkb7fddkVX8RmkourNoBQDV2kAg4GL/N+Bv//+O16/Qj799NN4jxLQS4X7n0EVBqH222+/8PPPP+d+xr3O4A2/ZwmDGk2aNAmvvPJKwe0R0DlfDNzVBOdn/PjxFR6SJEmaOTQrxUYJcfwRj9NOOy0GhFdffbXCfEoCU/pjm1BDaOYPdP5wpxLGIyGw3n333TEUZgMywYe5piB0DB8+PFYdU+snVcMVVlghVqeoUp1++ukxzA0cODD+nGDIvrEfvJbQRFWTfWU7uPrqq2N1tyYIGTfddFNYY4014tfZAQWqfbwn2ye8UUlLqFBSLU7Y14svvjgePz7++OO47RtvvLHS9yYocyypGk54JyhzDngvWmOpcDKoQEWeMMZ5Jbim4EewJ0wRjNO5ZLuXXXZZbrtcB/Y3Scea0F5PoHn22WfDhhtuGM8t14BQQ3im4r3ssstWehw8//DDDw8LLbRQ7lrlHyfnhgolCKNcJ65dVdvNBkfOEwGXqikIuLQZc81578quS6dOnYq6PyvDdSCQEsQ4J1nMcU6oKhOMGUBhgAAEbAYuGEwaO3ZsHEgh+DNwBcI2930agGCqA9eaDpVsKzbb5XcuDZIxPYIQnM53IQxAsR+cO0Is54opDiDc8x60bzOgwL6l+yPbEQHuMwY5OH4q6Nn7qC7xvzebb755HBxgwO3oo4+O15qwTSs4+0ggz+I8cn35WT7+94nfjWzLfLH43x7OsyRJkmY+Jal0Uw1MWHCI9uD8anH2OXPNNVf8b3oOYZRQQIgiuBFSqDLmVxKz26DVF9nqafpe2i6VZkIW20sPwgItuV988UV8D/7oppU4IYRk55JW5r333suFKUIfYZ9QCIIylVCCJpXMNNiQfzzZihsITlTFqRyDP/hp7a0qGNEunIJxOgeEt2y453vpnKRjTuEVs802WwxV/Kyy7XLNsteUUL/XXnvFcEx7Odec65iOkfD+119/xUEHnkdIraqyeuihh4Y999wzhnSqzISmLPY5DYxkr1N2n6vC9gjudEokDAZw7fK3kX9dir0/a4PuC/aJMM52CeH52+Vc0r3AeSFkpwEJqqe0RWePCXydf0xV/f5VhkEgAj4DKVR7CdcEUTC/+6yzzoqVd1q6+TmDYqBynH+MhG4Gph588MF4DKXA7w9Vfv43gUXrmHZBl0Bq5a8p7tnU0VFTRx11VPj9999zj5pOhZAkSdJMErr54zm1aieFVh7OtgGntliCbWXPSQuBpecQaPgDlyo58z1pgeUP59SuXdU2qtouYYnKONtLD4I41d5soKwNQirbI9wQLql6Em6pChLsCaGEZv7o59iQfzzZFZFB8KKCTDgB/yX4VKXQuS/melSn0Day9wJBhOOnvfmll16K/ya8p2Okcs68faqlDEzsv//+cY5wZStXM++ZBa6oxj711FOxQp/O2/SWf12KvT9rigos15ewSkAk4NIGnr9dWusZyKFam982Xqyqfk8qw2AKAZ/rxvQE1hvIXhMGSmjzZ5Dgp59+ivPewUBLFvcC15NuGAYOuNbZNQZKhf1gzQEq+un3K3+ggYEgphfkdyCk1nK6NtJgXk0wEMH/BmQfkiRJmjnUKHTzUUHZVlEqa1SI6xqtzrSoU80jzPAHcFqwaVpQJWauLHN38x+0yVIt5Y/u7BxUgmIxn4PN69kOVeXUcguCCfNICRfMA+U9ajJHnBBGZZBA9vnnn9d43nJ1qNZyzNk5rOwvx00wqsk1Y1EyAiOtyoQMglcWYZuKP+31VBs5JjoEKkO1lI9eY7Vr2oSZR5ywz9lF8tJ1KnYqAIMsXCf2O2EAgEGR6o67Lu5P3js/aDJYwQJjBG2q6wTcr776aqrXsio+A2BMheBcMigBghwL1GWPKe1vTa5lMRhw4UGLeBYBnn3gWtNqTsDm964yBH3Oe00HgWrjf//7X7y3U2WfbhTumezvO+eSfcl2foD/naNN3wXUJEmSVNI53VRdac8mONFWyzzqUnxMDmGD1ZV5H/6IZwXnuvijnLmuyy+/fJx3S+syFUxCOHNTaQWnWs08UKrhzPelhZn53wSI2qKlnIDFqsi03r7//vu5OdrFIGyyABQP5mITaOr6XFORpOWbucK0vzNnlbnDqVJZ7HbSKu0MxjAnOnveuG8ImYQZWtWZl87PCZn56BTg9cxHZz4uYYkwzAJ42UrtQQcdFEMn14lryrVN87mZ2828ZxY741jyce05p7wPc3i5Tqy2TRW5umBVF/cngzOsBs9gAR0BqYpMlZg53LTO03qdX93ne6xsz4AFYZb9p8uARdNYmZuv+QguBhVYuZyBCirxxa7CXwiDPQz80ELOwBvXg0Ekrl9qIQft5fz+MCDA+eE5t912W+5/I9gHrhsDFQzKMGhC2zVrC+R3UlSHrpVUsU6hmONM15KfM4eae4ZBEaYTMB89LZYHBmjYX+591isg/HMfMbCV/3vGOSesp/n/kiRJUkkq3fyBzHxkWixp+2We5LS2ZRdy7rnnxgDBgksEG/5IrqpaVizmsTIflQXJqDovueSSceAg+wc2IYWvOU4CLws95S+2VBOEFALn7bffHquNaR5usQjBnAPa4KtrLa8tjpl57FxXqn9UMFmgqyZBiMXH+OgxrhOryKeP4koYpGGhMuYXcx34iK37778/Bs58hDQqkoTmNHeYsJNdiIrgziAKK7mzTeY/EwwTwjOBtrL2dXAtCGXsL/tNiCMIZz9WqlT3J0GPQR4GKbhHqEYz/5jKPsGPwEzlm0Cf8HF4DAjQjp3ej3NCuzMDOuC80+ZNNZxwy+rgTHXIX4iuJljckDZ6AjahlZDMfcn+Za8xlXd+rzgmBgf4SDT+NyJhcISF3RgY4R5g3zlW2rZrisDO7y8PcMzp9zndQwxEcE65hzhv3OMcB4E/YSCA7pM111wzHh8fG8YigFkMqPA7THeDn8UtSZKkmiorz5+kLTVwBCA6EIpp+1fjxjQEOjwY0ClmQcP6RPcC92X6dISq0A1Cd8OCR54WylpU/Kg1NY7R6t7tW4cx4yeG0k+MKN5HJw6q711o8BhEY4oXA4b5izyqYfPaNW5ev8bLa1fc33QslFvVmj2eOUkNHp/Znj6GsKFhQT06Lepi9XpJkiTNeEryOd2SVBdYAyCt0J792LuGhNZ+pkCAqQKSJElSlqFbjQ5za3loxsdibcwjb8hYvI2HJEmSVIjt5ZIkSZIklYihW5IkSZKkEjF0S5IkSZJUIs7plqR68sqQ/Rr8R6Fpan58iiRJqgn/WpAkSZIkqUQM3ZIkSZIklYihW5IkSZKkEjF0S5IkSZJUIoZuSZIkSZJKxNXLJamerHT88FDWomV974ZqMVq9YKfW4eNfJoYpoWF4/6xB9b0LkiSpEla6JUmSJEkqEUO3JEmSJEklYuiWJEmSJKlEDN2SJEmSJJWIoVuSJEmSpBIxdEuSJEmSVCKG7iL16NEjnH/++dP9fZ955plQVlYWfvvtt+n+3iqdL7/8Ml7Xt99+u753pdG79tpr47nkMXDgwHr7HeWx6aabTvf3lyRJUsNm6K5j//vf/8Iss8wSFl100Rq/drXVVpsqNKy44orh+++/Dx06dKjDvVRjUF8DPbV18MEHh6WWWiq0aNEi9O3bt+BzHn300bD88suHdu3ahdlnnz1sscUWcQAiP8T269cvbmeBBRaIobo67du3j78nJ598cu57f/75ZzjwwAPDvPPOG1q1ahUWXnjhcNlll0018FHocfvtt+ee9+STT8bfQ/Z5zjnnDEOGDAn//fffVL+jW2+9dY3PmSRJkmZ8hu46RkDgj+/x48eHV155ZZq3R4DnD32CgBq+f//9N8zMdt9997DNNtsU/NkXX3wRNtlkk7DGGmvECj8B/Keffgqbb755hedssMEGYfXVV4/PYRBqzz33jM+tCr8f/J4QjJNDDz00PPLII+HGG28Mo0ePjtsihN93333x5127do1hOfs46aSTQtu2bcOAAQPic955552w/vrrh/XWWy+89dZb4dZbb42vP/LII6f6HSXYS5IkSdMcugtV36hqnXjiiRX+AL7qqqvCZpttFlq3bh169eqV+0M3245JBWnppZeOz6FaNGbMmNxzPvvss/gH+hxzzBH/CF5mmWXCE088MdW+nHLKKWHnnXeOz+nevXt8nx9//DG+lu8tvvji4fXXX6/wuhdeeCGsssoq8Y9k/vCmQjdhwoTcz8eNGxc22mij+PP55psvjBw5sqhzU15eHkaMGBF22mmnsP3224err756que8+OKLsaLNMc8666xh3XXXDb/++mvYddddw7PPPhsuuOCCXLWNSlx+ezmhvmPHjjGE9OnTJx4jgYDAkEyZMiUMHTo0VvhS1ZHwkV/hu+2223LngfP78ccfh9deey1ekxQ8OJd47rnnQvPmzcPYsWMrHA9Bhm1Ud3xpv04//fR4TnnPJZZYItxxxx251/K8HXbYIVZA+Tn3DeezMrx2scUWi8+dbbbZwlprrZW7jpxPWn0JUWyPSui+++5b41D89ddf5+4ltsGAyg8//JD7Ofc955f7neNq2bJl/D7ne+WVV47Xin3bcMMN4z1dLM7hV199FQYNGpS7H/Dzzz+H7bbbLswzzzzxHHP8N998c+51XC8C4GmnnZb73ksvvRSDIb9v6TzzO8P1YRtc508++ST3/GLusUIuvPDCcMABB4SePXsW/Pkbb7wRJk+eHH9n559//ljNPuyww2K4njRpUnwOlWjO4znnnBPfm5C85ZZbhvPOO6/oc5c97l122SWeS/63Yu+994733Kuvvhp/3rRp03iuso+77747XmOOGYRs/jfk+OOPj1X3/v37hzPPPDNccskl4Y8//qjxPkmSJGnmU7JKN2GHP17ffffdWCkiTP3yyy8VnnPMMcfEP64Jxc2aNYtVsmxrKK8jKFBh4o9+gjAhKIs/xldaaaX4HCpkBF4CxY477hjefPPN+Mc9XxOIQfBhW7S1sm/8UU0I54/7hMD2zTffhKeffjoGu0svvTQG8erw/IkTJ8bwx/vfcsstFcI84WLNNdeMba6jRo2K78sxEUQI2yussELYa6+9clU3BgQK4T3OPvvscMMNN8QwzDkhvCRsi/PKczhGgu/GG29cIVjhhBNOCMcee2w8T5x/BgqOOOKI+Prnn38+fPrppzFsYNVVV41hivdMCEoMSKTrVtXxgcB9/fXXx2D1wQcfxEDJeWKwAccdd1z48MMPw8MPPxwrk8OHDw+dO3cueA44P4RP3pvnMjhBxTRdZ3DvpJ8RTO+66654XxaLQQICN/ct+/j444+Hzz//fKpKLufpzjvvjNtPc7S57lRaubfZjyZNmsRBKLZZDLbFoAmDJ+l+wN9//x1buB988MHw/vvvxyDJPZ+CJAMM11xzTRwM4L0Jhvyc+5trk+5vfsYAFdeJc8bvWgq+xdxjtcF+cx4YSOGe+P333+P2+X1hQAfsD19ncf/y/ZpiII9j/Pbbb+Mx8vvJwNI666xT6aAA12+PPfbIfe+ff/7JDaQkDPJwHXh+sdgO3S/ZhyRJkmYOzUq1Yf6wJxSBqhtVMIIBgTc59dRTY+UItGsSmvljlj9yqUjxSJirSRWKP6KzAZmwsM8++8R/ExAJalRtt9pqq/g95l8SZqlOUski+DEAkOZOU01l39gPXku4IPSxr2wHVKypulWH52277baxgsacbkIqc0M5F6BCRhWZEJ8sssgiuX9TjaTyyH5WhXBEcGVAAZwPwllCWOK42RcMGzYsBg46FKjQJYQoAg0OOeSQeL0IiAxigPCRnU/L1wSmww8/PH59//33x+uV5rJWdXyEDu4DuhW4HuD8EMwvv/zyeP4590suuWTcBqhOVoYQyrxagjYdDqDqm8X5JIByTtkPzhH7zr1E+KsO5+K9996LLc9pAIRBA7ZFR0C6P6ie830Cb8KgThb7wc8ZVChmvn+nTp3ifZTmESdUuLPh96CDDooVaboWll122dzvBIM33OecyzZt2sT7Hgy88DtERwKhFAyccHz33HNP7vemunusNqhgP/bYY/F+4XeW4M298NBDD+WeQycF3S1ZfE1I/euvv2rUwn3RRRfFQQkGLxhU4ppfeeWVcQCpkPR7ns4L+P3g94ZBG/ab/UvnobrKfxbnvyYDPpIkSZpxlKzSTUtmwh/9tObmV4uzz5lrrrnif9NzqHQTLvgjmFZX2j2pWuZXurPbSH+sZ8NX+l7aLnM0CZJsLz34w5oKJOGK9+APdKpyyUILLRT3oSq0f1OdpHKb8O9si3mqBE8rQmQKQ+ncpeMjnHz33Xe54JzwNcdW03OXvWYMHlDVffnllyvMX+f6Vnd8vI7q6dprr13h3BNWU9v1fvvtF7sDaNem4k57cGUYkOG92F+CImEqtbFnn8O5Sgh43Fd0MRSD80UYzXYcUMXnXsieS0J/NnCncMsgBgML3PtpACH//q0pgiqDBhw3wZxzSOjO3y4DLwxKMOhDqGaaQTom7u/lllsu91za33v37l3hmKq6x2qLwMpgAC3fDFrQPcDACO3j2Q6FukLo5l5lkIGqNN0ftL/nT1MBgf6mm26qUOUGVfGzzjorTk3gHC644IJxUAPFDNwkRx11VKzsp0ex96AkSZJmwko3f2jm/4GcbUtNUrtowpzU/Nba7HPSnNX0HAI37byEB+ZSUuHij/P8ObmFtlHVdgldVNmYx52vW7dusf20NviDnapvNsxwnnhftskf63W10FKhc1ub0FLMuctesy5dusR2cardVC3pCKB1O6nq+DjvoC2aam1WCoTMLWYeM5VPrj2hmpDEPZCPKjDPIZhTPSVgMV2BxevYt+kpDTpkcZ4I4wwGzD333PE8UuGe1oXWCIC0/1N9JXjz3nRt5G+XgQwGX3hf5vDndwFMr3ssiy4LVuGnIyJhkTMGNbhurGpOVT87Zx58zcBFTX5/CNFHH3107I6hgyYNMjEwxP2U38LONBIGhZiKko9pAkyFoLLNPHjOJyG6srnrhXCPp/tckiRJM5caV7qp6GXbKqmsUiGua7S/UlllHiyBgT/G8z9aqDZYvIkWX4J8/oOqG1VtKoTZ+Zos8Fbd52RT0R48eHD8oz49qKqzyBitxemP/rSYVSG8f5r/XFuEE0Ie5y+Lr6nSTitWkmYe/BVXXBErodmKelXHx3sTOqjI5p/3bCWZ+4tKKGGMYMn7VIYgyPvTtsucfs4fISvh/BO+EqqeVIYrmyufjy4LKpLZqiT3DvdCVeeSxc64Z5gvz8AB28mvwhej0P3AdWSeOV0UVPIJfvkDRQRwfs7cc6riXLNUpWZfuL+zK+un/a2L+6MqhNr86jCDJ0iDO3Qj5N9DDK6kKQnFYiCQR6H3KzSvnt9f1j3I71jI3mv8XhH8aTXnHuJ/SyRJkqQ6D9183A+LH7HQFvNdCUjpD+e6xFzrtDAV4YlFvopdhKoqzHWmOsocVbZNG/C9996bmydOmy3zzqmGE0wI34SWqqpsbIfFyHge1czsgxbj6667LgYdqmO01e6///5xgbOPPvooziPnY5NACzLvyeAC36vt8TJvmXnchGPCFPPl2UfmbU8rWvEJ9qxAvdtuu1X4WVXHx9xkuheoGHI+qMRyzqhQ83Wak8+1oBWdhdYeeOCBSufSc56YI86CYAR57hVW7s4+n/BJuzBBmeo5C8dxnVMQu/jii6ts96cayoAPc6PZV+b5Uwll/nmad14I1VBathkw4FieeuqpWC2tKe4HFjFjIbB0j/B7kSr8tINzn+ZXhqn408LMWgXc73RZpMXueD2hnTZv5tPzu0VAp/uA708LjpX7jDZyBjvS4FOqwlNx5v5gTjS/d5xT7iE6ApjLD9q4WayO6QXcP6wPwHx17pua4B7lOvG7QDcGA4NMh2A6AwN5+fvNeeb3t7LuAv63jnuSQYwzzjgjnttS/O+eJEmSZjw1Dt0EK/6Y5SOQ+COaj2XKzv2sK+eee24MLyxqRKsuYa8uKktUY5lLSnWQKjR/7BP2qGIltE/zNcfJQl0sxkRrdWWoklElpEqejz/wqTIS+gg/tEITdFj0iuodIZM5tiCU8oc826LiVtv5v7TOE/KovBMa+fgq5rUSuKYVgZUOBCqw+a241R0fgYUVyllUinDM4Abt5qkdnMou9xfXiMWuOBfM8a4sVBGUmF/L+1JVZs5u+nxlEKg5ZrZF1ZdKZvaj7QiyVX2MF9VN9p/7kG0QwqksM5hR3TlivxmwYeCFwEhwqynCKQMw/H6lCizHye8Bvw98FBYdIPwOJgRMOgQYGOMcsS9pkIwBkHR/s2YBv8NcI9rGuT/zW8pritDK7xML4/H7xb950OaeBuyYhsGCbXyf60/3A/dnGtTiXuCeYGCBSj7XlI9jSwv+1QTXgMXuGDThd4qwzOKNBPssOlFYbK2yVc2ZRsH/VjDQwr5xT2TPuSRJklSVsvJSrGCkGRrVY6rK2c9eb2gYGKANnICnGRsVbOa1VzcFpCHdc0zLYX77wgedFspaVPxIMjWO0eoFO7UOH/8yMUx7/1XdeP+smnWDzKzoIGMgnIH0miyGqPrntWvcvH6Nl9euuL/p6DKl4FUZz5yKxs1ESzLVSj6qSmpI9ybz9Wmnn97oIuC9WSVekiRJmm6f060ZD3N+mddMey4f/SU1BHwm+sorrxz/Xd1H+5UCbefMXQfhW5IkScoydKto2Y8Hawwtx5o5sEgfj/rCfHRW4ZckSZIKsb1ckiRJkqQSMXRLkiRJklQihm5JkiRJkkrEOd2SVE9eHLpfvSz+pmnjx6dIkqSa8K8FSZIkSZJKxNAtSZIkSVKJGLolSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqURcvVyS6slqRwwPZc1b1vduqIaalIWwQOfW4dOfJoYp5dP//d+6ZND0f1NJklRrVrolSZIkSSoRQ7ckSZIkSSVi6JYkSZIkqUQM3ZIkSZIklYihW5IkSZKkEjF0S5IkSZJUIoZuSTVSVlYW7rnnnqKff+2114aOHTtO0/vxmJZtlNKXX36Z28e+ffvW9+5IkiSpgTF0T2c//vhj2G+//UK3bt1CixYtwpxzzhnWXXfd8OKLL9Y61EyrXXfdNWy66abT7f3UuH3//fdhwIABRT9/m222CR9//PE0veeIESMqbIN92H777cOCCy4YmjRpEgYOHFjl62+55Zb4e5W9zydNmhSGDBkSFltssdCmTZsw99xzh5133jl89913FV576qmnhhVXXDG0bt26YPDv2rVr3J/BgwdP0zFKkiRpxmTons622GKL8NZbb4Xrrrsuhoj77rsvrLbaauHnn3+u0Xb+/fffku2j6s6MeJ0YKGLAqFitWrUKXbp0mab3JOxmt/HPP/+E2WefPRx77LFhiSWWqLYSfdhhh4VVVlmlwvcnTpwY3nzzzXDcccfF/951111hzJgxYeONN57qGm611VZxsKyQpk2bxnPStm3baTpGSZIkzZgM3dPRb7/9Fp5//vkwbNiwsPrqq4fu3buHZZddNhx11FG5P/R79OgR/7vZZpvFylz6+sQTT4ytq1dddVWYb775QsuWLXPb3HPPPWMAad++fVhjjTXCO++8k3vP9LrLL788VuSo1m299dbh999/z/2cAYB777031yL7zDPPxJ+99957cXuEptlmmy3svffe4c8//6xwTNdcc01YZJFFYgiba665woEHHpj72ddffx022WSTGEbYN973hx9+qPD6+++/PyyzzDLxeDp37hyPOxusqESy32x/gQUWCFdffXWlLct0B7D/CeeB89yuXbv4/ksttVR4/fXXK70+vHb48OGxissx9+zZM9xxxx0VnsP+UF3lPPJzAhsV0/zznX+dHnnkkbDyyivHfeZcbrjhhuGzzz6rEOw4d5xDXsO9cfrpp+d+fu655+YqspyP/fffv8K1SOfj0UcfDX369InnfL311osV2OS///4LBx98cG4fOJZddtmlQvWX++3888+vcMwcD8dVqBMjtVYTWDnXnBdC8KhRo6bat9pel0LYzwsuuCBWpjt06FDp8yZPnhx22GGHcNJJJ8XrlcXrHn/88Xhf9u7dOyy//PLh4osvDm+88Ua8dxNeO2jQoHj+JUmSpJoydE9HBCEeBBYCZSGvvfZarp2WwJS+xqeffhruvPPOGHDefvvt+D0qcOPGjQsPP/xwDAv9+vULa665Zvjll18qvO62226LAZfwR6Wd0AYqgISOFNB40Eo7YcKE2PY+66yzxn24/fbbwxNPPFEhVBNQDzjggBjGCehU7QnGmDJlSgzc7Mezzz4bw83nn38eW42TBx98MIbs9ddfP+7Tk08+GQchEgLVzTffHC688MIwevToOHBQk2oiYWveeeeN+8+5OfLII0Pz5s2rfA0hmm4EgiGv33bbbeN7JwRFQuSHH34YQ9+VV14ZzjvvvArbKHSdOJ+HHnpoDJccJy3RHDvnCRwj54/rRLV15MiRuQEX8Hye88EHH8RBkqeeeiocccQRU1Vuzz777HDDDTeE5557LgZHrm/CYA/b5d5iOsP48ePrbBrDMcccE9+L42VQYrvttoshv66uS20NHTo0Vsj32GOPop7PYFQp5o/z+875zj4kSZI0c2hW3zswM2nWrFkMbHvttVe47LLLYkDu379/DHaLL754fA4Va/BHPy2rWVRDr7/++txzXnjhhfDqq6/G0J3afQldBCkqtIRh/P333/F188wzT/z6oosuChtssEE455xz4ntQ1SUUZN+PYJdeR3UVVAE32mijGN7mmGOOcMopp8R5rIccckjudVStQbAkiH/xxRexMgu2RVWcsMXzmCvLsVNJTFKrMK33BFDC+lprrRW/l1+prA6h8/DDDw8LLbRQ/LpXr17VvoZBDDoHcPLJJ8f353xdeuml8Xv/X3t3Aq9jmf9x/Dr2LefYOcmStYQsWV+RCammpClDjT1iipqkIms1pWgkqYkRKUKvMIUpVBpZK4QyQvaxlKxZ4/6/vtf/f53//RzPWT33OedxPu/X6xnnPOt939ej8b1/v+u61c7sKBQraGq+sD8AJx4nUZBP3CGgxxXer7vuOrut2j5VwxX6VOn2889Z1ufq2Pfu3Tthu0QVd32vKlWqZH/XCRKFTkf7oa4K102g8VywYIGJBB0HfadE46lx1skHd+wvdVzSQ38/1BnhTnykRN93Vf91wkAV+EhS14L/ew4AAIDsg0p3BlP40kJNqmqquqxWboVvhfGUKIj5g5yqsWoxVquwq6LrpqDrb13Wom0ucEvjxo1thVUV1aSouqsA7AK3NG3aNOF1CvraD1XVk3q9wrYL3HLttdfakwmucqwwlNTr9ZjmyuqkRHqpsqwArdA+cuTIkGOSFB2bxL/7K90zZ860x8HN4VUI97cihxsn2bJliw1zOnGgQOeq2O61WsxO+6w2Z7WAL1y4MOT16jLQsdI4qtreqVMnuw6AqtuOWrtd4Ba1qmucXAVXrf3+TgIdX7V2R4I7aeQ+V9xnR2Jc0ur48eP2GKkTQdMWUqITFur48DzPdnBEmk52aAzcbffu3RH/DAAAAGRNhO5MoDm7rVq1sq3My5cvt4Fr2LBhKb7OH4BFgVsBR2HNf1MoViUxSKqOB/keKb2/2q0VkPz8c6tF85DVjq0KrNqxFfrnzJmT7u3VPGW1Rqsdft68ebYlXm3ViRdLSzxOog4BtdorBK5atcrexL1WJ150skTV9VOnTtkAeM899yTMm9YccAVbta2rJXv8+PEhr5fELdqqmCc+RilJzXENx//Zbl69a51PLNLjEo6CvI6bjrs6THRT94FOdulnf9B3gXvnzp22syHSVW5RJ4re138DAABA9kDozgIUOjTn1x9gtABUShTU9u/fb0OE5lL7b/7qnqqp/ssgrVy50oYrVVUlT548F32eFuNSJd2/XZoH7F6naquqtWojD0evVzXPX9FTK7UWftP+ikJkUq/XolUKbZoPHo4qyapm+rcvXBux5hdrESxVju+++247nzk5OjaJf9e+iE6QqIqtoF2/fn3bFq2glhJVpHUiRFVxVav1focPH77oeQpimvOuYK6KugK2grpCto6FpgNosS/tU+LLWqVEi4ZpSoB/jQCNuVbtTnxc/Yuvae6xTgZEWlrHJa3Uuq7pDf6TUVqsUAu46WfXgeECtzoR1E2grhEAAAAgkpjTnYEUvjRnuHv37jZwKrhqYa2XXnrJLjrmuDCrNmZVyLSYWThqz1X7s1af1nu4MOYWKFMwdJV1rVKt+d4KUWpfVtBwc7j1eVr1WsFQoUMBTRVdVd/1OlUmdX3xvn372pZdhTfR/ZpXrIWqtOK3QrCCuZ6nbVNw1vtoNWwtqqXF29Qu7rZL768QqpZoze3WczTHWPNqtU36bB0rLSCmVncFXLUsa9sbNmxo26kHDRpk90eVY3+LvqrFqvarWqxVxPfs2WMDZ+K51YlpwThtn+ZWa9ExzZl3K6YrZOsEhuZwa066jnNqKrQaPx3XCRMm2M4EvYcWD/PT6uR6rE6dOvbEhrZD46N2fJ1EUTjUnGxVbnWMNXc7rTQumlus91Mo1fsp/PtXfNdq9TqO+hx99tChQ20beqSkd1zCcSdZ1PGh76d+1wkkndTRd15z5f3c4mjufh1TbYdOPKhzQSchdBJLihYtat9LNF46+aE/9Rz3uTqOXCYMAAAAKaHSnYH0D3SFRa123axZM/uPf7WYa2E1LWrlqKKpNldV4xTCkqKwpJCq9+rWrZsN3QqvCqcuGLtwoGqi2qJbt25tA79/AS59vqrXCpuqdCrUKdAqiCtsKGAqnCgg+7dToViBWu+lhbPUAq2Kods2XYZMgVPbpxCu+cyq4Dq6PrnCpVp+dVkqBT6FXEdza/W5CusKidpOV9lWKHr33Xft/ivca5Vz/2WtFBR1kkMroOu4KKjrxEBKi1npcYVqHSO1I+t9XWVelVJVZ7VAmbZXlW+NX0oUovWeqlhrzPUeo0aNCnmOTsDoxInGQMdbrdHaN71WJxwUyrWAnV6vkwH+y4mlllskTMdEJ2v0fdQK9e6yZm7usU6MaCzV/q0TOv554pcqveMSjv5u6KbjOn36dPuzvuOptXfvXvvdU/DXeOqkh7tpbB2deNB76ySRAr773LRe5gwAAADZU4yX1kmfiCoKolrNPLUrOGdnOlGgyrX/utWXM7Wsq9VdwVdzybOqaBmXtPxdU8eJOkpq93zexOT+/5MeiA45YoypXLyA2frzSXMhE/4fdO34v2T8h15G/91Tx5Q6tHRSE9GDsYtujF/0YuxS9286LZSb3Jo9tJcD2YQ6IDSHWpVsXSJOXQuar33fffeZrE4VerXoqyqd1ajtXN0QWtTOdUUAAAAADqEbyCZ0dlLztXVNbTW4qFVdi4e5heKyKjdlIZJzyyMpPj4+obqtNRgAAAAAP0L3ZU4tr/65zkja5T7TQmsEaL5+tNGaBFmZu3oAAAAAEA6N+QAAAAAABITQDQAAAABAQAjdAAAAAAAEhDndAJBJlrzUx8TFxWX2ZiCNuHwKAABIC/61AAAAAABAQAjdAAAAAAAEhNANAAAAAEBACN0AAAAAAASE0A0AAAAAQEBYvRwAMknLh143OXLny+zNQBrFxBhTuVQBs/XASeN5aXvt6imPBbVZAAAgi6LSDQAAAABAQAjdAAAAAAAEhNANAAAAAEBACN0AAAAAAASE0A0AAAAAQEAI3QAAAAAABITQjUDddNNN5tFHH83szTAxMTFm7ty56X59hQoVzCuvvBKx9wtS4m0NwpIlS+wxOHLkSJLPmTJliomLi7ukzxk+fLj9HN2C3qf06tq1a8I2ZtXvBAAAADIPoRvpChi9e/e+6LGHHnrIPqbnOLNnzzbPPvtshgZChAoiDDZp0sTs27fPxMbGmqDVqFHDflavXr0S7pswYYI9oVO4cOFkw//8+fNNw4YNTf78+U2RIkXMXXfdFfK4C8v+24wZMxIe//LLL03Tpk1NsWLF7HtUr17djBkzJuQ9xo4da7cPAAAACCdX2HuBZFx11VU2mCh8KIjI6dOnzfTp0025cuVCnlu0aNFM2koEKU+ePKZ06dIZ8lm5cuW66LNOnjxp2rRpY28DBw4M+7oPPvjA9OzZ0zz//PPmd7/7nfntt9/Mxo0bL3re5MmT7fs4/up8wYIFzcMPP2xq1aplf1YIf/DBB+3P7iSATjxkxMkHAAAARCcq3UizunXr2uCtKrajnxW469Spk2R7uX7euXOn+ctf/pJQVRTdd8cdd9hKpMKMKpsLFixIskVZVVv3WueNN94wlSpVsmGwWrVq5p133kl2H4YNG2bKlClj1q9fb39XmLrxxhvtSQTtW79+/cyvv/6a6mPy5JNPmqpVq5oCBQqYq6++2gwZMsScO3cuyefv2LHD7sOsWbMSPveGG24wP/zwg/nqq69M/fr1TaFChcytt95qfvrpp7DH01H11t9d4KfOAmnXrp39PPf7tm3bTNu2bU2pUqXs5+izFy9eHPLaM2fO2P3S8cibN6+pXLmymTRpUpLt5RorfQd0DPR5hw4dCnm/1HxmaukYPPXUU6ZRo0ZhH1fAfuSRR8yoUaNsV4bG5tprrzXt27e/6Ln6finUu1u+fPkSHtP3uWPHjvY7qWP3pz/9ydxyyy1m6dKl6dpuAAAAZD+EbqRL9+7dbYXQeeutt0y3bt2SfY2CedmyZc0zzzxj23FdS67a0hXw/v3vf5sNGzaYF1980Yay1JozZ44NWP3797eVTFUitS2ff/75Rc/1PM/07dvXTJ061QYnVTAVBlXp/MMf/mBD+MyZM20IV4Uzta644gobOr///nvbbjxx4sSL2pCTCv+DBw82a9assRXd++67zzzxxBP2PbR9W7duNUOHDjXppQAvGisdb/f7iRMnzG233WY+/fRTs3btWrv/OvGxa9euhNd27tzZvPfee+bVV181mzZtMm+++WaS47Jq1SrTo0cPe8zWrVtnWrRoYZ577rmQ56TmMyNFx3Pv3r0mR44cNjjrBItOYISrdOv7V7x4cdOgQQP7PdZ3JCna7uXLl5vmzZunaXv0/T527FjIDQAAANkD7eVIF1X81NarKrUsW7bMtpyrApoUtZrnzJnTBlR/u7BClwJvzZo17e+qFKfF6NGjbaX3z3/+s/39scceMytXrrT3K/z5q5/abgUnheorr7zS3v/CCy+Y+++/P6GCXKVKFRs0FaxUQfdXPpOi4OyoIvr444/b46EAnRw9T5VT0YkDVVUVSjWPWBRkFebTq0SJEiHVXKd27dr25mjevU5efPjhhzY4q+KuKvyiRYtMy5YtUxwXnSRQiHb7q8qywunHH3+c6s+MpB9//DFhIba//e1vdkxefvll2ymgfXPTHnQCSK3nqs4vXLjQfod0ckCdDn46WaSOA32H9J4PPPBAmrZH37ERI0ZEcA8BAAAQLQjdSHeYu/32220gVGVQP6tamB4KOH369LGhRwFPAVwV6NRSFda/yJYotCoI+qmtXW3SCuT+bf32229thXvatGkJ92mfLly4YLZv326uueaaFLdB1XEFdVXNFdoUzrTIV0r8+6m2a3EnH9x9Bw8eNJGmbVR41EJjqoBre0+dOpVQdVa1WidIUlvR1RiopdyvcePGIaE7pc+MJI2dPP300/b75Kr9Cs/vv/++7YYQTQNwVBHXlAK1pCcO3eo60Pbru6O2drXa6wRJaukElU4GOap0q20fAAAAlz/ay3FJLeYK3W+//bb9Ob1UNVRlslOnTra9XPOZx40bZx9Te3Didt/k5konp1WrVrbl+JNPPgm5X2FKIUxB090UxLds2WLniadkxYoVtlKu1ul58+bZSrrC3tmzZ1N8be7cuRN+dvPUE9/nAmQkj4cq7Koya5ExBUrts8K+22a3QF4kpfSZkaR2ctE8bkcnXFStTy7ka6XzPXv22HZwv4oVK9pt1cJsOnmjkwdpoc/WSRj/DQAAANkDoRvppnZiBSaFPtcinRItdHb+/PmL7lfVTwtead635mZrTrSrqB8/fjxkUTOFNT9VotXe7qff/YFL7rzzTrvCukK+/7JQWhhOc7FVvUx80/amRG3U5cuXt0FbJwzUnu7a7iNNx8N/eSody3DzlP0U4hMfcx0fteSrOq0wqdZzLe7m6D6F/S+++CJV26Ux0LxuP1WF0/KZkVSvXj0bdDdv3pxwn76n+jyNVVL03dKCfnptUnRcEodyAAAAICm0lyPd1H6stmL3c2pobq0WTOvQoYMNNmrz1lxqLXKlecCHDx+2C6C5lm5VHjXfdtCgQbblV8Eu8RznAQMG2FWp1R6s9vSPPvrIhvdwK2Mr8Gllc1XVtXDZPffcY1fo1irYmlesQK4V1BXCNZ/5tddeS3GfFLJVPVWQ14rcap9WRTcImn+sNmV9hqrwmq+c1DWq/cfczRPXMVeo1DbrGGkhM1XT1Wbtr6jrNV26dLEdDGqb11xsnUhQq3u4FcA1Nnp/zaPXCuXqJvC3lktKn5kW+/fvtzctNCfqkNBaAVo9XfO1VUnWSRwtVKcTOgraahuXe++91/6p78mBAwfs2GvevsZbVXhV5J3x48fb99T1uUXfXe1j4vZzAAAAIClUunFJ0toqq4WrVG1UYHSLfKkKqxWkFbRVPVf4fv311+1jClDvvvuuvYSYqqNaTTtxa68umaX52wpDurSTVtnW/F0tmhWOgrZa4hW8FQI1r1oVXS2wpct3KbxrxfD4+PhU7ZMq6Go5Vmi//vrrbeXbP1c4khSCFYa1srjmW6td2r9YXDhaQEyBUuHTXdJNYV3hu0mTJjYEq1NBFX8/LSKnY6XFxRQ61Vqd1GXUFFzVnaBxUEDX/Hz/4nKp/czU+vvf/273RdskzZo1s79rUTZHIVsndzTOOhmikwafffaZ3QbXAaBQrbnnGjd9b7SNCuqOTgpoPrYeVxeDnq/V9fU9BgAAAFIjxkvu+jgAkIl0gkXXZU88pSArUvVeHQ46CZQSLaQWGxtr6t33V5Mjd8qr4yNr0fILlUsVMFsPnDRp/X/Q1VP+f0E9ZDydSFPHTsmSJe0aGYgejF10Y/yiF2OXun/THT16NNlCJEcOQJam1nFdH9x1P2Q1amNPy3XlAQAAkL0wpxtAlqW507q2urjpCFmNWs3dPHC3ajoAAADgELoBZFma069bVqZ2K90AAACAcGgvBwAAAAAgIIRuAAAAAAACQugGAAAAACAgzOkGgEyyePyfTVxcXGZvBtKIy6cAAIC04F8LAAAAAAAEhNANAAAAAEBACN0AAAAAAASE0A0AAAAAQEAI3QAAAAAABITQDQAAAABAQAjdAAAAAAAEhNANAAAAAEBACN0AAAAAAASE0A0AAAAAQEAI3QAAAAAABITQDQAAAABAQAjdAAAAAAAEhNANAAAAAEBACN0AAAAAAASE0A0AAAAAQEAI3QAAAAAABITQDQAAAABAQAjdAAAAAAAEhNANAAAAAEBACN0AAAAAAAQkV1BvDAAIz/M8++exY8dMjhyc+4w2Fy5cMMePHzf58uVj/KIMYxe9GLvoxvhFL8Yuefq3nP/fdkkhdANABjt06JD9s3z58pm9KQAAALhEOjERGxub5OOEbgDIYEWLFrV/7tq1K9n/QCPrntW+6qqrzO7du03hwoUze3OQBoxd9GLsohvjF70Yu+Spwq3AHR8fn+zzCN0AkMFce5YCN/8HFr00doxfdGLsohdjF90Yv+jF2CUtNQUUGvMBAAAAAAgIoRsAAAAAgIAQugEgg+XNm9cMGzbM/onow/hFL8YuejF20Y3xi16MXWTEeCmtbw4AAAAAANKFSjcAAAAAAAEhdAMAAAAAEBBCNwAAAAAAASF0A0AEjB8/3lSoUMHky5fPNGzY0KxevTrZ57///vumevXq9vk1a9Y0CxYsCHlcy20MHTrUlClTxuTPn9+0bNnSbNmyJeC9yJ4iPXazZ882rVu3NsWKFTMxMTFm3bp1Ae9B9hbJ8Tt37px58skn7f0FCxY08fHxpnPnzua///1vBuxJ9hPpv3vDhw+3j2vsihQpYv+7uWrVqoD3InuK9Nj59e7d2/6385VXXglgyxHE+HXt2tWOmf/Wpk2bgPciymghNQBA+s2YMcPLkyeP99Zbb3nfffed17NnTy8uLs47cOBA2OcvW7bMy5kzp/fSSy9533//vTd48GAvd+7c3oYNGxKeM3LkSC82NtabO3eu9+2333p33nmnV7FiRe/UqVMZuGeXvyDGburUqd6IESO8iRMnaqFSb+3atRm4R9lLpMfvyJEjXsuWLb2ZM2d6//nPf7wVK1Z4DRo08OrVq5fBe3b5C+Lv3rRp07xFixZ527Zt8zZu3Oj16NHDK1y4sHfw4MEM3LPLXxBj58yePdurXbu2Fx8f740ZMyYD9ib7CWL8unTp4rVp08bbt29fwu2XX37JwL3K+gjdAHCJ9I/yhx56KOH38+fP238wvPDCC2Gf3759e+/2228Pua9hw4begw8+aH++cOGCV7p0aW/UqFEJjysM5M2b13vvvfcC24/sKNJj57d9+3ZCdxSPn7N69Wo7jjt37ozgliMjxu7o0aN27BYvXhzBLUdQY7dnzx7vyiuvtCdMypcvT+iOovFT6G7btm2AWx39aC8HgEtw9uxZ880339g2RidHjhz29xUrVoR9je73P19uueWWhOdv377d7N+/P+Q5sbGxtgUsqfdE1hg7XH7jd/ToUdsqGRcXF8Gtz94yYuz0GRMmTLD/7axdu3aE9yD7CmrsLly4YDp16mQGDBhgatSoEeAeZG9B/t1bsmSJKVmypKlWrZrp06ePOXToUEB7EZ0I3QBwCX7++Wdz/vx5U6pUqZD79buCczi6P7nnuz/T8p7IGmOHy2v8Tp8+bed4d+zY0RQuXDiCW5+9BTl28+bNM4UKFbJzT8eMGWMWLVpkihcvHsBeZE9Bjd2LL75ocuXKZfr16xfQliPI8dP87alTp5pPP/3UjuUXX3xhbr31VvtZ+F+5/u9PAAAA+BZVa9++vV3U8I033sjszUEqtWjRwi5eqHAxceJEO4ZaTE0VOGRNqryOHTvWrFmzxnaVIPp06NAh4WcttFarVi1TqVIlW/2++eabM3Xbsgoq3QBwCVRByZkzpzlw4EDI/fq9dOnSYV+j+5N7vvszLe+JrDF2uDzGzwXunTt32kopVe7oGTutXF65cmXTqFEjM2nSJFs91Z/IumO3dOlSc/DgQVOuXDk7Xrrp717//v3tCtuIvv/fu/rqq+1nbd26NUJbHv0I3QBwCfLkyWPq1atnW6r8c9P0e+PGjcO+Rvf7ny/6h717fsWKFe3/mfmfc+zYMVutSeo9kTXGDtE/fi5w6xJ9ixcvtpd+Q/T+3dP7njlzJkJbjiDGTnO5169fbzsU3E2X69P87k8++STgPcpeMurv3p49e+ycbl32FP8ns1dyA4DL4fIbWll8ypQp9nIavXr1spff2L9/v328U6dO3lNPPRVy+Y1cuXJ5o0eP9jZt2uQNGzYs7CXD9B7//Oc/vfXr19tVQblkWHSM3aFDh+yK5fPnz7crJ+sz9LsuoYKsPX5nz561l+crW7ast27dupDL35w5cybT9vNyFOmxO3HihDdw4EB7mbcdO3Z4X3/9tdetWzf7GVoNG1n7v5uJsXp59Izf8ePHvccff9z+3dNVO3S1gLp163pVqlTxTp8+nWn7mdUQugEgAsaNG+eVK1fOXvtSl+NYuXJlwmPNmze3l9PwmzVrlle1alX7/Bo1atiA5qfLhg0ZMsQrVaqU/T/Hm2++2du8eXOG7U92Eumxmzx5sg3biW/6hwqy9vi5y7yFu33++ecZul/ZQSTHTick27VrZy99pMfLlCljT6Dokm/I+v/dTIzQHT3jd/LkSa9169ZeiRIlbBjX2Ona3y7E43/F6H9c1RsAAAAAAEQOc7oBAAAAAAgIoRsAAAAAgIAQugEAAAAACAihGwAAAACAgBC6AQAAAAAICKEbAAAAAICAELoBAAAAAAgIoRsAAAAAgIAQugEAAAAACAihGwAAIIp17drV3HXXXSYr2rFjh4mJiTHr1q3L7E0BgExD6AYAAEDEnT17NrM3AQCyBEI3AADAZeKmm24yffv2NY8++qgpUqSIKVWqlJk4caL59ddfTbdu3cwVV1xhKleubP71r38lvGbJkiW2Gj1//nxTq1Ytky9fPtOoUSOzcePGkPf+4IMPTI0aNUzevHlNhQoVzMsvvxzyuO579tlnTefOnU3hwoVNr169TMWKFe1jderUsZ+h7ZOvvvrKtGrVyhQvXtzExsaa5s2bmzVr1oS8n57/j3/8w7Rr184UKFDAVKlSxXz44Ychz/nuu+/M73//e/t52rcbb7zRbNu2LeFxvf6aa66x+1S9enXz+uuvR/BoA0DqELoBAAAuI2+//bYNs6tXr7YBvE+fPubee+81TZo0scG2devWplOnTubkyZMhrxswYIAN0grEJUqUMHfccYc5d+6cfeybb74x7du3Nx06dDAbNmwww4cPN0OGDDFTpkwJeY/Ro0eb2rVrm7Vr19rHtQ2yePFis2/fPjN79mz7+/Hjx02XLl3Ml19+aVauXGkD9W233Wbv9xsxYoT93PXr19vH77//fvPLL7/Yx/bu3WuaNWtmTwJ89tlndhu7d+9ufvvtN/v4tGnTzNChQ81f//pXs2nTJvP888/bbdLxAYCMFON5npehnwgAAICIzuk+cuSImTt3rq0knz9/3ixdutQ+pp9VSb777rvN1KlT7X379+83ZcqUMStWrLAVbVW6W7RoYWbMmGH++Mc/2uco2JYtW9aGaoVehd2ffvrJLFy4MOFzn3jiCVsdV7XZVbpV0Z4zZ07InG5VuxXCr7/++iT34cKFCyYuLs5Mnz7dVq5dpXvw4MG2ei6q1hcqVMhW6du0aWMGDRpkt3nz5s0md+7cF72nKvp6bceOHRPue+6558yCBQvM8uXLL/m4A0BqUekGAAC4jKhF3MmZM6cpVqyYqVmzZsJ9ajmXgwcPhryucePGCT8XLVrUVKtWzVaIRX82bdo05Pn6fcuWLTbYO/Xr10/VNh44cMD07NnTVrh1UkDt4SdOnDC7du1Kcl8KFixon+e2W4uzqZ08XOBWQFebeY8ePWxQdzeFbn/7OQBkhFwZ8ikAAADIEIlDqCrG/vv0u6suR5qCcWqotfzQoUNm7Nixpnz58rZFXKE/8eJr4fbFbXf+/PmTfH8FeNF89oYNG4Y8phMRAJCRCN0AAACwc6vLlStnfz58+LD54Ycf7CJkoj+XLVsW8nz9XrVq1WRDbJ48eeyf/mq4e60WNdM8bdm9e7f5+eef07S9qoJrfrbmnScO56rmx8fHmx9//NG2xgNAZiJ0AwAAwDzzzDO2FV2B9emnn7aLsbnrf/fv39/ccMMNdo605n1rPvhrr72W4mrgJUuWtBXpjz/+2M4R1yriaidXW/k777xj29GPHTtmF3FLrnIdzsMPP2zGjRtnF3cbOHCgfV+dOGjQoIFtjdcibP369bP3aw74mTNnzNdff21PKDz22GOXdKwAIC2Y0w0AAAAzcuRI88gjj5h69erZxdY++uijhEp13bp1zaxZs+zCZdddd51dFVwhXYu4JSdXrlzm1VdfNW+++aatPLdt29beP2nSJBt+9b5aSV3hWAE9LXSCQKuWq5VclxzTdqud3FW9H3jgAXvJsMmTJ9s57XqOFoZzlzEDgIzC6uUAAADZmFu9XCFYK4gDACKLSjcAAAAAAAEhdAMAAAAAEBDaywEAAAAACAiVbgAAAAAAAkLoBgAAAAAgIIRuAAAAAAACQugGAAAAACAghG4AAAAAAAJC6AYAAAAAICCEbgAAAAAAAkLoBgAAAAAgIIRuAAAAAABMMP4H/7I2aae+md0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Map importances back to the feature names that survived preprocessing\n",
+    "kept = model.pipeline_[:-1].get_feature_names_out()\n",
+    "importances = pd.Series(model.feature_importances_, index=kept)\n",
+    "fig = mf.plot_feature_importance(importances, top_n=15, title=\"Top 15 Taxa\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5258d955",
+   "metadata": {},
+   "source": [
+    "## 8. Counterfactual explanations (headline feature)\n",
+    "\n",
+    "The core question MicroFactual is built to answer: *what minimal change in taxa\n",
+    "abundance would flip this sample's prediction?* We fit a model on CLR-transformed\n",
+    "features, then ask `DiCEExplainer` for counterfactuals on a single test sample.\n",
+    "\n",
+    "> Requires the `explainability` extra. If it isn't installed, this section prints a\n",
+    "> hint and is skipped rather than erroring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "9c5f7822",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.339070Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.338981Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.403979Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.403763Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Counterfactual model trained on 321 CLR features\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Work in the CLR-transformed feature space so DiCE perturbs the model's actual inputs.\n",
+    "X_clr = pd.DataFrame(\n",
+    "    CLRTransform().fit_transform(\n",
+    "        PrevalenceFilter(min_prevalence=0.01).fit_transform(\n",
+    "            AbundanceFilter(min_abundance=1e-6).fit_transform(X)\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "X_clr.columns = [f\"f{i}\" for i in range(X_clr.shape[1])]  # DiCE-friendly names\n",
+    "\n",
+    "Xc_train, Xc_test, yc_train, yc_test = train_test_split(\n",
+    "    X_clr, y, test_size=0.3, random_state=42, stratify=y\n",
+    ")\n",
+    "\n",
+    "# A plain classifier on the already-transformed space (preprocessing=None)\n",
+    "cf_model = mf.MicrobiomeClassifier(algorithm=\"random_forest\", preprocessing=None)\n",
+    "cf_model.fit(Xc_train, yc_train)\n",
+    "print(\"Counterfactual model trained on\", Xc_train.shape[1], \"CLR features\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a75bb925",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.405064Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.404992Z",
+     "iopub.status.idle": "2026-07-11T20:48:18.860294Z",
+     "shell.execute_reply": "2026-07-11T20:48:18.860045Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prediction for query sample: Control\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.55it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.54it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Query instance (original outcome : 1)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>f0</th>\n",
+       "      <th>f1</th>\n",
+       "      <th>f2</th>\n",
+       "      <th>f3</th>\n",
+       "      <th>f4</th>\n",
+       "      <th>f5</th>\n",
+       "      <th>f6</th>\n",
+       "      <th>f7</th>\n",
+       "      <th>f8</th>\n",
+       "      <th>f9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>f312</th>\n",
+       "      <th>f313</th>\n",
+       "      <th>f314</th>\n",
+       "      <th>f315</th>\n",
+       "      <th>f316</th>\n",
+       "      <th>f317</th>\n",
+       "      <th>f318</th>\n",
+       "      <th>f319</th>\n",
+       "      <th>f320</th>\n",
+       "      <th>Group</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>1.607858</td>\n",
+       "      <td>4.067077</td>\n",
+       "      <td>2.031572</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>0.886213</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.524223</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>8.398719</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>1.08387</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>1.999448</td>\n",
+       "      <td>-1.651685</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 322 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         f0        f1        f2        f3        f4        f5        f6  \\\n",
+       "0 -1.651685  1.607858  4.067077  2.031572 -1.651685  0.886213 -1.651685   \n",
+       "\n",
+       "         f7        f8        f9  ...      f312      f313      f314      f315  \\\n",
+       "0 -1.651685 -1.651685 -1.651685  ...  1.524223 -1.651685  8.398719 -1.651685   \n",
+       "\n",
+       "      f316      f317      f318      f319      f320  Group  \n",
+       "0  1.08387 -1.651685 -1.651685  1.999448 -1.651685      1  \n",
+       "\n",
+       "[1 rows x 322 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Diverse Counterfactual set (new outcome: 0)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>f0</th>\n",
+       "      <th>f1</th>\n",
+       "      <th>f2</th>\n",
+       "      <th>f3</th>\n",
+       "      <th>f4</th>\n",
+       "      <th>f5</th>\n",
+       "      <th>f6</th>\n",
+       "      <th>f7</th>\n",
+       "      <th>f8</th>\n",
+       "      <th>f9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>f312</th>\n",
+       "      <th>f313</th>\n",
+       "      <th>f314</th>\n",
+       "      <th>f315</th>\n",
+       "      <th>f316</th>\n",
+       "      <th>f317</th>\n",
+       "      <th>f318</th>\n",
+       "      <th>f319</th>\n",
+       "      <th>f320</th>\n",
+       "      <th>Group</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-1.658748388</td>\n",
+       "      <td>3.07791972</td>\n",
+       "      <td>6.81216097</td>\n",
+       "      <td>6.5858531</td>\n",
+       "      <td>8.66979694</td>\n",
+       "      <td>-1.658748388</td>\n",
+       "      <td>-1.658748388</td>\n",
+       "      <td>-1.65874839</td>\n",
+       "      <td>-1.658748388</td>\n",
+       "      <td>-0.698746443</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.30955088</td>\n",
+       "      <td>-1.658748388</td>\n",
+       "      <td>5.421412468</td>\n",
+       "      <td>-1.6587483883</td>\n",
+       "      <td>2.022823334</td>\n",
+       "      <td>3.41038799</td>\n",
+       "      <td>-1.658748388</td>\n",
+       "      <td>0.239433646</td>\n",
+       "      <td>-1.65874839</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>2.03709078</td>\n",
+       "      <td>5.4041996</td>\n",
+       "      <td>2.698209286</td>\n",
+       "      <td>7.40868378</td>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>-1.68713617</td>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.76798427</td>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>6.975078106</td>\n",
+       "      <td>1.6736824512</td>\n",
+       "      <td>8.974164963</td>\n",
+       "      <td>4.53500175</td>\n",
+       "      <td>4.277351379</td>\n",
+       "      <td>-1.687136173</td>\n",
+       "      <td>-1.68713617</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>-1.46440434</td>\n",
+       "      <td>5.00017118</td>\n",
+       "      <td>1.536356211</td>\n",
+       "      <td>-1.46440434</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>1.242063642</td>\n",
+       "      <td>-1.46440434</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-1.46440434</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>4.096763134</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>-1.46440434</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>-1.464404345</td>\n",
+       "      <td>-1.46440434</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3 rows × 322 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             f0           f1          f2           f3           f4  \\\n",
+       "0  -1.658748388   3.07791972  6.81216097    6.5858531   8.66979694   \n",
+       "0  -1.687136173   2.03709078   5.4041996  2.698209286   7.40868378   \n",
+       "0  -1.464404345  -1.46440434  5.00017118  1.536356211  -1.46440434   \n",
+       "\n",
+       "             f5            f6           f7            f8            f9  ...  \\\n",
+       "0  -1.658748388  -1.658748388  -1.65874839  -1.658748388  -0.698746443  ...   \n",
+       "0  -1.687136173  -1.687136173  -1.68713617  -1.687136173  -1.687136173  ...   \n",
+       "0  -1.464404345   1.242063642  -1.46440434  -1.464404345  -1.464404345  ...   \n",
+       "\n",
+       "          f312          f313          f314           f315          f316  \\\n",
+       "0   1.30955088  -1.658748388   5.421412468  -1.6587483883   2.022823334   \n",
+       "0   0.76798427  -1.687136173   6.975078106   1.6736824512   8.974164963   \n",
+       "0  -1.46440434  -1.464404345  -1.464404345    4.096763134  -1.464404345   \n",
+       "\n",
+       "          f317          f318          f319         f320 Group  \n",
+       "0   3.41038799  -1.658748388   0.239433646  -1.65874839   0.0  \n",
+       "0   4.53500175   4.277351379  -1.687136173  -1.68713617   0.0  \n",
+       "0  -1.46440434  -1.464404345  -1.464404345  -1.46440434   0.0  \n",
+       "\n",
+       "[3 rows x 322 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    explainer = mf.DiCEExplainer(\n",
+    "        model=cf_model,\n",
+    "        background_data=Xc_train,\n",
+    "        target_column=\"Group\",\n",
+    "        target_data=yc_train,\n",
+    "    )\n",
+    "    query = Xc_test.iloc[[0]]\n",
+    "    print(\"Prediction for query sample:\",\n",
+    "          dataset.target_names[int(cf_model.predict(query)[0])])\n",
+    "\n",
+    "    cf = explainer.explain(query, total_CFs=3, desired_class=\"opposite\")\n",
+    "    cf.visualize_as_dataframe(show_only_changes=True)\n",
+    "except ImportError as e:\n",
+    "    print(\"Counterfactual section skipped —\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc01985a",
+   "metadata": {},
+   "source": [
+    "## 9. Compare algorithms\n",
+    "\n",
+    "Same interface, different estimator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f3b02e5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:48:18.861453Z",
+     "iopub.status.busy": "2026-07-11T20:48:18.861366Z",
+     "iopub.status.idle": "2026-07-11T20:48:19.247567Z",
+     "shell.execute_reply": "2026-07-11T20:48:19.247316Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " random_forest: ROC-AUC 0.852 ± 0.071\n",
+      "      logistic: ROC-AUC 0.780 ± 0.108\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.model_selection import cross_val_score\n",
+    "\n",
+    "for algo in [\"random_forest\", \"logistic\"]:\n",
+    "    scores = cross_val_score(\n",
+    "        mf.MicrobiomeClassifier(algorithm=algo, preprocessing=\"auto\"),\n",
+    "        X, y, cv=5, scoring=\"roc_auc\",\n",
+    "    )\n",
+    "    print(f\"{algo:>14}: ROC-AUC {scores.mean():.3f} ± {scores.std():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72534d69",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "We exercised the full public surface end-to-end on a real CRC dataset:\n",
+    "`MicrobiomeDataset`, the preprocessing transforms, sklearn interop\n",
+    "(`Pipeline`/`cross_validate`/`GridSearchCV`), the `mf.classify()` one-liner,\n",
+    "`MicrobiomeClassifier` train/predict, the visualization helpers, and\n",
+    "`DiCEExplainer` counterfactuals.\n",
+    "\n",
+    "If every cell above ran without error, the library is healthy end-to-end."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,18 +38,23 @@ classifiers = [
 ]
 
 dependencies = [
-    "dice-ml>=0.9",
-    "explainerdashboard>=0.5.1",
     "matplotlib>=3.10.1",
     "pandas>=2.2.3",
-    "ruff>=0.11.6",
     "scikit-learn>=1.6.1",
     "scipy>=1.15.2",
     "skore>=0.10.0",
 ]
 
+[project.optional-dependencies]
+# Heavy interpretability stack — install with: pip install microfactual[explainability]
+explainability = [
+    "dice-ml>=0.9",
+    "explainerdashboard>=0.5.1",
+]
+
 [dependency-groups]
 dev = [
+    "ruff>=0.11.6",
     "ipykernel>=6.29.5",
     "pytest>=8.3.5",
     "pytest-cov>=6.2.1",

--- a/src/microfactual/explainability/counterfactuals.py
+++ b/src/microfactual/explainability/counterfactuals.py
@@ -54,7 +54,8 @@ class DiCEExplainer(BaseExplainer):
         if dice_ml is None:
             raise ImportError(
                 "dice-ml is required for counterfactuals. "
-                "Install it with: pip install dice-ml"
+                "Install the explainability extra with: "
+                "pip install 'microfactual[explainability]'"
             )
 
         super().__init__(model, background_data, **kwargs)

--- a/src/microfactual/models/classifiers.py
+++ b/src/microfactual/models/classifiers.py
@@ -67,6 +67,58 @@ class MicrobiomeClassifier(ClassifierMixin, BaseEstimator):
         self.preprocessing = preprocessing
         self.model_params = model_params
 
+    def get_params(self, deep: bool = True) -> dict:
+        """Get parameters for this estimator (sklearn-compatible).
+
+        Extends the default behaviour so that keyword arguments forwarded to the
+        underlying classifier (e.g. ``n_estimators``, ``max_depth``) are exposed
+        as top-level params. This makes the estimator usable with
+        ``sklearn.clone``, ``set_params`` and ``GridSearchCV`` over those params.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            Kept for sklearn API compatibility; has no nested effect here.
+
+        Returns
+        -------
+        dict
+            Parameter names mapped to their values, including forwarded
+            model params.
+
+        """
+        params = {
+            "algorithm": self.algorithm,
+            "preprocessing": self.preprocessing,
+        }
+        params.update(self.model_params)
+        return params
+
+    def set_params(self, **params) -> "MicrobiomeClassifier":
+        """Set the parameters of this estimator (sklearn-compatible).
+
+        Unknown parameters are treated as keyword arguments for the underlying
+        classifier rather than raising, mirroring the ``**model_params`` accepted
+        by ``__init__``.
+
+        Parameters
+        ----------
+        **params
+            Estimator parameters to set.
+
+        Returns
+        -------
+        MicrobiomeClassifier
+            self.
+
+        """
+        for key in ("algorithm", "preprocessing"):
+            if key in params:
+                setattr(self, key, params.pop(key))
+        # Remaining params are forwarded to the underlying classifier.
+        self.model_params = {**self.model_params, **params}
+        return self
+
     def fit(self, X, y):
         """Fit the classifier.
 

--- a/src/microfactual/visualization/dashboard.py
+++ b/src/microfactual/visualization/dashboard.py
@@ -38,7 +38,8 @@ def launch_dashboard(
     if ClassifierExplainer is None:
         raise ImportError(
             "explainerdashboard is required. "
-            "Install it with: pip install explainerdashboard"
+            "Install the explainability extra with: "
+            "pip install 'microfactual[explainability]'"
         )
 
     # Sanitize column names for SHAP compatibility

--- a/test/test_classifiers.py
+++ b/test/test_classifiers.py
@@ -89,6 +89,50 @@ class TestMicrobiomeClassifier:
 
         assert len(scores) == 2
 
+    def test_get_params_exposes_forwarded_model_params(self):
+        """Forwarded model kwargs appear in get_params (sklearn contract)."""
+        from microfactual.models.classifiers import MicrobiomeClassifier
+
+        clf = MicrobiomeClassifier(algorithm="random_forest", n_estimators=42)
+        params = clf.get_params()
+        assert params["algorithm"] == "random_forest"
+        assert params["n_estimators"] == 42
+
+    def test_set_params_roundtrip(self):
+        """set_params can update both declared and forwarded params."""
+        from microfactual.models.classifiers import MicrobiomeClassifier
+
+        clf = MicrobiomeClassifier()
+        clf.set_params(algorithm="logistic", n_estimators=10, preprocessing=None)
+        params = clf.get_params()
+        assert params["algorithm"] == "logistic"
+        assert params["preprocessing"] is None
+        assert params["n_estimators"] == 10
+
+    def test_clone_preserves_forwarded_params(self):
+        """sklearn.clone round-trips forwarded model params."""
+        from sklearn.base import clone
+
+        from microfactual.models.classifiers import MicrobiomeClassifier
+
+        clf = MicrobiomeClassifier(algorithm="random_forest", n_estimators=33)
+        cloned = clone(clf)
+        assert cloned.get_params()["n_estimators"] == 33
+
+    def test_gridsearch_over_forwarded_param(self, sample_X, sample_y):
+        """GridSearchCV can tune a forwarded underlying-model param."""
+        from sklearn.model_selection import GridSearchCV
+
+        from microfactual.models.classifiers import MicrobiomeClassifier
+
+        grid = GridSearchCV(
+            MicrobiomeClassifier(algorithm="random_forest", preprocessing=None),
+            param_grid={"n_estimators": [5, 10]},
+            cv=2,
+        )
+        grid.fit(sample_X, sample_y)
+        assert grid.best_params_["n_estimators"] in (5, 10)
+
 
 # === High-Level API Tests ===
 


### PR DESCRIPTION
Stacked on #22. Started as the T1.5 extras refactor and grew to include an end-to-end feature-tour notebook and a genuine sklearn-compatibility fix surfaced while building it.

## 1. Lean core install (T1.5)
- `dice-ml` and `explainerdashboard` moved from core `dependencies` to an optional `[explainability]` extra. Core install is now `matplotlib`, `pandas`, `scikit-learn`, `scipy`, `skore`.
- Moved `ruff` from runtime deps → dev group (lint tool, imported nowhere in `src/`).
- `ImportError` messages in `DiCEExplainer` / `launch_dashboard` now point to `pip install 'microfactual[explainability]'`.
- README documents core vs. extra install.

## 2. End-to-end feature-tour notebook (T1.6)
- `notebooks/00_End_to_End_Feature_Tour.ipynb`, executed end-to-end (15/15 code cells, 0 errors) on the shipped Zeller 2014 CRC dataset.
- Covers `MicrobiomeDataset`, preprocessing transforms, sklearn interop (`Pipeline`/`cross_validate`/`GridSearchCV`), `mf.classify()`, train/test eval, visualization helpers, and `DiCEExplainer` counterfactuals (genuine prediction flip demonstrated).

## 3. Fix: sklearn `get_params`/`set_params` for forwarded model params
- `MicrobiomeClassifier` accepted `**model_params` (e.g. `n_estimators`, `max_depth`) but didn't expose them via `get_params`, so `sklearn.clone`/`GridSearchCV` raised `Invalid parameter`. Overrode both methods to merge forwarded params.
- 4 new tests (get_params exposure, set_params roundtrip, clone, GridSearchCV over `n_estimators`).

## Verification
- All **52 tests pass** (48 + 4 new).
- Notebook re-executed clean; GridSearchCV now tunes `max_depth`/`n_estimators` (best ROC-AUC 0.818).
- Runtime import guards mean `import microfactual` works without the extra.

## Note
- `skore` left in core (used by the shipped counterfactuals notebook) — possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)