### PR TITLE
spec-003: first-class explain_counterfactual() API + methodology docs (T2.4, T2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrote the README roadmap (removed duplicated entries) around the v0.2.0 release plan.
 
 ### Added
+- **`mf.explain_counterfactual()`**: first-class, documented one-call entry point for per-sample counterfactual explanations (wraps `DiCEExplainer`). Exported at the top level.
+- Counterfactuals methodology documentation page (`docs/counterfactuals.rst`) covering assumptions, interpretation guidance, and limitations.
 - `CITATION.cff` for GitHub "Cite this repository" support (paper DOI placeholder pending).
 - End-to-end feature-tour notebook (`notebooks/00_End_to_End_Feature_Tour.ipynb`) exercising the full public API on the shipped Zeller 2014 CRC dataset.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 project = "microfactual"
 copyright = "2025, Simeon Hebrew, Lawrence Adu-Gyamfi"
 author = "Simeon Hebrew, Lawrence Adu-Gyamfi"
-release = "0.1.0"
+release = "0.2.0"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/counterfactuals.rst
+++ b/docs/counterfactuals.rst
@@ -1,0 +1,88 @@
+Counterfactual Explanations
+===========================
+
+Counterfactual explanations are MicroFactual's headline capability. For an
+individual sample they answer:
+
+    *"What is the smallest change in taxa abundance that would flip this
+    sample's predicted class?"*
+
+Unlike global feature-importance scores, a counterfactual is **per-sample and
+actionable**: it names specific taxa and the direction/magnitude of change that
+would move the sample across the decision boundary. This maps naturally onto
+clinical and biological reasoning ("which microbes, and by how much?").
+
+Quickstart
+----------
+
+.. code-block:: python
+
+    import microfactual as mf
+
+    # Fit a model in the feature space you want to explain (see note below).
+    model = mf.MicrobiomeClassifier(preprocessing=None).fit(X_clr, y)
+
+    # One call: what would flip the first sample's prediction?
+    cf = mf.explain_counterfactual(
+        model,
+        query=X_clr.iloc[[0]],
+        background_data=X_clr,
+        y=y,
+        total_CFs=3,
+    )
+
+    # Show only the features that changed
+    cf.visualize_as_dataframe(show_only_changes=True)
+
+``explain_counterfactual`` wraps :class:`~microfactual.explainability.counterfactuals.DiCEExplainer`
+(built on `DiCE <https://github.com/interpretml/DiCE>`_). Use the class directly
+when you need to reuse one explainer across many query samples.
+
+Methodology & assumptions
+--------------------------
+
+- **Search space = model input space.** DiCE perturbs the *inputs* the model was
+  trained on. Fit the model, and pass ``query``/``background_data``, in the
+  **same feature space** — if the model was trained on CLR-transformed
+  abundances, explain in CLR space. Explaining a model whose preprocessing is
+  baked into the estimator (``preprocessing="auto"``) will search over the raw
+  inputs, which is usually *not* what you want; transform first and use
+  ``preprocessing=None``.
+- **Background data defines plausibility.** DiCE samples candidate
+  counterfactuals guided by ``background_data``. A representative training set
+  yields more realistic counterfactuals; a small or skewed one yields less
+  trustworthy ones.
+- **Diversity vs. proximity.** ``total_CFs`` controls how many alternative
+  counterfactuals are returned. Multiple counterfactuals expose *different*
+  minimal routes across the boundary rather than a single point estimate.
+
+Interpretation guidance
+------------------------
+
+- Read a counterfactual as *"a sample like this one but with these taxa shifted
+  would likely be classified as the other group"* — a statement about the
+  **model**, not a validated biological intervention.
+- Prefer changes that are consistent across several counterfactuals and across
+  several query samples of the same class; single-counterfactual changes can be
+  artifacts of the search.
+- Report the feature space (raw / relative-abundance / CLR) alongside any
+  counterfactual, since the magnitude of a "minimal change" is only meaningful
+  relative to that space.
+
+Limitations
+-----------
+
+- **Compositional constraints are not enforced.** Counterfactuals in CLR space
+  are not guaranteed to map back to a valid composition on the simplex (values
+  summing to a constant). Treat the suggested shifts as directional rather than
+  exact recipes. Constrained, simplex-aware counterfactuals are on the roadmap
+  (see the release plan, T4.3).
+- **Binary classification only** in the current release.
+- **Correlated taxa.** Microbiome features are highly correlated; a
+  counterfactual may shift one taxon as a proxy for a correlated group. Corroborate
+  with domain knowledge before drawing biological conclusions.
+- Requires the optional ``explainability`` extra
+  (``pip install 'microfactual[explainability]'``).
+
+See also the end-to-end notebook ``notebooks/00_End_to_End_Feature_Tour.ipynb``
+for a runnable example on a real colorectal-cancer dataset.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,9 +64,10 @@ Contents
 --------
 
 .. toctree::
-   :maxdepth=2
+   :maxdepth: 2
    :caption: Contents:
 
+   counterfactuals
    modules
 
 API Reference

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,12 +1,3 @@
-Microfactual Documentation
-===========================
-
-.. toctree::
-   :maxdepth=2
-   :caption: Contents:
-
-   modules
-
 Microfactual API Reference
 ===========================
 
@@ -31,12 +22,7 @@ Preprocessing
     :undoc-members:
     :show-inheritance:
 
-.. automodule:: microfactual.preprocessing.filtering
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-.. automodule:: microfactual.preprocessing.transformation
+.. automodule:: microfactual.preprocessing.transforms
     :members:
     :undoc-members:
     :show-inheritance:

--- a/notebooks/00_End_to_End_Feature_Tour.ipynb
+++ b/notebooks/00_End_to_End_Feature_Tour.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7de33c61",
+   "id": "212801a4",
    "metadata": {},
    "source": [
     "# MicroFactual — End-to-End Feature Tour\n",
@@ -19,7 +19,7 @@
     "5. The one-liner `mf.classify()` API\n",
     "6. Train / test evaluation with `MicrobiomeClassifier`\n",
     "7. Visualization — ROC, confusion matrix, feature importance\n",
-    "8. **Counterfactual explanations** (the headline feature) via `DiCEExplainer`\n",
+    "8. **Counterfactual explanations** (the headline feature) via `mf.explain_counterfactual()`\n",
     "9. Comparing algorithms (random forest vs. logistic regression)\n",
     "\n",
     "> The dataset ships in `datasets/` (`abundance_crc.txt`, `metadata_crc.txt`).\n",
@@ -30,13 +30,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "dbb62e89",
+   "id": "2b01763b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:21.638172Z",
-     "iopub.status.busy": "2026-07-11T20:55:21.638098Z",
-     "iopub.status.idle": "2026-07-11T20:55:23.857687Z",
-     "shell.execute_reply": "2026-07-11T20:55:23.857333Z"
+     "iopub.execute_input": "2026-07-12T14:08:16.063319Z",
+     "iopub.status.busy": "2026-07-12T14:08:16.063058Z",
+     "iopub.status.idle": "2026-07-12T14:08:18.541318Z",
+     "shell.execute_reply": "2026-07-12T14:08:18.541049Z"
     }
    },
    "outputs": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a32899d",
