### PR TITLE
notebooks: demo full feature set (explore + actionable counterfactuals)

### DIFF
--- a/notebooks/00_End_to_End_Feature_Tour.ipynb
+++ b/notebooks/00_End_to_End_Feature_Tour.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cf4745a1",
+   "id": "bfb1a210",
    "metadata": {},
    "source": [
     "# MicroFactual — End-to-End Feature Tour\n",
@@ -19,7 +19,8 @@
     "5. The one-liner `mf.classify()` API\n",
     "6. Train / test evaluation with `MicrobiomeClassifier`\n",
     "7. Visualization — ROC, confusion matrix, feature importance\n",
-    "8. **Counterfactual explanations** (the headline feature) via `mf.explain_counterfactual()`\n",
+    "8. **Counterfactual explanations** (the headline feature): sparse, actionable per-sample\n",
+    "   `mf.explain_counterfactual()` + cohort-level `mf.counterfactual_importance()`\n",
     "9. Comparing algorithms (random forest vs. logistic regression)\n",
     "\n",
     "> The dataset ships in `datasets/` (`abundance_crc.txt`, `metadata_crc.txt`).\n",
@@ -30,13 +31,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "bf81fe67",
+   "id": "81862afd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:50.375103Z",
-     "iopub.status.busy": "2026-07-12T15:09:50.374900Z",
-     "iopub.status.idle": "2026-07-12T15:09:52.397867Z",
-     "shell.execute_reply": "2026-07-12T15:09:52.397623Z"
+     "iopub.execute_input": "2026-07-12T15:41:26.710284Z",
+     "iopub.status.busy": "2026-07-12T15:41:26.710060Z",
+     "iopub.status.idle": "2026-07-12T15:41:28.882658Z",
+     "shell.execute_reply": "2026-07-12T15:41:28.882428Z"
     }
    },
    "outputs": [
@@ -63,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e25417cc",
+   "id": "25b0662f",
    "metadata": {},
    "source": [
     "## 1. Load a real dataset\n",
@@ -74,13 +75,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "02e53928",
+   "id": "3aede241",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:52.399205Z",
-     "iopub.status.busy": "2026-07-12T15:09:52.399042Z",
-     "iopub.status.idle": "2026-07-12T15:09:52.418384Z",
-     "shell.execute_reply": "2026-07-12T15:09:52.418158Z"
+     "iopub.execute_input": "2026-07-12T15:41:28.883857Z",
+     "iopub.status.busy": "2026-07-12T15:41:28.883711Z",
+     "iopub.status.idle": "2026-07-12T15:41:28.907275Z",
+     "shell.execute_reply": "2026-07-12T15:41:28.907041Z"
     }
    },
    "outputs": [
@@ -115,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ee2b9f9",
+   "id": "9953e764",
    "metadata": {},
    "source": [
     "## 2. Explore the data\n",
@@ -126,13 +127,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6647a60f",
+   "id": "53461338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:52.419533Z",
-     "iopub.status.busy": "2026-07-12T15:09:52.419457Z",
-     "iopub.status.idle": "2026-07-12T15:09:52.423787Z",
-     "shell.execute_reply": "2026-07-12T15:09:52.423560Z"
+     "iopub.execute_input": "2026-07-12T15:41:28.908449Z",
+     "iopub.status.busy": "2026-07-12T15:41:28.908380Z",
+     "iopub.status.idle": "2026-07-12T15:41:28.913476Z",
+     "shell.execute_reply": "2026-07-12T15:41:28.913300Z"
     }
    },
    "outputs": [
@@ -165,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6045d3b",
+   "id": "6ea95dbd",
    "metadata": {},
    "source": [
     "### Choosing preprocessing cutoffs visually\n",
@@ -180,13 +181,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "419f556c",
+   "id": "d1b478df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:52.424852Z",
-     "iopub.status.busy": "2026-07-12T15:09:52.424779Z",
-     "iopub.status.idle": "2026-07-12T15:09:52.659344Z",
-     "shell.execute_reply": "2026-07-12T15:09:52.659078Z"
+     "iopub.execute_input": "2026-07-12T15:41:28.914546Z",
+     "iopub.status.busy": "2026-07-12T15:41:28.914469Z",
+     "iopub.status.idle": "2026-07-12T15:41:29.157938Z",
+     "shell.execute_reply": "2026-07-12T15:41:29.157645Z"
     }
    },
    "outputs": [
@@ -209,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f75fd3b1",
+   "id": "6b152a02",
    "metadata": {},
    "source": [
     "## 3. Microbiome-aware preprocessing\n",
@@ -223,13 +224,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d18d0dcf",
+   "id": "a1b5875c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:52.660625Z",
-     "iopub.status.busy": "2026-07-12T15:09:52.660538Z",
-     "iopub.status.idle": "2026-07-12T15:09:52.664797Z",
-     "shell.execute_reply": "2026-07-12T15:09:52.664591Z"
+     "iopub.execute_input": "2026-07-12T15:41:29.159318Z",
+     "iopub.status.busy": "2026-07-12T15:41:29.159221Z",
+     "iopub.status.idle": "2026-07-12T15:41:29.163671Z",
+     "shell.execute_reply": "2026-07-12T15:41:29.163445Z"
     }
    },
    "outputs": [
@@ -262,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "731b7e5b",
+   "id": "4d175f26",
    "metadata": {},
    "source": [
     "The `MicrobiomeDataset` also offers convenience methods that track a preprocessing history:"
@@ -271,13 +272,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8dca1565",
+   "id": "9a1296dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:52.665812Z",
-     "iopub.status.busy": "2026-07-12T15:09:52.665749Z",
-     "iopub.status.idle": "2026-07-12T15:09:52.671609Z",
-     "shell.execute_reply": "2026-07-12T15:09:52.671387Z"
+     "iopub.execute_input": "2026-07-12T15:41:29.164672Z",
+     "iopub.status.busy": "2026-07-12T15:41:29.164602Z",
+     "iopub.status.idle": "2026-07-12T15:41:29.170288Z",
+     "shell.execute_reply": "2026-07-12T15:41:29.170073Z"
     }
    },
    "outputs": [
@@ -309,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2b87b7b",
+   "id": "d33c2dda",
    "metadata": {},
    "source": [
     "## 4. sklearn-native usage\n",
@@ -320,13 +321,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e5a425aa",
+   "id": "e0e73e81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:52.672830Z",
-     "iopub.status.busy": "2026-07-12T15:09:52.672733Z",
-     "iopub.status.idle": "2026-07-12T15:09:53.054816Z",
-     "shell.execute_reply": "2026-07-12T15:09:53.054555Z"
+     "iopub.execute_input": "2026-07-12T15:41:29.171315Z",
+     "iopub.status.busy": "2026-07-12T15:41:29.171239Z",
+     "iopub.status.idle": "2026-07-12T15:41:29.552786Z",
+     "shell.execute_reply": "2026-07-12T15:41:29.552515Z"
     }
    },
    "outputs": [
@@ -357,13 +358,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3b7935bf",
+   "id": "99b3be90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:53.056338Z",
-     "iopub.status.busy": "2026-07-12T15:09:53.056246Z",
-     "iopub.status.idle": "2026-07-12T15:09:53.709367Z",
-     "shell.execute_reply": "2026-07-12T15:09:53.709111Z"
+     "iopub.execute_input": "2026-07-12T15:41:29.554015Z",
+     "iopub.status.busy": "2026-07-12T15:41:29.553935Z",
+     "iopub.status.idle": "2026-07-12T15:41:30.212928Z",
+     "shell.execute_reply": "2026-07-12T15:41:30.212659Z"
     }
    },
    "outputs": [
@@ -394,7 +395,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d5f0cf0",
+   "id": "b2661ed6",
    "metadata": {},
    "source": [
     "## 5. One-liner API\n",
@@ -405,13 +406,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c98a573d",
+   "id": "7ab692f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:53.710580Z",
-     "iopub.status.busy": "2026-07-12T15:09:53.710498Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.219319Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.219045Z"
+     "iopub.execute_input": "2026-07-12T15:41:30.214136Z",
+     "iopub.status.busy": "2026-07-12T15:41:30.214059Z",
+     "iopub.status.idle": "2026-07-12T15:41:30.712994Z",
+     "shell.execute_reply": "2026-07-12T15:41:30.712734Z"
     }
    },
    "outputs": [
@@ -421,8 +422,8 @@
      "text": [
       "Returned keys: ['model', 'dataset', 'cv_scores']\n",
       "CV scores:\n",
-      "            fit_time: 0.071\n",
-      "          score_time: 0.005\n",
+      "            fit_time: 0.070\n",
+      "          score_time: 0.004\n",
       "       test_accuracy: 0.751\n",
       "      train_accuracy: 1.000\n",
       "             test_f1: 0.818\n",
@@ -448,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b16d448a",
+   "id": "6a20dbce",
    "metadata": {},
    "source": [
     "## 6. Train / test evaluation\n",
@@ -459,13 +460,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "782005fa",
+   "id": "96fddba4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.220633Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.220552Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.295392Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.295036Z"
+     "iopub.execute_input": "2026-07-12T15:41:30.714323Z",
+     "iopub.status.busy": "2026-07-12T15:41:30.714228Z",
+     "iopub.status.idle": "2026-07-12T15:41:30.788127Z",
+     "shell.execute_reply": "2026-07-12T15:41:30.787854Z"
     }
    },
    "outputs": [
@@ -504,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8b5c46b",
+   "id": "9dabeccb",
    "metadata": {},
    "source": [
     "## 7. Visualization\n",
@@ -515,13 +516,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "c598518d",
+   "id": "6a509bcf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.296911Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.296787Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.339212Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.338958Z"
+     "iopub.execute_input": "2026-07-12T15:41:30.789358Z",
+     "iopub.status.busy": "2026-07-12T15:41:30.789278Z",
+     "iopub.status.idle": "2026-07-12T15:41:30.831398Z",
+     "shell.execute_reply": "2026-07-12T15:41:30.831125Z"
     }
    },
    "outputs": [
@@ -544,13 +545,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "2a5b475d",
+   "id": "5140da5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.340457Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.340379Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.385716Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.385495Z"
+     "iopub.execute_input": "2026-07-12T15:41:30.832644Z",
+     "iopub.status.busy": "2026-07-12T15:41:30.832567Z",
+     "iopub.status.idle": "2026-07-12T15:41:30.880180Z",
+     "shell.execute_reply": "2026-07-12T15:41:30.879918Z"
     }
    },
    "outputs": [
@@ -575,13 +576,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "cc874998",
+   "id": "94f82694",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.386765Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.386695Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.451889Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.451638Z"
+     "iopub.execute_input": "2026-07-12T15:41:30.881312Z",
+     "iopub.status.busy": "2026-07-12T15:41:30.881226Z",
+     "iopub.status.idle": "2026-07-12T15:41:30.952733Z",
+     "shell.execute_reply": "2026-07-12T15:41:30.952439Z"
     }
    },
    "outputs": [
@@ -606,15 +607,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50e56c9d",
+   "id": "f296b792",
    "metadata": {},
    "source": [
     "## 8. Counterfactual explanations (headline feature)\n",
     "\n",
     "The core question MicroFactual is built to answer: *what minimal change in taxa\n",
     "abundance would flip this sample's prediction?* We fit a model on CLR-transformed\n",
-    "features, then use the one-call `mf.explain_counterfactual()` API to generate\n",
-    "counterfactuals for a single test sample.\n",
+    "features, then use the one-call `mf.explain_counterfactual()` API.\n",
+    "\n",
+    "Two things make the result **actionable** rather than a wall of numbers:\n",
+    "`sparse=True` (default) reduces each counterfactual to a near-minimal set of taxa\n",
+    "changes that still flips the prediction, and the returned `CounterfactualResult`\n",
+    "exposes `.summary()`, `.changes()`, `.n_changes` and `.validity`.\n",
     "\n",
     "> Requires the `explainability` extra. If it isn't installed, this section prints a\n",
     "> hint and is skipped rather than erroring."
@@ -623,13 +628,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "207853b6",
+   "id": "09573377",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.453058Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.452979Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.521242Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.520998Z"
+     "iopub.execute_input": "2026-07-12T15:41:30.954044Z",
+     "iopub.status.busy": "2026-07-12T15:41:30.953937Z",
+     "iopub.status.idle": "2026-07-12T15:41:31.022995Z",
+     "shell.execute_reply": "2026-07-12T15:41:31.022735Z"
     }
    },
    "outputs": [
@@ -665,13 +670,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "39d9b4d3",
+   "id": "1a34c35a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.522481Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.522408Z",
-     "iopub.status.idle": "2026-07-12T15:09:54.989145Z",
-     "shell.execute_reply": "2026-07-12T15:09:54.988876Z"
+     "iopub.execute_input": "2026-07-12T15:41:31.024220Z",
+     "iopub.status.busy": "2026-07-12T15:41:31.024143Z",
+     "iopub.status.idle": "2026-07-12T15:41:32.686879Z",
+     "shell.execute_reply": "2026-07-12T15:41:32.686628Z"
     }
    },
    "outputs": [
@@ -707,10 +712,573 @@
      ]
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Query instance (original outcome : 1)\n"
+      "3 counterfactual(s) flipping Control → CRC; features changed: min=1, median=1, max=2; validity=100%.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>feature</th>\n",
+       "      <th>original</th>\n",
+       "      <th>counterfactual</th>\n",
+       "      <th>delta</th>\n",
+       "      <th>direction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>f178</td>\n",
+       "      <td>9.904985</td>\n",
+       "      <td>0.755342</td>\n",
+       "      <td>-9.149643</td>\n",
+       "      <td>decrease</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  feature  original  counterfactual     delta direction\n",
+       "0    f178  9.904985        0.755342 -9.149643  decrease"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "query = Xc_test.iloc[[0]]\n",
+    "\n",
+    "try:\n",
+    "    print(\"Prediction for query sample:\",\n",
+    "          dataset.target_names[int(cf_model.predict(query)[0])])\n",
+    "\n",
+    "    # One call: sparse, validated counterfactuals as a CounterfactualResult.\n",
+    "    cf = mf.explain_counterfactual(\n",
+    "        cf_model,\n",
+    "        query=query,\n",
+    "        background_data=Xc_train,\n",
+    "        y=yc_train,\n",
+    "        total_CFs=3,\n",
+    "        class_names=list(dataset.target_names),\n",
+    "    )\n",
+    "    print(cf.summary())\n",
+    "    display(cf.changes(0).head(10))   # taxa that must change, with direction\n",
+    "except ImportError as e:\n",
+    "    print(\"Counterfactual section skipped —\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad0065de",
+   "metadata": {},
+   "source": [
+    "### Cohort-level counterfactual importance\n",
+    "\n",
+    "`mf.counterfactual_importance()` aggregates counterfactuals across many samples\n",
+    "to rank **which taxa most often have to change to flip predictions**, with a net\n",
+    "direction — a local-aggregated importance that complements the global feature\n",
+    "importance from section 7."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d4ba9bc7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-12T15:41:32.688097Z",
+     "iopub.status.busy": "2026-07-12T15:41:32.688021Z",
+     "iopub.status.idle": "2026-07-12T15:41:57.157498Z",
+     "shell.execute_reply": "2026-07-12T15:41:57.157175Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.03it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.03it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.45it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.37it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.42it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.42it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
      ]
     },
     {
@@ -741,227 +1309,110 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>f0</th>\n",
-       "      <th>f1</th>\n",
-       "      <th>f2</th>\n",
-       "      <th>f3</th>\n",
-       "      <th>f4</th>\n",
-       "      <th>f5</th>\n",
-       "      <th>f6</th>\n",
-       "      <th>f7</th>\n",
-       "      <th>f8</th>\n",
-       "      <th>f9</th>\n",
-       "      <th>...</th>\n",
-       "      <th>f312</th>\n",
-       "      <th>f313</th>\n",
-       "      <th>f314</th>\n",
-       "      <th>f315</th>\n",
-       "      <th>f316</th>\n",
-       "      <th>f317</th>\n",
-       "      <th>f318</th>\n",
-       "      <th>f319</th>\n",
-       "      <th>f320</th>\n",
-       "      <th>outcome</th>\n",
+       "      <th>feature</th>\n",
+       "      <th>n_samples</th>\n",
+       "      <th>frequency</th>\n",
+       "      <th>mean_delta</th>\n",
+       "      <th>direction</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>1.607858</td>\n",
-       "      <td>4.067077</td>\n",
-       "      <td>2.031572</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>0.886213</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1.524223</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>8.398719</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>1.08387</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>1.999448</td>\n",
-       "      <td>-1.651685</td>\n",
-       "      <td>1</td>\n",
+       "      <td>f65</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0.533333</td>\n",
+       "      <td>3.256017</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>f164</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0.533333</td>\n",
+       "      <td>2.967274</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>f162</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.466667</td>\n",
+       "      <td>2.713865</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>f260</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.466667</td>\n",
+       "      <td>-1.361622</td>\n",
+       "      <td>decrease</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>f201</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0.400000</td>\n",
+       "      <td>5.896304</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>f227</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0.400000</td>\n",
+       "      <td>-0.976407</td>\n",
+       "      <td>decrease</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>f161</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.333333</td>\n",
+       "      <td>4.751266</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>f211</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.333333</td>\n",
+       "      <td>2.819815</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>f149</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.333333</td>\n",
+       "      <td>1.630964</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>f226</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.333333</td>\n",
+       "      <td>1.107697</td>\n",
+       "      <td>increase</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1 rows × 322 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "         f0        f1        f2        f3        f4        f5        f6  \\\n",
-       "0 -1.651685  1.607858  4.067077  2.031572 -1.651685  0.886213 -1.651685   \n",
-       "\n",
-       "         f7        f8        f9  ...      f312      f313      f314      f315  \\\n",
-       "0 -1.651685 -1.651685 -1.651685  ...  1.524223 -1.651685  8.398719 -1.651685   \n",
-       "\n",
-       "      f316      f317      f318      f319      f320  outcome  \n",
-       "0  1.08387 -1.651685 -1.651685  1.999448 -1.651685        1  \n",
-       "\n",
-       "[1 rows x 322 columns]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Diverse Counterfactual set (new outcome: 0)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>f0</th>\n",
-       "      <th>f1</th>\n",
-       "      <th>f2</th>\n",
-       "      <th>f3</th>\n",
-       "      <th>f4</th>\n",
-       "      <th>f5</th>\n",
-       "      <th>f6</th>\n",
-       "      <th>f7</th>\n",
-       "      <th>f8</th>\n",
-       "      <th>f9</th>\n",
-       "      <th>...</th>\n",
-       "      <th>f312</th>\n",
-       "      <th>f313</th>\n",
-       "      <th>f314</th>\n",
-       "      <th>f315</th>\n",
-       "      <th>f316</th>\n",
-       "      <th>f317</th>\n",
-       "      <th>f318</th>\n",
-       "      <th>f319</th>\n",
-       "      <th>f320</th>\n",
-       "      <th>outcome</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>-1.658748388</td>\n",
-       "      <td>3.07791972</td>\n",
-       "      <td>6.81216097</td>\n",
-       "      <td>6.5858531</td>\n",
-       "      <td>8.66979694</td>\n",
-       "      <td>-1.658748388</td>\n",
-       "      <td>-1.658748388</td>\n",
-       "      <td>-1.65874839</td>\n",
-       "      <td>-1.658748388</td>\n",
-       "      <td>-0.698746443</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1.30955088</td>\n",
-       "      <td>-1.658748388</td>\n",
-       "      <td>5.421412468</td>\n",
-       "      <td>-1.6587483883</td>\n",
-       "      <td>2.022823334</td>\n",
-       "      <td>3.41038799</td>\n",
-       "      <td>-1.658748388</td>\n",
-       "      <td>0.239433646</td>\n",
-       "      <td>-1.65874839</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>2.03709078</td>\n",
-       "      <td>5.4041996</td>\n",
-       "      <td>2.698209286</td>\n",
-       "      <td>7.40868378</td>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>-1.68713617</td>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0.76798427</td>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>6.975078106</td>\n",
-       "      <td>1.6736824512</td>\n",
-       "      <td>8.974164963</td>\n",
-       "      <td>4.53500175</td>\n",
-       "      <td>4.277351379</td>\n",
-       "      <td>-1.687136173</td>\n",
-       "      <td>-1.68713617</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>-1.46440434</td>\n",
-       "      <td>5.00017118</td>\n",
-       "      <td>1.536356211</td>\n",
-       "      <td>-1.46440434</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>1.242063642</td>\n",
-       "      <td>-1.46440434</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>...</td>\n",
-       "      <td>-1.46440434</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>4.096763134</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>-1.46440434</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>-1.464404345</td>\n",
-       "      <td>-1.46440434</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>3 rows × 322 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "             f0           f1          f2           f3           f4  \\\n",
-       "0  -1.658748388   3.07791972  6.81216097    6.5858531   8.66979694   \n",
-       "0  -1.687136173   2.03709078   5.4041996  2.698209286   7.40868378   \n",
-       "0  -1.464404345  -1.46440434  5.00017118  1.536356211  -1.46440434   \n",
-       "\n",
-       "             f5            f6           f7            f8            f9  ...  \\\n",
-       "0  -1.658748388  -1.658748388  -1.65874839  -1.658748388  -0.698746443  ...   \n",
-       "0  -1.687136173  -1.687136173  -1.68713617  -1.687136173  -1.687136173  ...   \n",
-       "0  -1.464404345   1.242063642  -1.46440434  -1.464404345  -1.464404345  ...   \n",
-       "\n",
-       "          f312          f313          f314           f315          f316  \\\n",
-       "0   1.30955088  -1.658748388   5.421412468  -1.6587483883   2.022823334   \n",
-       "0   0.76798427  -1.687136173   6.975078106   1.6736824512   8.974164963   \n",
-       "0  -1.46440434  -1.464404345  -1.464404345    4.096763134  -1.464404345   \n",
-       "\n",
-       "          f317          f318          f319         f320 outcome  \n",
-       "0   3.41038799  -1.658748388   0.239433646  -1.65874839     0.0  \n",
-       "0   4.53500175   4.277351379  -1.687136173  -1.68713617     0.0  \n",
-       "0  -1.46440434  -1.464404345  -1.464404345  -1.46440434     0.0  \n",
-       "\n",
-       "[3 rows x 322 columns]"
+       "  feature  n_samples  frequency  mean_delta direction\n",
+       "0     f65          8   0.533333    3.256017  increase\n",
+       "1    f164          8   0.533333    2.967274  increase\n",
+       "2    f162          7   0.466667    2.713865  increase\n",
+       "3    f260          7   0.466667   -1.361622  decrease\n",
+       "4    f201          6   0.400000    5.896304  increase\n",
+       "5    f227          6   0.400000   -0.976407  decrease\n",
+       "6    f161          5   0.333333    4.751266  increase\n",
+       "7    f211          5   0.333333    2.819815  increase\n",
+       "8    f149          5   0.333333    1.630964  increase\n",
+       "9    f226          5   0.333333    1.107697  increase"
       ]
      },
      "metadata": {},
