### PR TITLE
fix: keep real taxon names in counterfactual demo

### DIFF
--- a/docs/counterfactuals.rst
+++ b/docs/counterfactuals.rst
@@ -43,6 +43,15 @@ Quickstart
 object). It exposes ``.changes()``, ``.n_changes``, ``.validity`` and
 ``.summary()``.
 
+.. tip::
+
+   Keep the **real taxon names** as your feature columns. MicroFactual's
+   preprocessing transforms preserve them end-to-end, and DiCE handles names
+   with spaces/brackets fine — so ``.changes()`` names actual species (e.g.
+   *Parvimonas micra*) instead of opaque ``f0``/``f1`` placeholders. Renaming
+   features to positional ids throws away the interpretability that is the whole
+   point of a counterfactual.
+
 Actionable (sparse) counterfactuals
 -----------------------------------
 

--- a/notebooks/00_End_to_End_Feature_Tour.ipynb
+++ b/notebooks/00_End_to_End_Feature_Tour.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bfb1a210",
+   "id": "a23a6c20",
    "metadata": {},
    "source": [
     "# MicroFactual — End-to-End Feature Tour\n",
@@ -31,13 +31,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "81862afd",
+   "id": "0cacc479",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:26.710284Z",
-     "iopub.status.busy": "2026-07-12T15:41:26.710060Z",
-     "iopub.status.idle": "2026-07-12T15:41:28.882658Z",
-     "shell.execute_reply": "2026-07-12T15:41:28.882428Z"
+     "iopub.execute_input": "2026-07-12T15:56:48.313058Z",
+     "iopub.status.busy": "2026-07-12T15:56:48.312660Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.039838Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.039571Z"
     }
    },
    "outputs": [
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25b0662f",
+   "id": "90eb5879",
    "metadata": {},
    "source": [
     "## 1. Load a real dataset\n",
@@ -75,13 +75,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3aede241",
+   "id": "13637e0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:28.883857Z",
-     "iopub.status.busy": "2026-07-12T15:41:28.883711Z",
-     "iopub.status.idle": "2026-07-12T15:41:28.907275Z",
-     "shell.execute_reply": "2026-07-12T15:41:28.907041Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.041259Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.041082Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.060334Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.060077Z"
     }
    },
    "outputs": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9953e764",
+   "id": "58ee2687",
    "metadata": {},
    "source": [
     "## 2. Explore the data\n",
@@ -127,13 +127,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "53461338",
+   "id": "cec96a2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:28.908449Z",
-     "iopub.status.busy": "2026-07-12T15:41:28.908380Z",
-     "iopub.status.idle": "2026-07-12T15:41:28.913476Z",
-     "shell.execute_reply": "2026-07-12T15:41:28.913300Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.061573Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.061491Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.066750Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.066460Z"
     }
    },
    "outputs": [
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ea95dbd",
+   "id": "92f63c18",
    "metadata": {},
    "source": [
     "### Choosing preprocessing cutoffs visually\n",
@@ -181,13 +181,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d1b478df",
+   "id": "93625ff2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:28.914546Z",
-     "iopub.status.busy": "2026-07-12T15:41:28.914469Z",
-     "iopub.status.idle": "2026-07-12T15:41:29.157938Z",
-     "shell.execute_reply": "2026-07-12T15:41:29.157645Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.067934Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.067830Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.303410Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.303151Z"
     }
    },
    "outputs": [
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b152a02",
+   "id": "bafb061b",
    "metadata": {},
    "source": [
     "## 3. Microbiome-aware preprocessing\n",
@@ -224,13 +224,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a1b5875c",
+   "id": "88d11eb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:29.159318Z",
-     "iopub.status.busy": "2026-07-12T15:41:29.159221Z",
-     "iopub.status.idle": "2026-07-12T15:41:29.163671Z",
-     "shell.execute_reply": "2026-07-12T15:41:29.163445Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.304632Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.304542Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.308615Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.308417Z"
     }
    },
    "outputs": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d175f26",