+   "id": "304c6c4f",
    "metadata": {},
    "source": [
     "## 1. Load a real dataset\n",
@@ -74,13 +74,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a181516d",
+   "id": "420eb3bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:23.859413Z",
-     "iopub.status.busy": "2026-07-11T20:55:23.859229Z",
-     "iopub.status.idle": "2026-07-11T20:55:23.887482Z",
-     "shell.execute_reply": "2026-07-11T20:55:23.887246Z"
+     "iopub.execute_input": "2026-07-12T14:08:18.542805Z",
+     "iopub.status.busy": "2026-07-12T14:08:18.542612Z",
+     "iopub.status.idle": "2026-07-12T14:08:18.565627Z",
+     "shell.execute_reply": "2026-07-12T14:08:18.565389Z"
     }
    },
    "outputs": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c62ab1f8",
+   "id": "6f4fc113",
    "metadata": {},
    "source": [
     "## 2. Explore the data\n",
@@ -126,13 +126,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fa7375a2",
+   "id": "361e9f06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:23.888613Z",
-     "iopub.status.busy": "2026-07-11T20:55:23.888539Z",
-     "iopub.status.idle": "2026-07-11T20:55:23.893898Z",
-     "shell.execute_reply": "2026-07-11T20:55:23.893682Z"
+     "iopub.execute_input": "2026-07-12T14:08:18.566793Z",
+     "iopub.status.busy": "2026-07-12T14:08:18.566718Z",
+     "iopub.status.idle": "2026-07-12T14:08:18.571645Z",
+     "shell.execute_reply": "2026-07-12T14:08:18.571436Z"
     }
    },
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0015746f",
+   "id": "0bc10748",
    "metadata": {},
    "source": [
     "## 3. Microbiome-aware preprocessing\n",
@@ -179,13 +179,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "62d35994",
+   "id": "58e40300",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:23.895117Z",
-     "iopub.status.busy": "2026-07-11T20:55:23.895042Z",
-     "iopub.status.idle": "2026-07-11T20:55:23.898991Z",
-     "shell.execute_reply": "2026-07-11T20:55:23.898776Z"
+     "iopub.execute_input": "2026-07-12T14:08:18.572626Z",
+     "iopub.status.busy": "2026-07-12T14:08:18.572549Z",
+     "iopub.status.idle": "2026-07-12T14:08:18.576284Z",
+     "shell.execute_reply": "2026-07-12T14:08:18.576105Z"
     }
    },
    "outputs": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b238ab93",