@@ -969,28 +1420,23 @@
     }
    ],
    "source": [
-    "query = Xc_test.iloc[[0]]\n",
-    "\n",
     "try:\n",
-    "    print(\"Prediction for query sample:\",\n",
-    "          dataset.target_names[int(cf_model.predict(query)[0])])\n",
-    "\n",
-    "    # One call: fit an explainer on the training distribution and generate CFs.\n",
-    "    cf = mf.explain_counterfactual(\n",
+    "    importance = mf.counterfactual_importance(\n",
     "        cf_model,\n",
-    "        query=query,\n",
+    "        Xc_test.iloc[:15],       # a small cohort, for speed\n",
+    "        yc_train,\n",
     "        background_data=Xc_train,\n",
-    "        y=yc_train,\n",
     "        total_CFs=3,\n",
+    "        top_n=10,\n",
     "    )\n",
-    "    cf.visualize_as_dataframe(show_only_changes=True)\n",
+    "    display(importance)\n",
     "except ImportError as e:\n",
-    "    print(\"Counterfactual section skipped —\", e)"
+    "    print(\"Cohort counterfactual section skipped —\", e)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ac5a1230",
+   "id": "42e211da",
    "metadata": {},
    "source": [
     "## 9. Compare algorithms\n",
@@ -1000,14 +1446,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "17126b79",
+   "execution_count": 17,
+   "id": "10d65858",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:09:54.990511Z",
-     "iopub.status.busy": "2026-07-12T15:09:54.990409Z",
-     "iopub.status.idle": "2026-07-12T15:09:55.388828Z",
-     "shell.execute_reply": "2026-07-12T15:09:55.388574Z"
+     "iopub.execute_input": "2026-07-12T15:41:57.159380Z",
+     "iopub.status.busy": "2026-07-12T15:41:57.159240Z",
+     "iopub.status.idle": "2026-07-12T15:41:57.590618Z",
+     "shell.execute_reply": "2026-07-12T15:41:57.590311Z"
     }
    },
    "outputs": [
@@ -1033,7 +1479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9f3578a",
+   "id": "c57f13a4",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -1041,8 +1487,9 @@
     "We exercised the full public surface end-to-end on a real CRC dataset:\n",
     "`MicrobiomeDataset`, the preprocessing transforms, sklearn interop\n",
     "(`Pipeline`/`cross_validate`/`GridSearchCV`), the `mf.classify()` one-liner,\n",
-    "`MicrobiomeClassifier` train/predict, the visualization helpers, and\n",
-    "`mf.explain_counterfactual()` counterfactuals.\n",
+    "`MicrobiomeClassifier` train/predict, the visualization helpers, `mf.explore()`\n",
+    "cutoff diagnostics, and actionable `mf.explain_counterfactual()` /\n",
+    "`mf.counterfactual_importance()` counterfactuals.\n",
     "\n",
     "If every cell above ran without error, the library is healthy end-to-end."
    ]


### PR DESCRIPTION
Now that `mf.explore()` (#25) and the improved counterfactual API (#26) are both on `main`, this updates the end-to-end tour to demonstrate everything together.

## Changes
- **Counterfactual section** uses the new `CounterfactualResult`: `.summary()` + `.changes(0)` show a sparse, validated result (on the CRC model: **1–2 taxa changed, 100% validity** — vs. the old 220/220).
- **New cohort cell**: `mf.counterfactual_importance()` ranks taxa by how often they must change across a small cohort, with direction.
- (The `mf.explore()` cutoff-diagnostics panel was already added in #25.)

## Verification
Re-executed end-to-end via nbconvert: **31 cells, 0 errors**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)