+   "id": "96fbd7c7",
    "metadata": {},
    "source": [
     "The `MicrobiomeDataset` also offers convenience methods that track a preprocessing history:"
@@ -272,13 +272,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "9a1296dc",
+   "id": "1d751533",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:29.164672Z",
-     "iopub.status.busy": "2026-07-12T15:41:29.164602Z",
-     "iopub.status.idle": "2026-07-12T15:41:29.170288Z",
-     "shell.execute_reply": "2026-07-12T15:41:29.170073Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.309598Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.309531Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.314921Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.314711Z"
     }
    },
    "outputs": [
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d33c2dda",
+   "id": "0ff1665b",
    "metadata": {},
    "source": [
     "## 4. sklearn-native usage\n",
@@ -321,13 +321,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e0e73e81",
+   "id": "36bc1539",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:29.171315Z",
-     "iopub.status.busy": "2026-07-12T15:41:29.171239Z",
-     "iopub.status.idle": "2026-07-12T15:41:29.552786Z",
-     "shell.execute_reply": "2026-07-12T15:41:29.552515Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.316036Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.315940Z",
+     "iopub.status.idle": "2026-07-12T15:56:50.702428Z",
+     "shell.execute_reply": "2026-07-12T15:56:50.702120Z"
     }
    },
    "outputs": [
@@ -358,13 +358,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "99b3be90",
+   "id": "2ca9586c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:29.554015Z",
-     "iopub.status.busy": "2026-07-12T15:41:29.553935Z",
-     "iopub.status.idle": "2026-07-12T15:41:30.212928Z",
-     "shell.execute_reply": "2026-07-12T15:41:30.212659Z"
+     "iopub.execute_input": "2026-07-12T15:56:50.703611Z",
+     "iopub.status.busy": "2026-07-12T15:56:50.703537Z",
+     "iopub.status.idle": "2026-07-12T15:56:51.352373Z",
+     "shell.execute_reply": "2026-07-12T15:56:51.352112Z"
     }
    },
    "outputs": [
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2661ed6",
+   "id": "791a1380",
    "metadata": {},
    "source": [
     "## 5. One-liner API\n",
@@ -406,13 +406,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7ab692f7",
+   "id": "71688621",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:30.214136Z",
-     "iopub.status.busy": "2026-07-12T15:41:30.214059Z",
-     "iopub.status.idle": "2026-07-12T15:41:30.712994Z",
-     "shell.execute_reply": "2026-07-12T15:41:30.712734Z"
+     "iopub.execute_input": "2026-07-12T15:56:51.353633Z",
+     "iopub.status.busy": "2026-07-12T15:56:51.353554Z",
+     "iopub.status.idle": "2026-07-12T15:56:51.903246Z",
+     "shell.execute_reply": "2026-07-12T15:56:51.902693Z"
     }
    },
    "outputs": [
@@ -422,8 +422,8 @@
      "text": [
       "Returned keys: ['model', 'dataset', 'cv_scores']\n",
       "CV scores:\n",
-      "            fit_time: 0.070\n",
-      "          score_time: 0.004\n",
+      "            fit_time: 0.077\n",
+      "          score_time: 0.005\n",
       "       test_accuracy: 0.751\n",
       "      train_accuracy: 1.000\n",
       "             test_f1: 0.818\n",
@@ -449,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a20dbce",
+   "id": "33a8b8a9",
    "metadata": {},
    "source": [
     "## 6. Train / test evaluation\n",
@@ -460,13 +460,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "96fddba4",
+   "id": "86ea3e16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:30.714323Z",
-     "iopub.status.busy": "2026-07-12T15:41:30.714228Z",
-     "iopub.status.idle": "2026-07-12T15:41:30.788127Z",
-     "shell.execute_reply": "2026-07-12T15:41:30.787854Z"
+     "iopub.execute_input": "2026-07-12T15:56:51.905361Z",
+     "iopub.status.busy": "2026-07-12T15:56:51.905211Z",
+     "iopub.status.idle": "2026-07-12T15:56:52.006184Z",
+     "shell.execute_reply": "2026-07-12T15:56:52.005615Z"
     }
    },
    "outputs": [
@@ -505,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dabeccb",
+   "id": "97a69fef",
    "metadata": {},
    "source": [
     "## 7. Visualization\n",
@@ -516,13 +516,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6a509bcf",
+   "id": "d32cd039",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:30.789358Z",
-     "iopub.status.busy": "2026-07-12T15:41:30.789278Z",
-     "iopub.status.idle": "2026-07-12T15:41:30.831398Z",
-     "shell.execute_reply": "2026-07-12T15:41:30.831125Z"
+     "iopub.execute_input": "2026-07-12T15:56:52.008584Z",
+     "iopub.status.busy": "2026-07-12T15:56:52.008435Z",
+     "iopub.status.idle": "2026-07-12T15:56:52.065220Z",
+     "shell.execute_reply": "2026-07-12T15:56:52.064906Z"
     }
    },
    "outputs": [
@@ -545,13 +545,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "5140da5f",
+   "id": "73ea3e9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:30.832644Z",
-     "iopub.status.busy": "2026-07-12T15:41:30.832567Z",
-     "iopub.status.idle": "2026-07-12T15:41:30.880180Z",
-     "shell.execute_reply": "2026-07-12T15:41:30.879918Z"
+     "iopub.execute_input": "2026-07-12T15:56:52.066839Z",
+     "iopub.status.busy": "2026-07-12T15:56:52.066722Z",
+     "iopub.status.idle": "2026-07-12T15:56:52.116601Z",
+     "shell.execute_reply": "2026-07-12T15:56:52.116279Z"
     }
    },
    "outputs": [
@@ -576,13 +576,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "94f82694",
+   "id": "9ec8e060",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:30.881312Z",
-     "iopub.status.busy": "2026-07-12T15:41:30.881226Z",
-     "iopub.status.idle": "2026-07-12T15:41:30.952733Z",
-     "shell.execute_reply": "2026-07-12T15:41:30.952439Z"
+     "iopub.execute_input": "2026-07-12T15:56:52.118211Z",
+     "iopub.status.busy": "2026-07-12T15:56:52.118089Z",
+     "iopub.status.idle": "2026-07-12T15:56:52.193882Z",
+     "shell.execute_reply": "2026-07-12T15:56:52.193471Z"
     }
    },
    "outputs": [
@@ -607,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f296b792",
+   "id": "04b2b413",
    "metadata": {},
    "source": [
     "## 8. Counterfactual explanations (headline feature)\n",
@@ -628,13 +628,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "09573377",
+   "id": "841f95df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:30.954044Z",
-     "iopub.status.busy": "2026-07-12T15:41:30.953937Z",
-     "iopub.status.idle": "2026-07-12T15:41:31.022995Z",
-     "shell.execute_reply": "2026-07-12T15:41:31.022735Z"
+     "iopub.execute_input": "2026-07-12T15:56:52.195769Z",
+     "iopub.status.busy": "2026-07-12T15:56:52.195668Z",
+     "iopub.status.idle": "2026-07-12T15:56:52.267718Z",
+     "shell.execute_reply": "2026-07-12T15:56:52.267404Z"
     }
    },
    "outputs": [
@@ -647,15 +647,15 @@
     }
    ],
    "source": [
-    "# Work in the CLR-transformed feature space so DiCE perturbs the model's actual inputs.\n",
-    "X_clr = pd.DataFrame(\n",
-    "    CLRTransform().fit_transform(\n",
-    "        PrevalenceFilter(min_prevalence=0.01).fit_transform(\n",
-    "            AbundanceFilter(min_abundance=1e-6).fit_transform(X)\n",
-    "        )\n",
+    "# Work in the CLR-transformed feature space so DiCE perturbs the model's actual\n",
+    "# inputs. The preprocessing transforms preserve the real taxon names end-to-end,\n",
+    "# so counterfactuals name actual species (e.g. \"Parvimonas micra\") rather than\n",
+    "# opaque f0/f1 placeholders — the whole point of an interpretable explanation.\n",
+    "X_clr = CLRTransform().fit_transform(\n",
+    "    PrevalenceFilter(min_prevalence=0.01).fit_transform(\n",
+    "        AbundanceFilter(min_abundance=1e-6).fit_transform(X)\n",
     "    )\n",
     ")\n",
-    "X_clr.columns = [f\"f{i}\" for i in range(X_clr.shape[1])]  # DiCE-friendly names\n",
     "\n",
     "Xc_train, Xc_test, yc_train, yc_test = train_test_split(\n",
     "    X_clr, y, test_size=0.3, random_state=42, stratify=y\n",
@@ -670,13 +670,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "1a34c35a",
+   "id": "4081a036",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:31.024220Z",
-     "iopub.status.busy": "2026-07-12T15:41:31.024143Z",
-     "iopub.status.idle": "2026-07-12T15:41:32.686879Z",
-     "shell.execute_reply": "2026-07-12T15:41:32.686628Z"
+     "iopub.execute_input": "2026-07-12T15:56:52.269536Z",
+     "iopub.status.busy": "2026-07-12T15:56:52.269405Z",
+     "iopub.status.idle": "2026-07-12T15:56:53.976036Z",
+     "shell.execute_reply": "2026-07-12T15:56:53.975687Z"
     }
    },
    "outputs": [
@@ -700,7 +700,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.31it/s]"
      ]
     },
     {
@@ -708,7 +708,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.31it/s]"
      ]
     },
     {
@@ -756,7 +756,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>f178</td>\n",
+       "      <td>Ruminococcus bromii [1569]</td>\n",
        "      <td>9.904985</td>\n",
        "      <td>0.755342</td>\n",
        "      <td>-9.149643</td>\n",
@@ -767,8 +767,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  feature  original  counterfactual     delta direction\n",
-       "0    f178  9.904985        0.755342 -9.149643  decrease"
+       "                      feature  original  counterfactual     delta direction\n",
+       "0  Ruminococcus bromii [1569]  9.904985        0.755342 -9.149643  decrease"
       ]
      },
      "metadata": {},