+   "id": "3d828833",
    "metadata": {},
    "source": [
     "The `MicrobiomeDataset` also offers convenience methods that track a preprocessing history:"
@@ -227,13 +227,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9c114eb2",
+   "id": "50a704c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:23.900120Z",
-     "iopub.status.busy": "2026-07-11T20:55:23.900047Z",
-     "iopub.status.idle": "2026-07-11T20:55:23.905530Z",
-     "shell.execute_reply": "2026-07-11T20:55:23.905315Z"
+     "iopub.execute_input": "2026-07-12T14:08:18.577228Z",
+     "iopub.status.busy": "2026-07-12T14:08:18.577148Z",
+     "iopub.status.idle": "2026-07-12T14:08:18.582133Z",
+     "shell.execute_reply": "2026-07-12T14:08:18.581945Z"
     }
    },
    "outputs": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5de4ae70",
+   "id": "8bd48eae",
    "metadata": {},
    "source": [
     "## 4. sklearn-native usage\n",
@@ -276,13 +276,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a1264408",
+   "id": "6f97a083",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:23.906524Z",
-     "iopub.status.busy": "2026-07-11T20:55:23.906438Z",
-     "iopub.status.idle": "2026-07-11T20:55:24.297367Z",
-     "shell.execute_reply": "2026-07-11T20:55:24.297106Z"
+     "iopub.execute_input": "2026-07-12T14:08:18.583105Z",
+     "iopub.status.busy": "2026-07-12T14:08:18.583034Z",
+     "iopub.status.idle": "2026-07-12T14:08:18.967385Z",
+     "shell.execute_reply": "2026-07-12T14:08:18.967097Z"
     }
    },
    "outputs": [
@@ -313,13 +313,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ff1b3fd0",
+   "id": "fe262b03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:24.298549Z",
-     "iopub.status.busy": "2026-07-11T20:55:24.298471Z",
-     "iopub.status.idle": "2026-07-11T20:55:24.936271Z",
-     "shell.execute_reply": "2026-07-11T20:55:24.935970Z"
+     "iopub.execute_input": "2026-07-12T14:08:18.968575Z",
+     "iopub.status.busy": "2026-07-12T14:08:18.968502Z",
+     "iopub.status.idle": "2026-07-12T14:08:19.592384Z",
+     "shell.execute_reply": "2026-07-12T14:08:19.592120Z"
     }
    },
    "outputs": [
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0d28808",
+   "id": "d142bc99",
    "metadata": {},
    "source": [
     "## 5. One-liner API\n",
@@ -361,13 +361,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3a8c89dd",
+   "id": "add04bc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:24.937740Z",
-     "iopub.status.busy": "2026-07-11T20:55:24.937664Z",
-     "iopub.status.idle": "2026-07-11T20:55:25.454241Z",
-     "shell.execute_reply": "2026-07-11T20:55:25.453970Z"
+     "iopub.execute_input": "2026-07-12T14:08:19.593615Z",
+     "iopub.status.busy": "2026-07-12T14:08:19.593526Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.109853Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.109582Z"
     }
    },
    "outputs": [
@@ -377,8 +377,8 @@
      "text": [
       "Returned keys: ['model', 'dataset', 'cv_scores']\n",
       "CV scores:\n",
-      "            fit_time: 0.072\n",
-      "          score_time: 0.005\n",
+      "            fit_time: 0.073\n",
+      "          score_time: 0.004\n",
       "       test_accuracy: 0.751\n",
       "      train_accuracy: 1.000\n",
       "             test_f1: 0.818\n",
@@ -404,7 +404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92abb878",
+   "id": "fe14b37b",
    "metadata": {},
    "source": [
     "## 6. Train / test evaluation\n",
@@ -415,13 +415,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1a87b4af",
+   "id": "0d267a93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:25.455522Z",
-     "iopub.status.busy": "2026-07-11T20:55:25.455442Z",
-     "iopub.status.idle": "2026-07-11T20:55:25.530559Z",
-     "shell.execute_reply": "2026-07-11T20:55:25.530324Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.111075Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.111005Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.186882Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.186581Z"
     }
    },
    "outputs": [
@@ -460,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5058f1f0",
+   "id": "2c724826",
    "metadata": {},
    "source": [
     "## 7. Visualization\n",
@@ -471,13 +471,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "305fef73",
+   "id": "eab9004b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:25.531678Z",
-     "iopub.status.busy": "2026-07-11T20:55:25.531606Z",
-     "iopub.status.idle": "2026-07-11T20:55:25.599994Z",
-     "shell.execute_reply": "2026-07-11T20:55:25.599772Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.188421Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.188347Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.258918Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.258673Z"
     }
    },
    "outputs": [
@@ -500,13 +500,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "d089972c",
+   "id": "8777dd53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:25.601131Z",
-     "iopub.status.busy": "2026-07-11T20:55:25.601053Z",
-     "iopub.status.idle": "2026-07-11T20:55:25.665695Z",
-     "shell.execute_reply": "2026-07-11T20:55:25.665210Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.260014Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.259929Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.311301Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.310930Z"
     }
    },
    "outputs": [
@@ -531,13 +531,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ac989563",
+   "id": "aa178272",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:25.668573Z",
-     "iopub.status.busy": "2026-07-11T20:55:25.668440Z",
-     "iopub.status.idle": "2026-07-11T20:55:25.800739Z",
-     "shell.execute_reply": "2026-07-11T20:55:25.800422Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.312590Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.312500Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.439634Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.439353Z"
     }
    },
    "outputs": [
@@ -562,14 +562,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "601a9305",
+   "id": "8dfa6f9f",
    "metadata": {},
    "source": [
     "## 8. Counterfactual explanations (headline feature)\n",
     "\n",
     "The core question MicroFactual is built to answer: *what minimal change in taxa\n",
     "abundance would flip this sample's prediction?* We fit a model on CLR-transformed\n",
-    "features, then ask `DiCEExplainer` for counterfactuals on a single test sample.\n",
+    "features, then use the one-call `mf.explain_counterfactual()` API to generate\n",
+    "counterfactuals for a single test sample.\n",
     "\n",
     "> Requires the `explainability` extra. If it isn't installed, this section prints a\n",
     "> hint and is skipped rather than erroring."
@@ -578,13 +579,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "783983ab",
+   "id": "59c05b15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:25.802083Z",
-     "iopub.status.busy": "2026-07-11T20:55:25.801984Z",
-     "iopub.status.idle": "2026-07-11T20:55:25.870185Z",
-     "shell.execute_reply": "2026-07-11T20:55:25.869888Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.440829Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.440756Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.509150Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.508879Z"
     }
    },
    "outputs": [
@@ -620,13 +621,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "9b93c361",
+   "id": "b2370248",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:25.871385Z",
-     "iopub.status.busy": "2026-07-11T20:55:25.871299Z",
-     "iopub.status.idle": "2026-07-11T20:55:26.345664Z",
-     "shell.execute_reply": "2026-07-11T20:55:26.345358Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.510370Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.510278Z",
+     "iopub.status.idle": "2026-07-12T14:08:20.971470Z",
+     "shell.execute_reply": "2026-07-12T14:08:20.971094Z"
     }
    },
    "outputs": [
@@ -650,7 +651,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
      ]
     },
     {
@@ -658,7 +659,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
      ]
     },
     {
@@ -716,7 +717,7 @@
        "      <th>f318</th>\n",
        "      <th>f319</th>\n",
        "      <th>f320</th>\n",
-       "      <th>Group</th>\n",
+       "      <th>outcome</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -756,8 +757,8 @@
        "         f7        f8        f9  ...      f312      f313      f314      f315  \\\n",
        "0 -1.651685 -1.651685 -1.651685  ...  1.524223 -1.651685  8.398719 -1.651685   \n",
        "\n",
-       "      f316      f317      f318      f319      f320  Group  \n",
-       "0  1.08387 -1.651685 -1.651685  1.999448 -1.651685      1  \n",
+       "      f316      f317      f318      f319      f320  outcome  \n",
+       "0  1.08387 -1.651685 -1.651685  1.999448 -1.651685        1  \n",
        "\n",
        "[1 rows x 322 columns]"
       ]
@@ -814,7 +815,7 @@
        "      <th>f318</th>\n",
        "      <th>f319</th>\n",
        "      <th>f320</th>\n",
-       "      <th>Group</th>\n",
+       "      <th>outcome</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -911,10 +912,10 @@
        "0   0.76798427  -1.687136173   6.975078106   1.6736824512   8.974164963   \n",
        "0  -1.46440434  -1.464404345  -1.464404345    4.096763134  -1.464404345   \n",
        "\n",
-       "          f317          f318          f319         f320 Group  \n",
-       "0   3.41038799  -1.658748388   0.239433646  -1.65874839   0.0  \n",
-       "0   4.53500175   4.277351379  -1.687136173  -1.68713617   0.0  \n",
-       "0  -1.46440434  -1.464404345  -1.464404345  -1.46440434   0.0  \n",
+       "          f317          f318          f319         f320 outcome  \n",
+       "0   3.41038799  -1.658748388   0.239433646  -1.65874839     0.0  \n",
+       "0   4.53500175   4.277351379  -1.687136173  -1.68713617     0.0  \n",
+       "0  -1.46440434  -1.464404345  -1.464404345  -1.46440434     0.0  \n",
        "\n",
        "[3 rows x 322 columns]"
       ]
@@ -924,18 +925,20 @@
     }
    ],
    "source": [
+    "query = Xc_test.iloc[[0]]\n",
+    "\n",
     "try:\n",
-    "    explainer = mf.DiCEExplainer(\n",
-    "        model=cf_model,\n",
-    "        background_data=Xc_train,\n",
-    "        target_column=\"Group\",\n",
-    "        target_data=yc_train,\n",
-    "    )\n",
-    "    query = Xc_test.iloc[[0]]\n",
     "    print(\"Prediction for query sample:\",\n",
     "          dataset.target_names[int(cf_model.predict(query)[0])])\n",
     "\n",
-    "    cf = explainer.explain(query, total_CFs=3, desired_class=\"opposite\")\n",
+    "    # One call: fit an explainer on the training distribution and generate CFs.\n",
+    "    cf = mf.explain_counterfactual(\n",
+    "        cf_model,\n",
+    "        query=query,\n",
+    "        background_data=Xc_train,\n",
+    "        y=yc_train,\n",
+    "        total_CFs=3,\n",
+    "    )\n",
     "    cf.visualize_as_dataframe(show_only_changes=True)\n",
     "except ImportError as e:\n",
     "    print(\"Counterfactual section skipped —\", e)"
@@ -943,7 +946,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6e913ab",
+   "id": "fe454645",
    "metadata": {},
    "source": [
     "## 9. Compare algorithms\n",
@@ -954,13 +957,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "e079d234",
+   "id": "7569eb3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:55:26.347047Z",
-     "iopub.status.busy": "2026-07-11T20:55:26.346942Z",
-     "iopub.status.idle": "2026-07-11T20:55:26.755554Z",
-     "shell.execute_reply": "2026-07-11T20:55:26.755296Z"
+     "iopub.execute_input": "2026-07-12T14:08:20.972961Z",
+     "iopub.status.busy": "2026-07-12T14:08:20.972855Z",
+     "iopub.status.idle": "2026-07-12T14:08:21.383732Z",
+     "shell.execute_reply": "2026-07-12T14:08:21.383444Z"
     }
    },
    "outputs": [
@@ -986,7 +989,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7533b890",
+   "id": "d5acbf98",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -995,7 +998,7 @@
     "`MicrobiomeDataset`, the preprocessing transforms, sklearn interop\n",
     "(`Pipeline`/`cross_validate`/`GridSearchCV`), the `mf.classify()` one-liner,\n",
     "`MicrobiomeClassifier` train/predict, the visualization helpers, and\n",
-    "`DiCEExplainer` counterfactuals.\n",
+    "`mf.explain_counterfactual()` counterfactuals.\n",
     "\n",
     "If every cell above ran without error, the library is healthy end-to-end."
    ]