@@ -799,7 +799,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad0065de",
+   "id": "2aaa6c62",
    "metadata": {},
    "source": [
     "### Cohort-level counterfactual importance\n",
@@ -813,13 +813,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d4ba9bc7",
+   "id": "113c4b9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:32.688097Z",
-     "iopub.status.busy": "2026-07-12T15:41:32.688021Z",
-     "iopub.status.idle": "2026-07-12T15:41:57.157498Z",
-     "shell.execute_reply": "2026-07-12T15:41:57.157175Z"
+     "iopub.execute_input": "2026-07-12T15:56:53.977454Z",
+     "iopub.status.busy": "2026-07-12T15:56:53.977360Z",
+     "iopub.status.idle": "2026-07-12T15:57:18.247235Z",
+     "shell.execute_reply": "2026-07-12T15:57:18.246954Z"
     }
    },
    "outputs": [
@@ -836,7 +836,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
      ]
     },
     {
@@ -844,7 +844,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
      ]
     },
     {
@@ -867,7 +867,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
      ]
     },
     {
@@ -875,7 +875,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
      ]
     },
     {
@@ -898,7 +898,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
      ]
     },
     {
@@ -906,38 +906,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
      ]
     },
     {
@@ -969,161 +938,6 @@
      "text": [
       "\r",
       "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
      ]
     },
     {
@@ -1177,7 +991,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.05it/s]"
      ]
     },
     {
@@ -1185,7 +999,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.05it/s]"
      ]
     },
     {
@@ -1208,7 +1022,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.37it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.51it/s]"
      ]
     },
     {
@@ -1216,7 +1030,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.36it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.51it/s]"
      ]
     },
     {
@@ -1239,7 +1053,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.42it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
      ]
     },
     {
@@ -1247,7 +1061,193 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.42it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  1.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  1.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.45it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
      ]
     },
     {
@@ -1319,63 +1319,63 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>f65</td>\n",
+       "      <td>Gemella morbillorum [1302]</td>\n",
        "      <td>8</td>\n",
        "      <td>0.533333</td>\n",
-       "      <td>3.256017</td>\n",
+       "      <td>3.272303</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>f164</td>\n",
+       "      <td>Peptostreptococcus stomatis [1530]</td>\n",
        "      <td>8</td>\n",
        "      <td>0.533333</td>\n",
-       "      <td>2.967274</td>\n",
+       "      <td>3.076364</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>f162</td>\n",
+       "      <td>Escherichia coli [390]</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0.533333</td>\n",
+       "      <td>-2.127725</td>\n",
+       "      <td>decrease</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Clostridium symbiosum [1600]</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.466667</td>\n",
+       "      <td>4.258748</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>unnamed Parvimonas sp. oral taxon 110 [1506]</td>\n",
        "      <td>7</td>\n",
        "      <td>0.466667</td>\n",
        "      <td>2.713865</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>f260</td>\n",
-       "      <td>7</td>\n",
-       "      <td>0.466667</td>\n",
-       "      <td>-1.361622</td>\n",
-       "      <td>decrease</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>f201</td>\n",
-       "      <td>6</td>\n",
-       "      <td>0.400000</td>\n",
-       "      <td>5.896304</td>\n",
-       "      <td>increase</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>f227</td>\n",
+       "      <td>Parvimonas micra [1505]</td>\n",
        "      <td>6</td>\n",
        "      <td>0.400000</td>\n",
-       "      <td>-0.976407</td>\n",
-       "      <td>decrease</td>\n",
+       "      <td>3.322925</td>\n",
+       "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>f161</td>\n",
-       "      <td>5</td>\n",
-       "      <td>0.333333</td>\n",
-       "      <td>4.751266</td>\n",
-       "      <td>increase</td>\n",
+       "      <td>Eubacterium rectale [1630]</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0.400000</td>\n",
+       "      <td>-1.680489</td>\n",
+       "      <td>decrease</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>f211</td>\n",
+       "      <td>[Ruminococcus] gnavus [1611]</td>\n",
        "      <td>5</td>\n",
        "      <td>0.333333</td>\n",
        "      <td>2.819815</td>\n",
@@ -1383,15 +1383,15 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>f149</td>\n",
+       "      <td>unclassified Fusobacterium [1482]</td>\n",
        "      <td>5</td>\n",
        "      <td>0.333333</td>\n",
-       "      <td>1.630964</td>\n",
+       "      <td>1.721709</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>f226</td>\n",
+       "      <td>Eubacterium ventriosum [1629]</td>\n",
        "      <td>5</td>\n",
        "      <td>0.333333</td>\n",
        "      <td>1.107697</td>\n",
@@ -1402,17 +1402,29 @@
        "</div>"
       ],
       "text/plain": [
-       "  feature  n_samples  frequency  mean_delta direction\n",
-       "0     f65          8   0.533333    3.256017  increase\n",
-       "1    f164          8   0.533333    2.967274  increase\n",
-       "2    f162          7   0.466667    2.713865  increase\n",
-       "3    f260          7   0.466667   -1.361622  decrease\n",
-       "4    f201          6   0.400000    5.896304  increase\n",
-       "5    f227          6   0.400000   -0.976407  decrease\n",
-       "6    f161          5   0.333333    4.751266  increase\n",
-       "7    f211          5   0.333333    2.819815  increase\n",
-       "8    f149          5   0.333333    1.630964  increase\n",
-       "9    f226          5   0.333333    1.107697  increase"
+       "                                        feature  n_samples  frequency  \\\n",
+       "0                    Gemella morbillorum [1302]          8   0.533333   \n",
+       "1            Peptostreptococcus stomatis [1530]          8   0.533333   \n",
+       "2                        Escherichia coli [390]          8   0.533333   \n",
+       "3                  Clostridium symbiosum [1600]          7   0.466667   \n",
+       "4  unnamed Parvimonas sp. oral taxon 110 [1506]          7   0.466667   \n",
+       "5                       Parvimonas micra [1505]          6   0.400000   \n",
+       "6                    Eubacterium rectale [1630]          6   0.400000   \n",
+       "7                  [Ruminococcus] gnavus [1611]          5   0.333333   \n",
+       "8             unclassified Fusobacterium [1482]          5   0.333333   \n",
+       "9                 Eubacterium ventriosum [1629]          5   0.333333   \n",
+       "\n",
+       "   mean_delta direction  \n",
+       "0    3.272303  increase  \n",
+       "1    3.076364  increase  \n",
+       "2   -2.127725  decrease  \n",
+       "3    4.258748  increase  \n",
+       "4    2.713865  increase  \n",
+       "5    3.322925  increase  \n",
+       "6   -1.680489  decrease  \n",
+       "7    2.819815  increase  \n",
+       "8    1.721709  increase  \n",
+       "9    1.107697  increase  "
       ]
      },
      "metadata": {},