--- a/src/microfactual/__init__.py
+++ b/src/microfactual/__init__.py
@@ -12,7 +12,7 @@ from .core import BaseModel, MicrobiomeDataset
 from .data_processing import clr_transform, filter_data, load_data
 
 # New explainability module
-from .explainability import BaseExplainer, DiCEExplainer
+from .explainability import BaseExplainer, DiCEExplainer, explain_counterfactual
 from .main import main
 from .main import run_pipeline as _run_pipeline_internal
 from .modeling import train_model
@@ -168,6 +168,7 @@ __all__ = [
     "launch_dashboard",
     "save_roc_curve",
     # Explainability
+    "explain_counterfactual",
     "BaseExplainer",
     "DiCEExplainer",
     # Utilities

--- a/src/microfactual/explainability/__init__.py
+++ b/src/microfactual/explainability/__init__.py
@@ -1,6 +1,9 @@
 """Explainability module for interpretability methods."""
 
 from microfactual.explainability.base import BaseExplainer
-from microfactual.explainability.counterfactuals import DiCEExplainer
+from microfactual.explainability.counterfactuals import (
+    DiCEExplainer,
+    explain_counterfactual,
+)
 
-__all__ = ["BaseExplainer", "DiCEExplainer"]
+__all__ = ["BaseExplainer", "DiCEExplainer", "explain_counterfactual"]

--- a/src/microfactual/explainability/counterfactuals.py
+++ b/src/microfactual/explainability/counterfactuals.py
@@ -121,3 +121,94 @@ class DiCEExplainer(BaseExplainer):
             query_instance, total_CFs=total_CFs, desired_class=desired_class, **kwargs
         )
         return dice_exp
+
+
+def explain_counterfactual(
+    model: Any,
+    query: pd.DataFrame,
+    background_data: pd.DataFrame,
+    y: pd.Series | pd.DataFrame | Any,
+    *,
+    target_column: str = "outcome",
+    total_CFs: int = 5,
+    desired_class: str = "opposite",
+    continuous_features: list[str] | None = None,
+    method: str = "genetic",
+    backend: str = "sklearn",
+    **kwargs: Any,
+) -> Any:
+    """Generate counterfactual explanations for one or more samples.
+
+    This is MicroFactual's headline entry point: it answers *"what minimal
+    change in feature values would flip this sample's prediction?"* in a single
+    call, wrapping :class:`DiCEExplainer`.
+
+    Because DiCE searches for counterfactuals in the model's *input* space, pass
+    ``model``, ``query`` and ``background_data`` in the **same feature space the
+    model was trained on** (e.g. CLR-transformed features, if the model was fit
+    on CLR-transformed data).
+
+    Parameters
+    ----------
+    model : Any
+        A fitted, sklearn-compatible classifier (e.g. a
+        :class:`~microfactual.models.classifiers.MicrobiomeClassifier` or a bare
+        sklearn estimator) exposing ``predict``/``predict_proba``.
+    query : pd.DataFrame
+        Sample(s) to explain, as one or more rows with the same feature columns
+        as ``background_data``.
+    background_data : pd.DataFrame
+        Training features (samples x features) used to describe the data
+        distribution DiCE samples from.
+    y : pd.Series, pd.DataFrame, or array-like
+        Training targets aligned with ``background_data``.
+    target_column : str, default="outcome"
+        Name DiCE uses for the outcome column internally. Only needs to differ
+        from the feature names; it is not a column in ``query``.
+    total_CFs : int, default=5
+        Number of counterfactuals to generate per query sample.
+    desired_class : str, default="opposite"
+        Target class for the counterfactuals ("opposite" flips the prediction).
+    continuous_features : list of str, optional
+        Feature names to treat as continuous. Defaults to all columns of
+        ``background_data`` (appropriate for abundance / CLR features).
+    method : str, default="genetic"
+        DiCE search method ("genetic", "random", or "kdtree").
+    backend : str, default="sklearn"
+        DiCE model backend.
+    **kwargs
+        Additional arguments forwarded to
+        ``dice_ml.Dice.generate_counterfactuals``.
+
+    Returns
+    -------
+    dice_ml.counterfactual_explanations.CounterfactualExplanations
+        The explanation object. Inspect it with
+        ``result.visualize_as_dataframe(show_only_changes=True)`` or read the
+        raw counterfactuals from ``result.cf_examples_list``.
+
+    Raises
+    ------
+    ImportError
+        If the optional ``explainability`` extra (dice-ml) is not installed.
+
+    Examples
+    --------
+    >>> import microfactual as mf
+    >>> model = mf.MicrobiomeClassifier(preprocessing=None).fit(X_clr, y)
+    >>> cf = mf.explain_counterfactual(model, X_clr.iloc[[0]], X_clr, y)
+    >>> cf.visualize_as_dataframe(show_only_changes=True)  # doctest: +SKIP
+
+    """
+    explainer = DiCEExplainer(
+        model=model,
+        background_data=background_data,
+        target_column=target_column,
+        target_data=y,
+        continuous_features=continuous_features,
+        backend=backend,
+        method=method,
+    )
+    return explainer.explain(
+        query, total_CFs=total_CFs, desired_class=desired_class, **kwargs
+    )