@@ -1436,7 +1448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42e211da",
+   "id": "c9f0c261",
    "metadata": {},
    "source": [
     "## 9. Compare algorithms\n",
@@ -1447,13 +1459,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "10d65858",
+   "id": "ad79ef3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T15:41:57.159380Z",
-     "iopub.status.busy": "2026-07-12T15:41:57.159240Z",
-     "iopub.status.idle": "2026-07-12T15:41:57.590618Z",
-     "shell.execute_reply": "2026-07-12T15:41:57.590311Z"
+     "iopub.execute_input": "2026-07-12T15:57:18.248452Z",
+     "iopub.status.busy": "2026-07-12T15:57:18.248377Z",
+     "iopub.status.idle": "2026-07-12T15:57:18.664131Z",
+     "shell.execute_reply": "2026-07-12T15:57:18.663855Z"
     }
    },
    "outputs": [
@@ -1479,7 +1491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c57f13a4",
+   "id": "5f2a2e07",
    "metadata": {},
    "source": [
     "## Summary\n",


### PR DESCRIPTION
Follow-up to the counterfactual work: the tour notebook was renaming CLR features to `f0/f1/...` ("DiCE-friendly names"), which made counterfactual output uninterpretable.

## Why it was wrong
- The rename existed **only in the notebook** — the library's transforms (`AbundanceFilter`, `PrevalenceFilter`, `CLRTransform`) all preserve real taxon-name columns end-to-end.
- It was **unnecessary**: DiCE works fine with names containing spaces/brackets (verified).
- It was **harmful**: it defeats the point of a counterfactual — "f110 ↑" tells a researcher nothing.

## Fix
Drop the rename so counterfactuals name actual species. Output now surfaces known CRC-associated taxa (*Peptostreptococcus stomatis*, *Escherichia coli*, *Gemella morbillorum*, *Ruminococcus bromii*). Added a docs tip warning against positional renaming.

## Verification
Notebook re-executed end-to-end: **0 errors**; CF `.changes()` and `counterfactual_importance()` now show real species names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)