--- a/test/test_explainability.py
+++ b/test/test_explainability.py
@@ -101,3 +101,53 @@ class TestDiCEExplainer:
 
             # Assert
             mock_exp_instance.generate_counterfactuals.assert_called_once()
+
+
+# === explain_counterfactual() convenience API ===
+
+
+class TestExplainCounterfactual:
+    """Test the top-level one-call counterfactual entry point."""
+
+    def test_wires_through_to_dice(self, sample_data, mock_model):
+        """explain_counterfactual builds an explainer and generates CFs."""
+        from microfactual.explainability.counterfactuals import explain_counterfactual
+
+        X, y = sample_data
+        query = X.iloc[[0]]
+
+        with patch("microfactual.explainability.counterfactuals.dice_ml") as mock_dice:
+            mock_exp_instance = MagicMock()
+            mock_dice.Dice.return_value = mock_exp_instance
+
+            explain_counterfactual(
+                model=mock_model,
+                query=query,
+                background_data=X,
+                y=y,
+                total_CFs=3,
+            )
+
+            mock_exp_instance.generate_counterfactuals.assert_called_once()
+            _, called_kwargs = mock_exp_instance.generate_counterfactuals.call_args
+            assert called_kwargs["total_CFs"] == 3
+            assert called_kwargs["desired_class"] == "opposite"
+
+    def test_raises_without_dice(self, sample_data, mock_model):
+        """A clear ImportError is raised when dice-ml is unavailable."""
+        from microfactual.explainability.counterfactuals import explain_counterfactual
+
+        X, y = sample_data
+
+        with patch("microfactual.explainability.counterfactuals.dice_ml", None):
+            with pytest.raises(ImportError, match="explainability"):
+                explain_counterfactual(
+                    model=mock_model, query=X.iloc[[0]], background_data=X, y=y
+                )
+
+    def test_exported_at_top_level(self):
+        """explain_counterfactual is part of the public API."""
+        import microfactual as mf
+
+        assert hasattr(mf, "explain_counterfactual")
+        assert "explain_counterfactual" in mf.__all__


### PR DESCRIPTION
Stacked on #23. Gives MicroFactual's headline feature a real, documented entry point.

## Changes
- **T2.4** New `mf.explain_counterfactual(model, query, background_data, y, ...)` — a one-call wrapper around `DiCEExplainer` for per-sample counterfactuals ("what minimal change flips this prediction?"). Exported at the top level and added to `__all__`.
- **T2.5** `docs/counterfactuals.rst` — methodology page covering the search-space assumption (explain in the model's input space), background-data plausibility, interpretation guidance, and limitations (no simplex constraint, binary-only, correlated taxa). Wired into the docs toctree.
- Fixed pre-existing docs bugs surfaced while building: `:maxdepth=2` → `:maxdepth: 2` typo (index + modules), and stale `microfactual.preprocessing.filtering`/`transformation` autodoc refs → `transforms` (they pointed at nonexistent modules and broke autodoc).
- Synced `docs/conf.py` `release` to `0.2.0`.

## Verification
- **55 tests pass** (3 new: DiCE wiring, ImportError-without-extra path, top-level export).
- Real end-to-end call on the CRC dataset returns a `CounterfactualExplanations` object.
- `sphinx-build` renders `counterfactuals.html` and auto-documents `explain_counterfactual` in the API reference. Remaining build warnings are pre-existing (placeholder GitHub link, inherited sklearn docstrings) and are slated for spec-004 (docs deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)