### PR TITLE
fix: explain_counterfactual returns empty result (not []) when no CF found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End-to-end feature-tour notebook (`notebooks/00_End_to_End_Feature_Tour.ipynb`) exercising the full public API on the shipped Zeller 2014 CRC dataset.
 
 ### Fixed
+- `explain_counterfactual()` now always returns a single `CounterfactualResult` for a single-row query, even when DiCE finds no counterfactual (previously it returned a bare `[]`, causing `AttributeError: 'list' object has no attribute 'changes'` downstream). `CounterfactualResult.changes()` also handles zero counterfactuals without raising. Empty results report `n_counterfactuals == 0` / `validity == 0` and a "No counterfactuals found." summary.
 - Version metadata is now consistent: `pyproject.toml` bumped to `0.2.0` to match `microfactual.__version__`.
 - `MicrobiomeClassifier` now exposes forwarded model kwargs (e.g. `n_estimators`, `max_depth`) through `get_params`/`set_params`, so `sklearn.clone`, `set_params`, and `GridSearchCV` can tune the underlying classifier's hyperparameters. Previously these raised `Invalid parameter` under GridSearchCV.
 - CI lint (`ruff check src/microfactual`) now passes: migrated ruff config to the `[tool.ruff.lint]` section, ignored ML naming conventions (`X`/`y`) and undocumented `__init__`, per-file-ignored `E402` in the deprecated shim modules, and documented the `y` parameter on transformer `fit` methods.

--- a/notebooks/00_End_to_End_Feature_Tour.ipynb
+++ b/notebooks/00_End_to_End_Feature_Tour.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "34734c75",
+   "id": "31d77b1f",
    "metadata": {},
    "source": [
     "# MicroFactual — End-to-End Feature Tour\n",
@@ -32,13 +32,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "8ef6656b",
+   "id": "53859a7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:49.335046Z",
-     "iopub.status.busy": "2026-07-12T16:39:49.334928Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.126941Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.126658Z"
+     "iopub.execute_input": "2026-07-12T17:07:57.421739Z",
+     "iopub.status.busy": "2026-07-12T17:07:57.421532Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.105787Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.105542Z"
     }
    },
    "outputs": [
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "348e03f8",
+   "id": "6a712bc3",
    "metadata": {},
    "source": [
     "## 1. Load a real dataset\n",
@@ -76,13 +76,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a1a695fd",
+   "id": "f85afb76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.128292Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.128123Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.147523Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.147316Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.107227Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.107087Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.128176Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.127974Z"
     }
    },
    "outputs": [
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c4d3687",
+   "id": "b7fcba85",
    "metadata": {},
    "source": [
     "## 2. Explore the data\n",
@@ -128,13 +128,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8a6e6d18",
+   "id": "7861f135",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.148720Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.148642Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.153233Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.153004Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.129608Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.129512Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.134222Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.134011Z"
     }
    },
    "outputs": [
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8382f894",
+   "id": "aefdcfdc",
    "metadata": {},
    "source": [
     "### Choosing preprocessing cutoffs visually\n",
@@ -182,13 +182,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "14c0f291",
+   "id": "6fd3addc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.154299Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.154215Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.390554Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.390279Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.135298Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.135231Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.369915Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.369678Z"
     }
    },
    "outputs": [
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecfa5d7a",
+   "id": "92a8c6fe",
    "metadata": {},
    "source": [
     "## 3. Microbiome-aware preprocessing\n",
@@ -225,13 +225,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "59191266",
+   "id": "bd02fce9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.391991Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.391896Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.396074Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.395874Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.371137Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.371038Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.375157Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.374970Z"
     }
    },
    "outputs": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e03c721",
+   "id": "8bad73be",
    "metadata": {},
    "source": [
     "The `MicrobiomeDataset` also offers convenience methods that track a preprocessing history:"
@@ -273,13 +273,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "75b89c22",
+   "id": "7a5c6185",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.397166Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.397096Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.402742Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.402522Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.376174Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.376105Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.381498Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.381284Z"
     }
    },
    "outputs": [
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cef1137",
+   "id": "a6ccb685",
    "metadata": {},
    "source": [
     "## 4. sklearn-native usage\n",
@@ -322,13 +322,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "98d1bb22",
+   "id": "241b7e0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.403887Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.403788Z",
-     "iopub.status.idle": "2026-07-12T16:39:51.793906Z",
-     "shell.execute_reply": "2026-07-12T16:39:51.793590Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.382604Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.382514Z",
+     "iopub.status.idle": "2026-07-12T17:07:59.763968Z",
+     "shell.execute_reply": "2026-07-12T17:07:59.763697Z"
     }
    },
    "outputs": [
@@ -359,13 +359,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "bcb8e415",
+   "id": "a4983730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:51.795176Z",
-     "iopub.status.busy": "2026-07-12T16:39:51.795098Z",
-     "iopub.status.idle": "2026-07-12T16:39:52.432044Z",
-     "shell.execute_reply": "2026-07-12T16:39:52.431758Z"
+     "iopub.execute_input": "2026-07-12T17:07:59.765325Z",
+     "iopub.status.busy": "2026-07-12T17:07:59.765235Z",
+     "iopub.status.idle": "2026-07-12T17:08:00.399746Z",
+     "shell.execute_reply": "2026-07-12T17:08:00.399481Z"
     }
    },
    "outputs": [
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9d1a872",
+   "id": "4f850dd5",
    "metadata": {},
    "source": [
     "## 5. One-liner API\n",
@@ -407,13 +407,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "a47fb421",
+   "id": "70a7f77b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:52.433292Z",
-     "iopub.status.busy": "2026-07-12T16:39:52.433212Z",
-     "iopub.status.idle": "2026-07-12T16:39:52.945971Z",
-     "shell.execute_reply": "2026-07-12T16:39:52.945703Z"
+     "iopub.execute_input": "2026-07-12T17:08:00.400971Z",
+     "iopub.status.busy": "2026-07-12T17:08:00.400891Z",
+     "iopub.status.idle": "2026-07-12T17:08:00.907690Z",
+     "shell.execute_reply": "2026-07-12T17:08:00.907356Z"
     }
    },
    "outputs": [
@@ -423,7 +423,7 @@
      "text": [
       "Returned keys: ['model', 'dataset', 'cv_scores']\n",
       "CV scores:\n",
-      "            fit_time: 0.072\n",
+      "            fit_time: 0.071\n",
       "          score_time: 0.005\n",
       "       test_accuracy: 0.751\n",
       "      train_accuracy: 1.000\n",
@@ -450,7 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7188a10d",
+   "id": "b40aa2c7",
    "metadata": {},
    "source": [
     "## 6. Train / test evaluation\n",
@@ -461,13 +461,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b47b5e3b",
+   "id": "ab32253f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:52.947509Z",
-     "iopub.status.busy": "2026-07-12T16:39:52.947409Z",
-     "iopub.status.idle": "2026-07-12T16:39:53.023568Z",
-     "shell.execute_reply": "2026-07-12T16:39:53.023292Z"
+     "iopub.execute_input": "2026-07-12T17:08:00.909150Z",
+     "iopub.status.busy": "2026-07-12T17:08:00.909038Z",
+     "iopub.status.idle": "2026-07-12T17:08:00.980914Z",
+     "shell.execute_reply": "2026-07-12T17:08:00.980645Z"
     }
    },
    "outputs": [
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5877a0ec",
+   "id": "b8852dd3",
    "metadata": {},
    "source": [
     "## 7. Visualization\n",
@@ -517,13 +517,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "da49c93d",
+   "id": "b3d354b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:53.025039Z",
-     "iopub.status.busy": "2026-07-12T16:39:53.024953Z",
-     "iopub.status.idle": "2026-07-12T16:39:53.070805Z",
-     "shell.execute_reply": "2026-07-12T16:39:53.070553Z"
+     "iopub.execute_input": "2026-07-12T17:08:00.982191Z",
+     "iopub.status.busy": "2026-07-12T17:08:00.982090Z",
+     "iopub.status.idle": "2026-07-12T17:08:01.023288Z",
+     "shell.execute_reply": "2026-07-12T17:08:01.023054Z"
     }
    },
    "outputs": [
@@ -546,13 +546,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3e454817",
+   "id": "77e9417c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:53.072034Z",
-     "iopub.status.busy": "2026-07-12T16:39:53.071938Z",
-     "iopub.status.idle": "2026-07-12T16:39:53.120761Z",
-     "shell.execute_reply": "2026-07-12T16:39:53.120476Z"
+     "iopub.execute_input": "2026-07-12T17:08:01.024471Z",
+     "iopub.status.busy": "2026-07-12T17:08:01.024396Z",
+     "iopub.status.idle": "2026-07-12T17:08:01.069818Z",
+     "shell.execute_reply": "2026-07-12T17:08:01.069569Z"
     }
    },
    "outputs": [
@@ -577,13 +577,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "f136d190",
+   "id": "172d2d13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:53.121959Z",
-     "iopub.status.busy": "2026-07-12T16:39:53.121869Z",
-     "iopub.status.idle": "2026-07-12T16:39:53.193651Z",
-     "shell.execute_reply": "2026-07-12T16:39:53.193255Z"
+     "iopub.execute_input": "2026-07-12T17:08:01.071082Z",
+     "iopub.status.busy": "2026-07-12T17:08:01.070994Z",
+     "iopub.status.idle": "2026-07-12T17:08:01.142363Z",
+     "shell.execute_reply": "2026-07-12T17:08:01.142121Z"
     }
    },
    "outputs": [
@@ -608,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7e8b14c",
+   "id": "c16c5206",
    "metadata": {},
    "source": [
     "## 8. Counterfactual explanations (headline feature)\n",
@@ -629,13 +629,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a7d1875f",
+   "id": "769a73df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:53.195001Z",
-     "iopub.status.busy": "2026-07-12T16:39:53.194911Z",
-     "iopub.status.idle": "2026-07-12T16:39:53.261231Z",
-     "shell.execute_reply": "2026-07-12T16:39:53.261003Z"
+     "iopub.execute_input": "2026-07-12T17:08:01.143623Z",
+     "iopub.status.busy": "2026-07-12T17:08:01.143535Z",
+     "iopub.status.idle": "2026-07-12T17:08:01.211130Z",
+     "shell.execute_reply": "2026-07-12T17:08:01.210820Z"
     }
    },
    "outputs": [
@@ -671,13 +671,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "1c7481e5",
+   "id": "294731d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:53.262510Z",
-     "iopub.status.busy": "2026-07-12T16:39:53.262436Z",
-     "iopub.status.idle": "2026-07-12T16:39:54.936378Z",
-     "shell.execute_reply": "2026-07-12T16:39:54.936051Z"
+     "iopub.execute_input": "2026-07-12T17:08:01.212222Z",
+     "iopub.status.busy": "2026-07-12T17:08:01.212144Z",
+     "iopub.status.idle": "2026-07-12T17:08:02.845851Z",
+     "shell.execute_reply": "2026-07-12T17:08:02.845560Z"
     }
    },
    "outputs": [
@@ -701,7 +701,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.18it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
      ]
     },
     {
@@ -709,7 +709,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.18it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
      ]
     },
     {
@@ -723,7 +723,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3 counterfactual(s) flipping CRC → Control; features changed: min=5, median=6, max=8; validity=100%.\n"
+      "3 counterfactual(s) flipping CRC → Control; features changed: min=6, median=8, max=11; validity=100%.\n"
      ]
     },
     {
@@ -857,7 +857,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adadb180",
+   "id": "573aad64",
    "metadata": {},
    "source": [
     "### Plausible counterfactuals + heatmap\n",
@@ -874,367 +874,16 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "0e1f8d07",
+   "id": "e75c7636",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:54.937863Z",
-     "iopub.status.busy": "2026-07-12T16:39:54.937761Z",
-     "iopub.status.idle": "2026-07-12T16:39:55.775308Z",
-     "shell.execute_reply": "2026-07-12T16:39:55.775073Z"
+     "iopub.execute_input": "2026-07-12T17:08:02.847176Z",
+     "iopub.status.busy": "2026-07-12T17:08:02.847081Z",
+     "iopub.status.idle": "2026-07-12T17:08:04.527121Z",
+     "shell.execute_reply": "2026-07-12T17:08:04.526882Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  3.37it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  3.37it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "concordance with Control — unbounded: 100% | bounded: 100%\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7cAAAH/CAYAAACM8CorAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAwPBJREFUeJzs3QV4FFcXBuCTBIIneCC4FHd3d4eixZ1iRYqVon+R0pYWK1Lciru7uzstLklwElyS/Z/v0lk2ySa72cjuhO99nmk3M7Ozd2YnYc6cc+84GQwGgxARERERERHpmLO9G0BEREREREQUXgxuiYiIiIiISPcY3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYjIYR08eFBy584tMWPGlHr16okju3Xrljg5OcmZM2fEEQwfPlzy5csnerNmzRrJnDmzuLi4SK9eveRLVKZMGVm8eLHonV7PwaDmzp0rCRMmDNc2ihUrJitXroywNhGReQxuiYh0zsfHR3r06CEZM2aUWLFiSZo0aaR27dqyc+fOKG8LgjsEJxGlT58+6uL45s2b6gLTEdtIEatz587SsGFDuXv3rvzvf/+TL826devkwYMH0rRp00DzT58+LY0aNRIPDw+JHTu2fPXVV9KxY0f5559/IvTzo/r349GjR/Ltt99K2rRp1d+vFClSSNWqVdWNLU369OlVuzDFiRNH/dy4cWPZtWtXlLSxSZMmgY6zLUH7jz/+KAMHDpSAgIBIaCERaRjcEhHpGLKFBQsWVBd5v/zyi5w/f162bNki5cuXl27duoleffjwQf3/+vXrUqFCBUmdOnW4MydkP/7+/lZd1L98+VIePnyoghtPT09JkCCBTZ/3/v170auJEydK27Ztxdn58yXahg0bVObv3bt3smjRIrl8+bIsXLhQ3N3dZciQIVHexog8vl9//bUK3OfNm6cCSAT35cqVkydPngRab+TIkeLt7S1Xr16V+fPnq78HlSpVklGjRklkQ0CdPHnycG2jevXq8uLFC9m8eXOEtYuIzDAQEZFuVa9e3ZAqVSrDy5cvgy179uyZ8fXt27cNderUMcSLF8+QIEECQ6NGjQw+Pj7G5a1btzbUrVs30Pu/++47Q9myZY0/43WPHj0M/fr1MyRKlMjg4eFhGDZsmHF5unTpDPhnRZvws2bNmjWG/PnzG2LFimXIkCGDYfjw4YYPHz4Yl2P9P//801C7dm1D3LhxVXtMt4Vpzpw5ho8fPxratWtnSJ8+vSF27NiGLFmyGP74449g+z5r1ixDjhw5DK6uroYUKVIYunXrFmobrdn/zZs3G0qWLGlwd3c3JE6c2FCzZk3DtWvXjMtv3ryptnn69Gmz39WgQYMMRYoUCTY/T548hhEjRqjXu3fvNhQuXFgdA3xOiRIlDLdu3TKE5O7du4amTZuq7wPvKViwoOHIkSNqGb6bvHnzGtc9duyYoVKlSoYkSZIY3NzcDGXKlDGcPHnSuDwgIEC9J02aNOq4pUyZUn3fmilTphgyZ86svsPkyZMbvv766xDbhe8K7V+7dq0he/bsBhcXF3V83r59a+jbt6/B09NTtRfHA/us7XvQ71xbtn//fkOpUqXUd546dWrVLtNzHt/jyJEjDS1btlTnN75Pa983atQoQ9u2bQ3x48dX+z59+nSrj7Glc9vSMQ3q4cOHBicnJ8OFCxeM8169emVImjSpoV69embfY/p7vmfPHnX+aOf9gAEDAv2e2fo7rJ1Lf/31l/rdQxut+bsS9Bw013Z8DtodGrTj999/DzZ/6NChBmdnZ8OVK1dCfC+2v3r16kDzcG7iHDX9vV25cqWhXLlyhjhx4qjfyUOHDgU7n7XX5v42WfNd4zxr0aJFqPtKROHD4JaISKeePHmiLjJHjx4d6nr+/v6GfPnyqYv8EydOqAtzXKCbBm7WBrcIinDx/s8//xjmzZunPn/btm3GC3PtQs/b21v9DPv27VPvmzt3ruH69etqfVwgYzsavA8B0+zZs9U6COiwDbwPwStev3792vD+/Xt1QXv8+HHDjRs3DAsXLlQBx9KlS43bQpCMYAbvu3r1qgrqtAvjkNpozf6vWLFCXQD/+++/KoBFIJ47d251fK0JbhGwYLlpQKzNwzYRhOAC+vvvv1frXLp0SR0zBBDmvHjxwpAxY0ZD6dKlVRCHbeA4aBflQQOLnTt3GhYsWGC4fPmy2nb79u1VcOPn56eWL1++XB3vTZs2qc88evSoYcaMGWoZjjcC1MWLF6vv5tSpU4YJEyYYQoLjGzNmTBWcHzx4UAUfCNI6dOig5uGcwD7+8ssvKijE+fTu3Tv1fWmBBr4fzMN6CJ7wHWI9bA/BZJs2bQIFP2j7r7/+qtbXJmvehxsVCNxx/MaMGRMoWLJ0jC2d26EdU3NWrVql2qydU9o8HBPTYMuce/fuqd+Frl27qu8YAR2CYtPg1dbfYWwD7apWrZr67s+ePWvV3xVLwS3OedxU6NWrl7rxEdbgVvsb+PPPP4c7uM2WLZthw4YN6hxs2LCh+kztxoBpcIu/Q7hBkzNnTnWMtL9N1nzXU6dODXTTj4giHoNbIiKdwsUTLspw8RsaXLgiMLlz545x3sWLF9V7EfiFJbjFhawpZImQHQrtQrJixYrBAnAEWchsmL4PF7hBmV6EhgRZWdMsIrKCgwcPDnF9c220Zv+DevTokdrW+fPnrQpuARf6yDCaZnOLFi1qvFC3JoulQYYR2TK8zxxLgQWCE7x//fr16ufffvtNZcJxAyEoBJu4cNcCYUu07NaZM2eM83DBj/Pw/v37wc4PHAfTTJ6WsQUE4Z06dQr0HgSaCELfvHmjfkbAEDSzae37TDNpyL7hJguCEGuOsaVzO7Rjag4COATTphC44Zg8ffo01Pf+8MMPhqxZs6p90CBoR/CoBcu2/g7jXMLNCi3YtfbviqVzULtphCwybkjhxgfOBQTP1gS3gBs03377bbiD25kzZwbbD9wkCBrchrRf1nzXqGTA+Wd684KIIhb73BIR6dSn6zbL0D8Pg0xh0uTIkUP1WcOysMiTJ0+gn1OmTKn6SIbm7Nmzqr9c/PjxjRMGwkH/udevXxvXK1SokFVtmDJliupnnCxZMrWtGTNmyJ07d9QytMXLy0sqVqwoEe3ff/+VZs2aqYG73Nzc1KA2oH22NZo3b24cBRff399//63mQeLEiaVNmzaqvykGBJswYYI6RiHBqMz58+dX77MGBinCccdAROiriX1AH1et/Ris6M2bN2r/sN7q1avl48ePalnlypUlXbp0alnLli1Vv0/T784cV1fXQOcL+oOj722WLFkCnQt79+5VfatDO38wmJjpe3CM0IcXA42FdP5Y+z7TNmLAIgxopJ3Tlo6xpXM7tGNqDtbFYFG2/p4XL15c7YOmZMmS6ju+d++e2f219ncY8P3jd87Wvyv79+8PdJxwDml9bvE7i7621apVkz179kiBAgWsHkAOx8d0n21lelxwTMCa46Kx5rtG312cf+g7TUSRI0YkbZeIiCIZghRc1F25ciXc28LgNUEvorVBnUzhkTym8PmWBgrCxfWIESOkQYMGwZaZXsjHixfPYjuXLFki33//vfz222/qQh4DDmEgraNHjxovHiNr/xFw4gL/r7/+UoMdYb9z5coVpsF1EBwPGDBATp06pS6EMSIwRmLVzJkzR3r27KkGBVu6dKkaYXX79u1qMKGgwrqvrVu3VoP0IGjGfmBkWhxDrf0IUjBYz44dO9Rndu3aVR1bBJ84zmgzAo9t27bJ0KFD1Yixx48fD3GgL7TPNOjAeYDH+5w8eVL93xSCnZDgfRhBGcclKIywG9L5Y+37QjunLR1jS+d2aMc06OdC0qRJ5dmzZ4Hm4WYA4Pcc31d42fI7bO3vZ2hw88H0MVkY9dn0WOEGCiYMkNWhQwcZNmyYutkTGpzPGG05Q4YMIa6D/Qvr3zbtvA3LyMbWfNdPnz5Vx9HWv1NEZBmDWyIinUI2CZkoZDJxAR/04vP58+cq8MiePbsKojBpWZZLly6p5ci0ADIyFy5cCPR+XIiauwAPDdZHds4UsjC46MOzS8MLjwcpUaKEunDUmGb9EIQho4rHIGHEaGvbaGn/cRGNfUBgW7p0aTXvwIEDYW4/Rn0uW7asylohuMXFfNBRWJEpxDRo0CAVzCDTay64RaZp5syZ6oLZmuwtjt2ff/4pNWrUUD/jfHj8+HGgdXDRjSAeE0bbzpYtm8q44juMESOGGp0WEwIPnFsYpdtcYGcO9gnHHdkw7RhaA5+N8zWs54+t7wvLMbbm3A7tmJo7Rni0FwLcRIkSqXlVqlRRQe+4ceNUNjAo099zPEfVNJOJ7xy/EzjvrGXu98Mca/6uBD0O1n4XeL81jyPCjRrcmArtGdj43TatgEAFhqWqA0tQlWDuGFn6rvE3Bt8xEUUeliUTEekYAltcZBUpUkRd2OLCDSWBeJyIluVBMJI7d25V/ors27Fjx6RVq1YqyNJKOfG4nRMnTqhHbGAbCF6CBnvW0AJL7QIdkOXDdpHhunjxomofMrDIStqSrUY7t27dqh4bgiwPsoemkFFEZhfHAPuCfZ40aVKobbS0/wg0kiRJokqgr127poI6PIPXFvgesP/Lly83liQDSmUR0B4+fFhu376tMqRoC4KIkLLAKKHFhT2CmBs3bqhzAO8P6dgtWLBAHX9kuvHZphkklIHOmjVL7Te2hUfNYDmyvHgUDY4nAn60DccJWa2sWbNavd/IQOIzce6tWrVK7S/OxTFjxsjGjRtDfB8y3YcOHZLu3burz8cxWbt2rfo5NLa+LyzH2NK5HdoxNQeBDwJZ02e84qYVAmwcozp16qjMIB4BhvO1f//+0qVLF7Uebvgg0MQzr5Hlxb7iPMZ5avpYIUvM/X6YY83fFUtw0wi/ezgu586dU+cEfi8QyNetWzfQuniMDtqEfdy3b5906tRJfvrpJ/UooNCCZmx/8uTJ6nFDOGY4XmG9aWfuGKGtOK9wgwhlxtZ81yjNxs0KIopEEdyHl4iIopiXl5caVAmDruARFHg0EB7PYTooj6VHdgBGIcbgLBg4pXfv3obu3bsHG1AKgyyZwiBM2mNXYN26depxMTFixAg0KuiWLVvUYDF4zAYGJsIjYExHEjU36Iu5AaUwoipGu8X8hAkTqoFkBg4cGGxwl2nTpqnBdTAITtBHcoTURkv7v337dvVYG4zui0eFYOAn03ZbM6CUNmgStoGRbTEarwbfBwZFQnvxPaJtaFNog89g5GIMpoVjiu0VKlRIDTRmbtAbjHKL5Ri456uvvlKju5oO1IP9wOBW2BbOk2LFihl27NhhHIgJxwID/2iPSjEdoTqooAPwaLTRrjGisPbd1K9f33Du3LkQB5QCDFBUuXJlNTgS2obPxyN8LA04ZMv7cMxMRxgO7RhbOrdDO6Yh6d+/v3r0UFAYsbpBgwaGZMmSqfMH5zAGzMIIzmF5FJAtv8MhDQwV3kcB4fcZv78FChRQ5wuOL35vf/zxRzUCsblHFGHf0qZNa2jcuLFh165dBkswgFmVKlVUG3HeYzRjcwNKmf7eBj0Pg57PaDfOCfwN0kaXtvRdYzRrnPN4tBQRRR71oLLIDJ6JiIiIyDrITubMmVNlQ0PK8JL+oJIAmXBUfxBR5GFZMhEREZGDQBk0ylvDMgo3OT70rf/f//5n72YQRXvM3BIREREREZHuMXNLREREREREusfgloiIiIiIiHSPwS0REZGD2LNnj3pGKZ4VGl3gsTXYJzw2JTTlypWTXr16yZfA2mNCRERhw+CWiIiIIk2aNGnE29tbcuXKFSkBvJ+fnwwePFiyZcsmsWPHVgMy4RmseJZuRA4r0qZNG/W8W73A/uOZqng+c0iB9Nu3b6Vbt25qnfjx48vXX38tDx48CLQOBraqWbOmxI0bVw2K1K9fP/n48aNxOZ4fi+fz4v21a9eWp0+fGpdhvYIFC6pn4BIRRQUGt0RERFHs/fv38qVwcXFRAWeMGDEifNsIkEuUKCHz58+XQYMGqcfn7Nu3T5o0aSL9+/cXX19fiWofPnwQR/Dq1SspVaqU/PzzzyGu07t3b1m/fr0sX75c9u7dK15eXtKgQQPjcn9/fxXY4nw9dOiQzJs3T+bOnStDhw41rtOhQwepUKGCOvY43qNHjzYu++2336RkyZJSpEiRSNxTIiITkfgMXSIiokjn7+9v+Pnnnw2ZMmUyuLq6GtKkSWP46aefjMvPnTtnKF++vCF27NiGxIkTGzp27Gh48eKFcXnr1q0NdevWNfzyyy+GFClSqHW6du1qeP/+vXGdt2/fGvr3729InTq1+gx81syZM43L9+zZYyhcuLBahm0MGDDA8OHDB+PysmXLGrp162b47rvvDEmSJDGUK1dOzd+4caPhq6++Um3DvDlz5iDVaHj27Jla/vjxY0PTpk0Nnp6ehjhx4hhy5cplWLx4caD9x7Z79Ohh6NevnyFRokQGDw8Pw7BhwwKtg+116tTJkDx5ckOsWLEMOXPmNKxfv964fP/+/YZSpUqpdmAfsb2XL1+aPd7Pnz83ODs7G44fP248/vjcokWLGtdZsGCB2g7cvHlT7dPp06eNr00nHH9r9yOob7/91hAvXjzD/fv3gy3Dd6x9B0+fPjW0bNnSkDBhQnUcq1WrZvjnn3+M6+K4u7u7G7Zs2WLIli2b2mbVqlUNXl5eajnaEbTdu3fvNu7PkiVLDGXKlFHHFtvCMRkxYoQhVapU6pzImzevYfPmzcbPMz0mkS2kz8L3GDNmTMPy5cuN8y5fvqzWPXz4sPp506ZN6rv28fExrjN16lSDm5ub4d27d+pnHE+8D/78809DjRo11Ovr16+rc9vPzy/S95GISMPMLRER6RoydmPHjpUhQ4bIpUuXZPHixeLh4WHMXlWtWlUSJUokx48fVxmqHTt2SPfu3QNtY/fu3XL9+nX1fy07hUnTqlUr+fvvv2XixIly+fJlmT59uirDhPv370uNGjWkcOHCcvbsWZk6dap6TulPP/0U6DOwXVdXVzl48KBMmzZN7t69q7JkKOVEySgyYAMHDgxWNoqyzo0bN8qFCxekU6dO0rJly2Blnth2vHjx5OjRozJu3DgZOXKkbN++XS0LCAiQ6tWrq89duHChOkY4XsioAva7WrVqqiT13LlzsnTpUjlw4ECwY6Rxd3eXfPnyqfJiOH/+vCp7RXnqy5cv1TxkAcuWLWu2RHnlypXq9dWrV1W58oQJE6zaj6CwX0uWLJHmzZuLp6dnsOX4frRsMUqKT5w4IevWrZPDhw+rcmV8Z6ZZ1tevX8uvv/4qCxYsUNlflON+//33ahn+37hxY3Wc0GZMyBhr8L1999136tzA+YZ9QtYS28Mxxbw6derIv//+K9bq0qWL2ofQpvA4efKk2n+UcGtQ2p02bVp1jAD/z507t/H3CbAvKAW/ePGi+jlv3rzqO0IJ8s6dOyVPnjzG9uM7TJAgQbjaSUQUJsYwl4iISGeQFUK27K+//jK7fMaMGSoLaJqFRLbUNBuFzGG6dOkMHz9+NK7TqFEjQ5MmTdTrq1evqmzW9u3bzX7GDz/8YMiaNashICDAOG/KlCmG+PHjqwyelpXMnz9/oPcNGjTIkCNHjkDzkPE1zdyaU7NmTUPfvn2NP2PbyLqaQhYZ24KtW7eq/cV+mNO+fXuV1TWFTC7e8+bNG7Pv6dOnj2oH/PHHH+pYmWYnM2fOrI69ucwhMp7m9tHSfgT14MEDtZ3x48cbQoMMLdY7ePCgcR4y4sg4Llu2TP2sZcyvXbsW6DtE9jhoht+Utm84BqaQaR81alSwfUFFgLljEtL+/fvvv6FO1gjpsxYtWqSyykGhnahSAFQ5VKlSJdDyV69eqe0hqwsXLlxQWeu0adMamjVrZvD19TXMnz9fHat79+6p96PSYfDgwVa1l4goPCK+AwwREVEUQabs3bt3UrFixRCXI7OEbKAGfQCR9UPmUMtI5cyZ05jJhJQpU6qMJCCrimXmMpHaZxQvXlxlL00/A1nMe/fuqUwYIAMb9H1FixYNNA/bMYU+j+jDuGzZMpUhRt9H7C8G9zGlZctM2//w4UNj+1OnTi1ZsmQx235km5FdXLRokXEeMps4Rjdv3pTs2bMHew+OBbLTaB+ytBi4CP1qkc1FW65du6ZGPw6r0PYjKGsHi8JxRgbX9FhjAKWsWbOqZRoc00yZMln12UEVKlTI+BpZTfRdxTlgCj/jWFsLgzdhcnT43cE5oHny5IkMGzZMZb979OihMtwY3AqVDfgOUKlARBRZWJZMRES6FSdOnAjZTsyYMQP9jEAVwV1EfoZpgG2tX375RZW4DhgwQJVMI1BFWWjQAanC034E4Z07d1bb1iYEYSihNQ32TJUpU0ZevHhhHMAJgSwmBLcIdFAm/NVXX4V5f0Pbj6CSJUsmCRMmlCtXroT5c6z9bGsDaFu+W3uXJeNmBM6joKNWY7RkLNPWCTp6svaztk5Qffr0UY90wg0VnA+NGjVSxwcDU2ml7EREkYXBLRER6RYCKARv6OtnDrKOCNTQ91aDvqfOzs4qc2cN9DlEgGWanQr6GVo/TtPPQF9DXOCHBO8L2nf2yJEjgX7GdurWrSstWrRQGeiMGTPKP//8I2HNhiKDHNL7ChQooPrhZs6cOdiEPsLmIKjEdidPnqyCQvTVRMCLfrcbNmwIMcsN2jaR9Q0PfIdNmzZVGWdkSs0F7egHiuOM/6Mfr2l2EZn7HDlyWP15aLc1bXZzc1PBPb47U/g5LJ+H/samNxzMTeGBSgJ8d6a/Ozgm6GusVRDg/6hgMM1go38t9tHcvmBbyIZr/bVxvLR+zfh/eL9zIiJLGNwSEZFu4bmmyGrisS94HAwGR0KAiJJZwGBDWKd169ZqQCZkP1EqiUGZTAfJCU369OnV+9u1aydr1qxRpbrIQKFUGLp27aoGh8J2kUVcu3atKstEBgsBWGiZOWRH8dxQBBUYCMt0ECsteEcwgcewIGhAhjVoJs0SBJoIPDFgFLaF9m/evFm2bNmiluP4YfsISBAwoU3Yh5AGlNIgU4vAUgtkEydOrAJJDEgVWnCbLl06lRVFEPzo0SPjIFS2GDVqlBqkCuWu+P4RpKP9s2fPVs9exbZxDHGDoGPHjmqgLNzswM2CVKlSqfnWwnmA8m18V48fPw71kT/4TvEIHhwLrI8Bp3BsMeiUtVCSbO6Gg+kUGjxvFp+JYwJoB3728fExDgzWvn17dZ7i9wIDTLVt21YFtMWKFVProNwcQSx+X3Dctm7dKj/++KN6Nm6sWLGCDX6Gc2bGjBnG8x6l2FOmTFHvxUBiQUu1iYgiXLh67BIREdkZBm3Co38wKBQebYKBbUaPHh3mRwGZwiN7MMCRBgMr9e7d25AyZUo1CA8GTJo9e3aYHgWEbQaFx/FgWxgUq3Tp0mqbpoMtPXnyRLUNg1PhMT4//vijoVWrVoHaa27bWK49YkfbTtu2bdVjiHAc8EihDRs2GJcfO3bMULlyZfU5eAxOnjx5gg2IFNTq1atVW/FoGNPjhnlXrlwJdUCjkSNHquPk5OQU6FFAlvbDHDzSZuDAgeqxMzj+GASqUqVKqn3aIF/ao4DwuB8MJIXH/Jh7FJC5/dM8fPjQeIyCPgoo6GBNOCeHDx+uHgWEc9IejwLSBskKOpk+XgnnNQa5wqBrcePGNdSvX9/g7e0daDu3bt0yVK9eXR23pEmTqsHMTM9tDb4D04HOAINe4fcCjw7CY5u0AdaIiCKLE/4T8SEzERERERERUdRhWTIRERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdi2HvBhCRYwgICBAvLy9JkCCBODk52bs5RERERHaFJ6a+ePFCPD09xdmZOUE9YHBLRAoC2zRp0ti7GUREREQO5e7du5I6dWp7N4OswOCWiBRkbKG5pBJX9lggGzU+s9feTaBoIEUCV3s3gaKBFAfn2LsJpHMv3ryVLJ1HGa+RyPExuCUiRStFRmDL4JZsFY8XABQBEiSIZe8mUDTgFje2vZtA0QS7a+kHr2CJiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHQvhr0bQETkaN5JgGyQB2IQgwSISG5JINklgXH5BwmQ7fJIXshHcRInySHxJZe42bXN5JjevXsrI3t1kRtXL0nyFJ4yYvIsSZg4SaB1/p4xWbavW/Fp/bdv5dnjR7LpzHU7tZgcEc6L3l3ay9XLFyWFZyqZNHO+JE4S+DzS7Nq2WTq1aCKb9h6RLNlzRHlbyTE1HTdX9l+8IeVyZ5ZF37cKtrz3X6tk9ZHzkjpJQjkw7ju7tJEoInyRmdukSZPKrVu3gs3fs2ePxIkTR/Llyyd58uSRUqVKyblz5yL0s7HtFy9eROg2v0Tp06eXM2fOBJuP73XatGniCNCWcuXKibu7u/rerV0Gs2bNkq+++koyZcokHTt2lA8fPoR4HLJmzSozZ860artknZjiJHXEQxqKp9SXFHJafOWt+AdaJ5+4SxNJpZZflBfiK+a/I/qybVi6UDzTpJO/dx2TMtVqyaJpE4Ot06xTd5m9YY+amnXsJqUqV7dLW8lxLV00T9KkSy87j56RqrXqyPSJ40MMgudM/1PyFigY5W0kx9a1Rmn5q0fTEJc3Lp1fVv/QPkrbRBQZvsjgNjQIFBA0Iaht0KCBtG3bNkzv//jxY6jLse0ECT5ngMg8f//AgYS1HCm4dXNzk59++kkWL14cpmU3b96UIUOGyP79++XatWvy4MEDmTFjRoifs3TpUunQoYPF7ZL1nMVJYv7359Ff5W9FTRos85TYxtfuElNeBwl+ieDgzq1StX4j9bpKvUZyaNfWUNfftWmdVKhZL4paR3qxc8smqdfoU2BSr2ETlZ01Z8bkP+SbNu0lVuw4UdxCcnRlcmWS+LFjhbi8eLYMkjhB3ChtE5Hdg1snJyd5/vy52QwoMkhDhw6V4sWLS4YMGdQFtgaZpO+//15Kly6tMlFdunQxLsNFeNGiRSV//vySN29eWb9+faD39e3bV8qUKSNp06ZVF/ybNm1SGVV83vjxn+9c/vvvv1KzZk0pXLiwyrpOnjzZuGzdunWSPXt2Nb9///5W72+1atXk6tWrKmCtWrWqFCpUSHLmzCnffPONvHr1ypjtxbz27durTNnff/8tyZMnl/fv3xu306ZNG5kwYUKwY4h9+PHHH6VEiRKSJk0aFZTNmTNHHUMsW7JkiXEbW7dulQIFCqh9KFu2rFy6dMn4+bly5ZKuXbuq44e2nDhxQi0Lrd04XiVLllTvyZ07t2pHUG/evJEmTZpIjhw51HpVqlQJ9JmtWrVS/y9YsKDZLKo5CxYsUPuACd/X/fv31fy5c+dK+fLl5euvv1btOXbsmPp+8X3iuOL/hw8ftrh9nFv4zvCeOnXqqHk497Tt4FzCcsD/U6dOLTdu3FA///rrr+o7DwgIUEFlpUqVVDvxvjVr1hg/A9/h6NGjpUiRIupcx3dmTuLEidW5Gi9evDAtW7FihWp7ihQp1Gdhn3BeWSO07Qb17t078fPzCzRR4NLk5eIli+S+5BV3iSMuZtd7KR/lqbyXpOIa5W0kx/fkgY8k9UipXidwc5eXofyePX/6RK5fviiFSpaNwhaSHjx84CMeKT3Vazf3hOLn6xtsnXt3bsuZk8elem3eHCGiL1eEZm4RtCEAOX78uPzyyy/GwAWuX78uu3fvlgsXLqhATQtUEHwdOXJETp8+LWvXrlUlmLjo1ty+fVu97+zZszJx4kQV3CKjdfDgQRVM4zOR5WvWrJn89ttv6rOxPWS68Prhw4cq+7py5UqVjc2cObM8efLEqv1BcInAzcXFRQXhCBrRfpR8Tpo0ybje5cuXVaCHAK9ly5YqGEJADS9fvlSvW7RoYfYzEGweOnRI7WPv3r3VMcOxWb58ufTo0UOtg31AYDpv3jy1D506dZKGDRuKwfApl3TlyhVp3bq1OkZ4z+DBg9X80NqN4L9WrVrqPefPn5c+ffoEa9uWLVvU8UUgjfVMg+2LFy+qz8R2BwwYIE2bNjW2JyRYt1+/frJ582a1HwjqtYwjHD16VAWNaA8CfBxLfIc4rmi3NVl03CDQsu/ad4D2advBTYDvvvvUlwTr4Txt3LixCtinTJmigm9nZ2dp3ry5NGrUSLUT3wVuXuBc1MSKFUsF4NiXnj17WszYh8WdO3ckXbp0xp9xowPzItqYMWPUOaFNuMFCn8USZ2kkntJMUsk1eWU2M4us7g55LMUkkTHTS2SrfVs3SsmKVSVGzJj2bgrp0JjhP0q/H0fYuxlERHYVoVdjCMC0jG7GjBlVeaUGGcAYMWIY+7Qi2AWsU716dZUBrFevnjx9+jTQ+xDEIUhLlCiR2iYCMmSzUqVKJcmSJVOZY2TgEGwhwMK2ETShXyuCMgS6yL4h+wgIUlxdQ86waFk/TAgaEVAiaPv9999Vdhnb2rhxY6BMJdqFbKoGQZiWzUNgVKFCBUkSwsAPOC6AoDt27NhqfwHZVhwLBJcI+pDNxAQIvLy8vIw3D/BeZL8BQaF2bENrNzKYf/31lwqEt23bJgkTJgzWNmRrEbgjIETpa0yTCy4EXBUrVlSvERz6+PjI3bt3JTQI4JEZxXcH2O6uXbuMJcj43hBwanDDA8cV54aWkUU2Oay2b9+ujgu2M3LkyEDfHW6KICOOmywIbHFO4dw5deqUOlcAfV+RDcVNFQ2+A8iWLZs6r7H/ejNo0CDx9fU1Tpa+vy9VXHGRJBJTfORtoPkoVt4ljyWtxJaMYjlTTl+OVQtmSbta5dSUJLmHPH7grea/8POV+G4hDzy2a+MaqVCLWTf6ZMGsGVK7fEk1JU+eQh54e6n5fr7Pxc3dPdj6l86dlc6tmkrZgrlUBrdtk/ry79Urdmg5EZFORktGkGnaF/Lt28AXewjOTNc1zWaFtAwB6dixY41BHcoqTbcb9H3mtoOgC+8zVxqrZe80CIxDo2X9TC1cuFAFYXv37lV9GpFBxs+a+PHjB1q/fv36Kpvn7e2tym1DK4UOaf/QTkzWZARDOrbI2obUbpT/IphE4Ics7h9//KGy4qYQtOMGAd6zY8cOtR8hlR9r7Q2LoOubHkeUdaPPMwJilBSjZBbZRWT1cYPEWsh4du/eXWVuURKPTCwCew2OFTLKOH9MKw0stTW0cz28UIKv3aAA3MDBvIiG7DMmCg5Z2hjiJK7irMqTveWd5DAZLRmOyXO1TgEJfmOIvmwNWrZXE6yYO0O2rl4umbPnkm1rlkvxCp+6dwSFEZJvX/9H8hcrFcWtJUfVsn0nNcG8v6bKmuVLJHuu3LJmxVIpX7lasPV3n/g8AOY39WrI8DG/yldZs0Vpm4mIdJW5RYYQWURYtWqVsf9meDx79kz1W9SCSPwcVghIEbyZ9n1En0lkPpGxQ0CDLCzMnj07UH9Ya9uIbDQ+A1k9BKyhQeCDktbhw4erIAXZyvAoVqyYKtVFEAYoD0b2U8uA2tJu9Ln18PBQ5dTjxo1TGe6g7t27p4I69P9Ef1RkgrXsHgIuBJ5aH1FsC/1XQ4M+tSh1RtZZKyFG9hfBYVC4wYHvSQvqTMvAQ4N9RRZSg9e4+ZEyZUrVftO+2DBw4EB1/iAri765OG8w4Beyudr5hHkHDhwIFBRHJtx4wE0ZZIPRZhwn3ASiqIN+tOvER/W5xf9zSQJJIq6ySR7IK/molp8RP3kk72WFeKnproS9qoCiv9pNW8r92zelWfnCsmfzOmnRuaeaf2DHFpn1+1jjenu3bpBSlaqb/XtI1KRFG7l984ZUKJJXNq9bI517fupKtGPLJvlj7OcxTohCUnPEdGk5foFsPXVFvur0kxy9ekvqj5ol3k8/XTN1mrxEyv8wWS7c8VbLVx06a+8mE0V+5hYlrshIYvAhDAYUUqltWGCgJWRtURaL8l1bMlQoC92wYYP06tVLtRHZZQR1yFwiAERAi2wqypERaIa13QgA0R8YQRDKVjEwlmn/S3NQmowBh9DfM7wXK/jMRYsWqXYgQ4gSbZQ7W8qUhtZuBKS4mYBjggGUzI0wjIAapasIsPC56AOL8mZtEC0EyzgfsA0MeKS1ByXdyAJ7en4a/EKDsmD0cdWCffTxRGm0OdqovziG+C6tDe7QPrQNn4XMM4JEvBfz8L2j9F2DcwbBNvrOxo0bVw1ghRJr9IHG8UYpNIJh7BcetRPWc/P169eSJUsWlW1GkI3gH8cQfV1DW4Z2jxgxQg34pQ2s1rlz53B/JlkvucRSjwEKqoZ4GF93ls/9oolCglFrR0+fH2x+qUrV1KSp1zxsI/PTlyV2nDgybX7wgQUrVauhpqAWrwlciUW0cVjw64jVgz8/+mdGd95Ep+jByWBpFCCiIBDc4kaCtSMkU+RB32eM5BwRz7TVSr/bShpVjktki+bXP43WThQengnYZYLCL+W+6fZuAumc3+u3krLVEJUwQOKFHB+vYIl0DBl5jMSNzDIRERER0ZcsTGXJRFqZLLO2jgEDZRERERERETO3REREREREFA0wuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpXgx7N4CIiKKPom5v7d0EigaufYxp7yZQNPDvkh32bgLp3MsPH+3dBAojZm6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERke4xuCUiIiIiIiLdY3BLREREREREusfgloiIiIiIiHSPwS0RERERERHpHoNbIiIiIiIi0j0Gt0RERERERKR7DG6JiIiIiIhI9xjcEhERERERfeGmTp0qefLkETc3NzUVL15cNm/eLHrC4JaIiIiIiOgLlzp1ahk7dqycPHlSTpw4IRUqVJC6devKxYsXRS9i2LsBREREREREZF+1a9cO9POoUaNUNvfIkSOSM2dO0QMGt0RERERERDrx9u1bef/+vVXrGgwGcXJyCjQvVqxYagqNv7+/LF++XF69eqXKk/WCwS0REREREZFOAtskceLLa/G3av348ePLy5cvA80bNmyYDB8+3Oz658+fV8EsPgfvXb16teTIkUP0gsEtERERERGRDiBji8C2laQSVwvDJ72XAJn/8r7cvXtXDRClCS1rmzVrVjlz5oz4+vrKihUrpHXr1rJ3717dBLgMbomIgngnAbJBHohBDBIgIrklgWSXBIHWWSs+6h8NLM8scaWgJLRbe8lxbdy2QwYM/Z8EBATI9z26SruWzYzLXr9+I03adpJbd+6Ki4uLdGzdQrp1bGvX9pJjevf2rfTv2kH+uXJJPFJ6yu8z5kmiJEkCrXPs0H7p2ba5eKZJq36u26iZtO7czU4tJkfT+9BpOfHoqRRNnkR+LZ4v2PKNd7xk9pWbqoS1TvpU0iZrBru0k6wXx8lFXJ1CD25dDE4iBjGOfmwNV1dXyZw5s3pdsGBBOX78uEyYMEGmT58uehCtRktOnz69utuQL18+dXdhypQp4dre3Llz5cqVK+Haxh9//CE+Pj4S0W7duiXTpk2TL0FkHcPQoFQD5RiaoUOHyqJFi6x+/549eyROnDjqXHz48KGaN3v2bMmdO7fEiBFD7ZOpNm3aSKpUqdT6mPr162dcNnjwYPU+bdmSJUuMy16/fi3NmjVTf4SyZMmi7rBpsI20adNKvXr1bD4OX6qY4iR1xEMaiqfUlxRyWnzlbZDyn+qSXBqJpzSSlHJH3shjsa7vC305Pn78KP2HjJStq5fIsV1bZPyUafLk6bNA6/Tr2VXOH94jB7ask2mz58m1Gzft1l5yXCsWz5fU6dLL5kOnpHLNOjJz8u9m1ytWupys2nFATQxsydQ3mdPJT4Vzm1327N17+fPiNZlTrogsr1JSjj98KrdevIryNlLYODuJuFiYnAN3tbUJbs6+e/dO9CJaBbewdOlSlUrHM5l++OEHOXfunMMGtzhZMNmCwW3kGjFiRKDgduTIkdK8efMwbUMr60iePLnx7teyZcvkm2++Mbs+glGsj+mXX34JNB/9HzB/48aN0qlTJ3n8+LFa9uuvv6rSkmvXrsnWrVula9eu8uTJE7UM20C7KeycxUli/vfn0V/lb9WNz0C0UqCA/7K7REEdP3VGcmTLIqlSppT48eNJ1YrlZceevcblcePGkTIlPw3SgeVZMmcUnwefboYRmdqzdbPUbthEva79dWPZs32LvZtEOlM4eWKJG8N8wea9V68lQ4J44uYaU1ycnKRAskSy6/6DKG8jhQ2+K2umsBg0aJDs27dPxRm49sTPSNiE9RrYnqJdcKtJly6dCi7++ecfefHihXTs2FGKFCmiHkyM4EAbYaxcuXLSo0cPKVy4sMp+9e3bV5VkzJw5Uz3fqXfv3ipbtmnTJjVqGAKNXLlyqQnv07aD9ZEtxrrIsh09elQFFl5eXtKkSRM1H8EJMoJff/21VK1aVW3D29tbBSWlSpVSwQ/auHv3brVNnExYp1WrVur/WI5tQJcuXeTq1atqu3Xq1FHz0N4SJUqofcR2Dh48aDweCIqwj3nz5lXvQfsAn12gQAH1nrJly8qlS5eM75kzZ45aF+8pVKiQOtFD2xZGYnv+/Lnx/UmTJlXvQQDfvXt3yZ49u3oP9sM0cNRYewzRKb5du3bG7wGBqAbfJ77DMmXKqKzlkCFD1HeH44vM/vjx443rfv/992o/sF2sj+OpHVsoXbq0MfOKzKqWbV2/fr06XliGz1+7dq1V5yT2HcfA2Tlsv3YJE34ud8W+4/zUborgZo7W3gwZMqj9R8d/a+AunJ+fX6CJApcmLxcvWST3Ja+4SxxxCbbOGvGR+XJPUklsSSqudmknOS5vnwfimSKF8WfPlCnkvrf5G3V373vJ+UtXJH8e85kV+rI9fOAjHik81Ws394TywtfX7HrHDx2Q+hVLSrfWTeX2zRtR3ErSq7Tx48p1v5fy4M1beefvLwd9HsvDN/rJ1H2pLGVtXf6bwgLXvIg7EENVrFhRlSQjVqhcubLoRbTtc4u7Dci6IqBAsINA5a+//lKBAQJd1I5rpZ8I6A4dOiQfPnxQQc7ff/8tHTp0kIULF0qvXr2MZZ14zhO+ZDzYGP2jEFT+/vvvMmDAAPUZ+LyUKVOq7SBwKFq0qCpFRQCCQAjWrFkjhw8fltOnT4uHh4fcuHFDBbw4cVALjwwc2qoFknhoMto6f/58lfVr2rSpXL58WWVt0TYt2EWQ3aBBA7WPCJwPHDiggmhsD8Fh27Zt1Z2YbNmyqfahnBUnMLKICKIRTKLstmHDhuoz0XEcgSWOC/YJ6wNuFpjbVmjOnj0rO3fuVNtFYIcO6qjnD8raY4jjjWXIyr9580YFrmgLAmC4ffu2ukGAYA0B7bNnz2T//v3qOOCXFYExAkZsB5lPQKnvd999J1u2bFHHFv0K8B7TwFLz448/quUYSQ5BZkQFhfiesa8Iyn/66Sfj/sLEiRNVmf29e/fUTQAtG3znzh11I0eD/cU8a4wZMybQjQEKLJY4q7JjDNqwTR5JRokrcYMEuPUkhep3u10eyVN5L4kZ4JIN8PesRceuMnbYYIkXL669m0M6lSN3Xtl2/JzEixdfdmxaL/2+bS/Ltny6WU4UGndXV+mXN5vql+vq7CxZEiaIkHJWilzWZGZdJGxf5KxZs0Tvol3mVsvwde7cWQUKX331lQooUaKJ+fnz51dBC4I+De5QxIwZU+LGjSstWrSQHTt2mN025iODhzJQ9JtEkLx9+3a1DHc3WrZsqQKUmzdvqqGzQ1KjRg0V2AKCKbQFQTXah+ASAaAWoCBYwbahcePGqjwXI54Fhawj3ofAFhDw4TMQ/KKN1apVUwEgYF/d3d1VZhRBLSZAyQECwPv376vsLPYHgSbg2GAKaVuhyZgxo+p7hqBy3rx5KnA1l7209hjie8CxxzbixYunvj/tewAcQ9x8SJQokfrsWrVqqawy+rQmS5bMeOMA70GAiuwrAnntRoElaCcC4XHjxqkA21wAHFZ4SPb169fV9tq3by/Vq1cPNGx7z5491XeMmw2jR482lh6HB0pNcKNBm8ydVyQqoE0iMcVHglcbaOXJyNzelTdR3jZybClTeIiXSZcKL28f8Uzx6W+/Bjdc23XrJdUqlpcGdWraoZXkqBbP+UsaVCqlpmQeHvLAx0vN9/N9LgnM/LsbP4GbCmyhUo3a4nP/nqo4I7JGhVQesrhicZlbvqgkix1L0saPZ+8mkR0yt9FBtO1ziyAAQY528bBy5Upjf0YECaGN+BX0QcfWrIftjx07VgVuCF5NB/0JyjRoQ9uQ6tfahgnBJYLykD7TlvZFBQSUpv+QaqXHCH4vXLigssTIzKKk1/Tmgi3HMLT9jB07dqA2Bf0ZgTZuHqBUGtl5tA2fZa5U2hyUNqNkG8E+hkdHkBteCLy1gL9+/foqi6+VSZtCJQLWRbYdkOVFplqDwB3zrIGbNNroeWEZRe9LgGwtMrJaebK3vBN3iWlcjnlv/htgCn1y78pbSWiynAgKF8gnFy9flfve3vLy5SvZunO3VC5fLtA6P/5vrMSNE0cG9f3Obu0kx/RN247GwaHKVa4m61csVfPXr1wmZSt9upFt6vGjz/21Tx49LImSJFX/5hFZ4+nbT2XIj9++k613faR62s9dKujL6XNrD7juR4IF171Pnz4N9/aiXXBrDsqKf/75ZxXUAMpUTYMrBDg4sChxXbx4sVSqVEnNx8U+MloazEd5MEqAsS2Uh1apUkW9RtYN/VLRjxNB9bFjx8xuIyhkWpGJNB34SnuvFqxofXAxEi6ysalTpw62XZTbokRWy2AiuEeWF9lgfAbKnrXBsbCveG+xYsVU+TaCO0CAh8AJU+3atdVxQZ9gQOkxppC2BeizrPW/XbVqlbx69WmkvUePHqnXOFbIOiIbbdq3F8JyDPE9oGwCNwaw3QULFqhthwW2h6wzMtPYzuTJkwMtT5AgQYjfG/Y9Z86cKjj+9ttv5ciRIxJeKDfWYHvIzGrDsJseKxwjlLRrzxpr1KiRcWAxZLsR9HJ05PB7KR9lnfioPrf4fy5JIEnEVTbJA3klH1Xgu0kequUrxVs8JZakE5aTUmCo8Pl55BCpUq+JFC5fVXp17SRJEieSOk1bqYzuPS9v+XXSn3L89FkpXK6qmrbt+nTjishUw+at5c7NG1KteH7Ztn6NdOjeW83ftXWTTBo3Sr3eum611ClbTGV6fx81QsZO+jIGnSTrdN53XPofOSMHfB5JlY175OyT59LtwEl5+ObTjf3Rpy9Lg60HpMu+E9InT1ZVqkyOzem/QC60yUkcE8ZDQndPjPeD63zEBhiXBhWW6G6HCk10BbVFtO1zawr9YgcOHKgCPWTHcMGBbJsWPOBglixZUt0tqFu3rurXChh4Cv1A8X4EZfgZwQUGYAIM3oN+r8hWouQW78e28cUgs6eVk+ILQpYPoy8HhTYgoEYZNYJHBM4oncY8QBCF92E76KeK/sDIVCL7iWUoqUXp7bp161RAifXQZmQrEQwjS4zPQHtQco1gFHdyERBh0Cn0s0VZL4JLlPEuX75cbR9l0sOGDVPBLH7GZ2N7oW0Lxwmfjz6pNWvWlCT/PYMPd2NwDLA+jhWONcpuTYXlGGKQKMzTyqkR4KFkOyzwXnzPOIZoZ9CAEMcQGXV85rZt2wItwyjcuLuEY4Ll+OW0BtqOY4ObKyiVR39fDE6F7xvl7g8ePFDHE48QwveglXv3799fBa4IxnFsEIjjnAX0G8dxy5Qpk3ovlmEgLwqf5BJLPQYoqBryuaT0a/lUsk8UmtrVqqjJ1Lol842v3z1idwCyLHacODJp7qfrAlMVqtZQEzRv31lNROZML1M42LwppQoaX5t79i19eX1uowIqINEdD9euSKbhutrT01Nd/yIOQNINXUiRuMLYO5MmTQqxotUcJwPSVl8wLUB1xGwXsnCmg0aRfjjKd4eAGoE0JkswMBYC6raSxviYG6KwmvjogL2bQNHAtY8J7N0EigY+9Pg00CSRrV5++Cil1u5U1XyO0n1Lu14bGTejxHYKvevBW4O/DH19w6Ha36xZM5XsQYLJ0mCLSHQhmYREjrW+iMwtUVTDLyJKi1EtgMyvNrpxVEJWFxl9PB6KiIiIiKIPawaMchHHgypUa8eG0R53GRZffHCrDczjqFlle2f+yDYIKO09+jBGCMdERERERNGLXsuSzcFYSOj6iW6RKE9GYbGtA+Oy9pCIiIiIiEhHnK14DJCzg8e2qHLEQLFZsmRRT0rRBrLFYzEx/o0tGNwSERERERHpSHR4FFDv3r3VYKl4RCcGadU0adJEtmzZYtM2v/iyZCIiIiIiIj3Ra59bUxiXBo8YxWNOTWF05Nu3b4stGNwSERERERHpSHQIbl+9ehUoY6vBI4EwoJQtWJZMRERERESkI9GhLLl06dIyf/7nZ79jEKmAgAAZN26clC9f3qZtMnNLRERERESkI8jKWszcGsShIYitWLGinDhxQt6/fy/9+/eXixcvqsztwYMHbdomM7dEREREREQ64mxF1tbZwTO3uXLlkn/++UdKlSoldevWVWXKDRo0kNOnT0umTJls2iYzt0RERERERNGtz62TOKwPHz5ItWrVZNq0aTJ48OAI2y6DWyIiIiIiIh2xpk+tiwNnbmPGjCnnzp2L8O2yLJmIiIiIiEiHmVtLkyNr0aKFzJo1K0K3ycwtERERERGRjsR0dlZTqOuIY48o9fHjR5k9e7bs2LFDChYsKPHixQu0fPz48WHeJoNbIiIiIiIiHXFycRIn59BTs04OXJYMFy5ckAIFCqjXGFgqIjC4JSIiIiIi0hFnFydxthDcOjt4cLt79+4I3yb73BIREREREemJi7M4WZgEkwNr166dvHjxIth8PBIIy2zh2HtMREREREREgaAkWZUmhzY5O3bmdt68efLmzZtg8zFv/vz5Nm2TZclERERERER6K0u2MByyszhmcOvn5ycGg0FNyNzGjh3buMzf3182bdokyZMnt2nbDG6JiIiIiIh0xMnZWU2hrmNwzNGSEyZMqAa7wpQlS5ZgyzF/xIgRNm2bwS0REREREZGO6Dlzu3v3bpW1rVChgqxcuVISJ05sXObq6irp0qUTT09Pm7bN4JaIiIiIiEhHtH61oa4jjhncli1bVv3/5s2bkiZNGnG2kIEOCwa3REREREREugtuLZQlS4A4MmRonz9/LseOHZOHDx9KQEDg9rZq1SrM22RwS0SBlNq/TeLGT2DvZpBOfdy/zN5NoOiguG2PgCAyFXPSUns3gXQu5gs/kbVpxRHpuSxZs379emnevLm8fPlS3NzcVF9bDV7bEtzyUUBEREREREQ6ogZkcrYwOTl2cNu3b1/1PFsEt8jgPnv2zDg9ffrUpm0yuCUiIiIiItIRZxdnq6awGDNmjBQuXFgSJEigHsVTr149uXr1qkSW+/fvS8+ePSVu3LgRtk0Gt0RERERERDocUMrSFBZ79+6Vbt26yZEjR2T79u3y4cMHqVKlirx69UoiQ9WqVeXEiRMRuk32uSUiIiIiItIRF1cXcYnhEvo6zmF7zu2WLVsC/Tx37lyVwT158qSUKVNGIlrNmjWlX79+cunSJcmdO7fEjBkz0PI6deqEeZsMbomIiIiIiPTEmsys4dNyPz+/QLNjxYqlJkt8fX3V/02fQxuROnbsqP4/cuTIYMvQX9jf3z/M22RZMhERERERkY44OzmJs7OFyelTcItnybq7uxsn9K21BI/l6dWrl5QsWVJy5coVKfuAzwhpsiWwBWZuiYiIiIiIdATPuLX4nNuAT8vv3r2rHrWjsSZri763Fy5ckAMHDkhUePv2rcSOHTvc22HmloiIiIiISEe059xamgCBrelkKbjt3r27bNiwQXbv3i2pU6eWyILs7P/+9z9JlSqVxI8fX27cuKHmDxkyRGbNmmXTNhncEhERERERfeGjJRsMBhXYrl69Wnbt2iUZMmSQyDRq1Cg1aNW4cePE1dXVOB9l0DNnzrRpmwxuiYiIiIiIdFiWbGkKC5QiL1y4UBYvXqyedevj46OmN2/eSGSYP3++zJgxQ5o3by4uLp9Hfs6bN69cuXLFpm0yuCUiIiIiItIRZxdrSpMlTKZOnapGSC5XrpykTJnSOC1dujRS9uH+/fuSOXPmYPMxoBSesWsLDihFRERERESkI07OTmqytE5Yy5KjUo4cOWT//v2SLl26QPNXrFgh+fPnt2mbDG6JiIiIiIh0xNnZWZwtlB07+zt2ke7QoUOldevWKoOLbO2qVavk6tWrqlwZA1rZwrH3mIiIiIiIiCJ9QKmoVrduXVm/fr3s2LFD4sWLp4Ldy5cvq3mVK1e2aZvM3BIREREREUW359y6OH4es3Tp0rJ9+/YI2x6DWyIiIiIiIh1xcnZWk6V1HNnx48dVOXLRokUDzT969KgaPblQoUJh3qZj7zEREREREREF4uwaQ1wsTM6ujp3HxKOH7t69G2w++uBimS0ce4+JiIiIiIgoeObWRd+Z20uXLkmBAgWCzcdIyVhmC8feYyIiIiIiIjJblmxpcmSxYsWSBw8eBJvv7e0tMWLYloN17D0mIiIiIiIiMwNKuViYnMWRValSRQYNGiS+vr7Gec+fP5cffviBoyUTERERERF9CaLDaMm//vqrlClTRtKlS6dKkeHMmTPi4eEhCxYssGmbDG6JiIiIiIh0xNnZWU2W1nFkqVKlknPnzsmiRYvk7NmzEidOHGnbtq00a9ZMYsaMadM2GdwSERERERHpSHTI3EK8ePGkU6dOElEcf4+JiOzg1L4d0q9hRfmmQBq5e+2K2XUMBoPM/Gmg9KpTUn74poY8uHsryttJjqvp2NmSquVgaT5urtnlvWeslPRth0qpfuOjvG2kL+/evpXv2rWQ6iUKSJuva8mzJ0+CrXPs0H4pljWtNKhUSk3zpk+xS1vJMfEcir7BraXpS+NQe5w+fXrJmjWr5MuXT3LkyCFTpkTsL9W6deukd+/eEbaNPXv2qLZGlFu3bsm0adMipG2R5fr162rIbtTFz5kzJ9I+Z8OGDVKuXDmJSvguX7x4Eeo6aNOaNWvMLhs6dKgqqwB8j7/88kuo5/nMmTPVz3h4dZ8+fdQ5nydPHilfvrxcu3ZNLTt//rzqi5AtWzbJlSuXtGvXTt68eWPclpOTk+TOnVu1HdP+/fvVfKyDn+PHjx9ieyl0KdNllF6/TJdsBQI/WNzU6f075cXzp/LHuoPSsEsfWTxhdJS2kRxb11pl5K+e34S4vHHpArL6x45R2ibSpxWL50vqdOll86FTUrlmHZk5+Xez6xUrXU5W7TigptadbXtGJEVPPIeiHycnK0ZLdnKoUC9KONweL126VHUk3rx5sxopC3XYphAIYLJFnTp15Pffzf8yR+U2IiO4/fjxY6S2TbNixQopXLiwnD59WtXEB22DI7PUPpx3CRIksHn7I0eOlObNm6vXXbp0kX79+oV6nnfo0MF4U+LgwYOqrwHO94oVK6pzH2LHji2TJ0+WK1euqOWvXr2Sn3/+OdC2ENCi7ZhKly6t5qHPAn4uVKiQzfvzpUNwmypD5lDXObl3m5Su+bV6nb90Rfnn7EmVzSWCMrkyS/w4sUJcXjx7BkmcIF6Uton0ac/WzVK7YRP1uvbXjWXP9i32bhLpDM+h6IeZW/Mcdo8xahayW//8848MHz5cvv76a6latarKXuHZRxhBC1kuTDVr1pT79++r982dO1cqVKigAj1kwpD1QtCoLatXr57xM5BZy5kzp8p8ISjRhqHG5zVp0kRq166ttoHtPX361Ow2EDC1atVKtatgwYIqoAAfHx+VgcM8fEb37t0DBeUIUPC5efPmlWLFisnr169VQHT16lWVcUP74d9//1X7h4AS+4pAxzRrN2zYMLUMw2ibti1oVvnChQsqYwg4HgkTJpQhQ4aoLOxXX32lgitkffEe7AvWD2r+/PkqeF61apVaDw9XRiazZ8+eUrx4cTWctzbyWZEiRdS2q1WrJrdv3zYe1169ehm3h31p06aNev3hwwfp2rWragveu3v37kCfje+7aNGiapv4ThHoad9HpUqVVMdzHE8Eczdu3DAeAxz79u3bq/auXr3a4vHE8ONw+fJldb5p55jpTYcDBw6oIDJTpkzqO9NgX/744w+z+xoafO67d+/k7du3KjDy8/OT1KlTq2U4Hvh8cHFxUe3Wzmeyv2ePHkii5CmM32M8N3d58fyZvZtFRNHMwwc+4pHCU712c08oL0wem2Hq+KEDUr9iSenWuqncvvnp30Ii4DkU/TC4Nc9h9xjlmMhWIfiDw4cPq+AKAdWzZ89UVgzZXWS6SpQoYcyCAQI1BI9Yt1atWmY7KeO9s2fPVuvis9CZeeDAgcblR48eVYETtpE8eXKZPn262XZevHhRWrdurYLBAQMGSNOmTVWAguBx/fr1cvLkSdVGBCTLli1T75k3b56sXLlSBUkI0tAWPMQYARQCegTIyOb5+/uroO23336T48ePy5EjR2TGjBnqtQYBD34OqQQ2JAjkEXifOnVK7TcCOQTU+Gzsz4gRI4K9B0E8gjncCMB6CPwBNyD27dsnu3btksWLF6sAHd8Xto11EbRagv3C+3A8cVzwXg2+o7///lt9BuaPGjVKvvnmc6kf9n/06NHqe0Sga5rZRJCKdqO9DRo0sHg8tRsWdevWVcEqvjtMDRs2DFSajeAb3/nWrVvVvoYHbqLgJkGKFCkkZcqUsnPnTpUFDgpZW5Qyo22mkOnF7wlKm7GOtRBQI5A2nYiISJ9y5M4r246fk9U7D0r9Js2l37ft7d0k0hmeQ/ri7OJs1fSlcbg9RsYUWbbOnTur4BOZK6hRo4Z65hEgsEBGEMNHA4InBFYIBgHBbvbs2dVrBLbI4GnLNDt27FCfhSAUvv32W9m+fbtxObafJEkS9RpZSQQ05iAbiuACGjdurDK2d+/eVVlaBLsIOtA/9cSJE8asLvqTIkh0d3dXPydKlEgFqUFpwR4CZhwT7Bf6hCLg1qAPpi1Q7qpleZHtRN9MZJoBmVNkOK3VokUL43Dd6N+JY4vAGW0eN26c3Llzx+I2ENAhCHV1dVWT6X6tXbtW3QRA5hbb7NGjh8qka31P8f1kyJDB7HeVMWNGKVu2rNXHU1sPWVQEwpqkSZMaX+O8iREjhir9xXZCOjeshXMDgTKqD7y8vNT5ZJoRhvfv36vPRXa8fv36xvnIiuMGyqFDh+TRo0ehlkIHNWbMGHUOalOaNGnkS7dt6VwZ2KSKmt6//dy3OSSJknnIs4c+6jVuar3y85UECRNFQUuJKLpbPOcv48A+yTw85IGPl5rv5/tcEvx3/WAqfgI3iRcvvnpdqUZt8bl/L9i1D31ZeA5Fb07OTpb73Do7iaNB3JM4cWKrpmjxKCD0RTQ3SBOCr5CgHDC8gm4DwZ8Ggae1/UmxHUzjx4+Xhw8fqgwwtoWsGgKmsMDFMr5YLSg2J6TjguDL9A9S0M9Gpth0/2zd36BtQJtRIm0uW26pTSF9H9gmssnIzpoTWtuDts3S8bRGeI6VOahIQOm7dqMF+6qVeGsl2whskdWdMGFCoPemTZtW/R+VB7jJE5ah1PE94bzUIHP7pQe4VZq0UZO18peuJPs3rJBC5auqwaWy5CkQIX+PiIi+adtRTbBw5jRZv2KpZMuZW9avXCZlK1UNtv7jRw8labLk6vXJo4clUZKkZm+c05eD51D05uwaQ02hrhPgeDcntC58X0zm1hrIMG7ZskVluQDlvMh2ab+AKBNFSTOgjBPrB/3lRPkqyoS1UkyUHZsGFNZCubHWPxSDLSG7jP6SKJ1GmSkCIWRzly9fbnwPyn/RZq2PL/p5Iuhzc3MzzgOUKGOe6ajEGEVX6/8bGmQskdVDNk/rsxoVkA3GvmltRGCGwacgc+bMKkuJfUUfY5Rmm34fCxcuVOsjS2m6zzheWKZlgJEVx3bCytrjifXixo2rSqE1jx8/lsiC7wqVB9hvLbOPfs+AwBmZZgTlKKE2DZxwjuE4ascEN4ZQJWAt3ODA8TCd6DMEq92qFpJ/z52SUV2ayR/9Oqv5J/Zsk+V/fuoGUKBMJYnvnlC+q11SVkz7TZr2HGTnVpMjqTl8qrT8dZ5sPXVZvuowQo5evSX1f5oh3k8//Z3vNOlvKT9wgly47a2WrzoUvhtvFH01bN5a7ty8IdWK55dt69dIh+6fnoywa+smmTRulHq9dd1qqVO2mMrS/T5qhIydZPvTFyj64TkU/eh1tOTWrVtbPUWLzK01cOGPPqYoHQZkm/766y/jcpSboiQYgQtKi5EZC6p69eqqFBRlrM7OzmrQnj///DPMbcGAReibi0GVUE6LgAgByHfffaf6aWK5p6enCt40LVu2VIE52olsJrJuKOVFG7A+9g8BD/rdItDBwEQYyAlBIcpj0a/VEnxm//79VYkxAm7sb1RAH9snT54YS5wRnKHEGEEX+rwiyEfJOG4AYJ4WnHXs2FF9H+jHi3IFDNiEclvAa5Q3oxwX20MQiEGhwjoSMI61NccT66EUGuXPyBbj/EBWFKXykaFbt26qbzBK2FHejZsi2gBWCFgxgBfODS1wLVmypHpMFm7goE0433BcMNhW0Mwu2Q6jH0/ZGvwmSqFyVdQEODc6Dhlnh9aRHmwc/m2weat//FxdMaPH564PRKGJHSeOTJob/N/+ClVrqAmat++sJiJzeA5FP04uLuJsIbPupIPMO67H0a0R18KAWAiJLVurBpwM0ey5FQg0cYD4bE9yVOinjfMzIp+RHBIMVIVg3nSE75CgigF9b2ftvyxx49v+SCT6stW5+WngPKLwuFXctvEkiIgi0ssXflI0S1pVWekoFW7a9drtP/qIWyiPmwO/N+8kXa/xDtV+U0hEYlwljDuDyklt7BskLjdu3KieTBJWjperJormkiVLpgbhQsl8ZMFgWwie8Vgk0z7CRERERKR/0eFRQD179lQBLAbjxRNRMKEbIgaKxbIvpiw5NHh8i/bsVCJHFPTRQ5EBIzmHd+AsIiIiInJMWr9aS+s4sr1796pHc5qOjIwupWPHjlXd8GwR7YJbIiIiIiKi6MyazKyTg2duMbgpHssZ1MuXL9VYRrZw7D0mIiIiIiKi4M+5tVSW7OzYjyesVauWeowlHp2KYaAwIZPbpUsXNaiULRjcEhERERER6YjFxwA5Wy5btreJEyeqPrd4eg3GiMGEcmQ8PtTWJ4CwLJmIiIiIiEhHnJxd1GRpHUeFLC1Gfl6yZIkaLVl7FBAeGYrg1lYMbomIiIiIiPQEgaul4NXZsYNbBLEXL16Ur776KlwBrSnHzlUTERERERFRYCg5tmZyUM7OziqoffLkScRuN0K3RkRERERERJHKycXFqims9u3bJ7Vr1xZPT09xcnKSNWvWSGTBI3/69esnFy5ciLBtsiyZiIiIiIhIT2LEFIlh4XE5MfzDvNlXr15J3rx5pV27dtKgQQOJTK1atZLXr1+rz8Ojf+LEiRNo+dOnT8O8TQa3REREREREOmLNaMhONpQlV69eXU1R4ffff1fZ4YjE4JaIiIiIiEhPnKwYUMrp03KMSmwqVqxYarK3Nm3aRPg22eeWiIiIiIhIj6MlW5pEJE2aNOLu7m6cxowZI47AxcVFHj58GGw+BpnCMlswc0tERERERBRNy5Lv3r0rbm5uxvmOkLXVHgdkzrt371QfXFswuCUiIiIiIoqmz7l1c3MLFNza28SJE9X/0d925syZEj9+fOMyf39/NWJztmzZbNo2g1siIiIiIiI9Uc+xtRTcOosjwkBSWuZ22rRpgUqQkbFNnz69mm8LBrdEREREREQ6Ys1zbJ1s6Lf68uVLuXbtmvHnmzdvypkzZyRx4sSSNm1aiQjYJpQvX15WrVoliRIlkojC4JaIiIiIiEh3mVvnCM/cnjhxQgWdmj59+qj/t27dWubOnSsRaffu3RLRGNwSERERERFF0z63YVGuXLkQB3qKaOhfi4B5586datTkgICAQMt37doV5m0yuCUiIiIiItIRJ2cXNVlax5F99913KritWbOm5MqVSw0wFV4MbomIiIiIiPTEyYqyZCfHHFBKs2TJElm2bJnUqFEjwrbJ4JaIiIiIiEhHokPm1tXVVTJnzhyh23TscJ6IiIiIiIgCixFDJEZMC1MMcWR9+/aVCRMmRGgfX8feYyKKciP+OirOrnHt3QzSqdoTuti7CRQNZH75wN5NoGjgjiS2dxNI52I6h78PqN4eBRSVDhw4oEZM3rx5s+TMmVNixowZaDkeExRWDG6JiIiIiIj0JJJGS45KCRMmlPr160foNhncEhERERER6Uk0CG7nzJkT4dtkcEtERERERKQjTs7OarK0jh48evRIrl69ql5nzZpVkiVLZvO29LHHRERERERE9InTf5nb0CYnx87cvnr1Stq1aycpU6aUMmXKqMnT01Pat28vr1+/tmmbDG6JiIiIiIj0xMnp03NsQ52cxJH16dNH9u7dK+vXr5fnz5+rae3atWoeRlK2BcuSiYiIiIiI9EQLYC2t48BWrlwpK1askHLlyhnn1ahRQ+LEiSONGzeWqVOnhnmbDG6JiIiIiIh0xODkrCZL6zgylB57eHgEm588eXKWJRMREREREX0RLJYkOzt85rZ48eIybNgwefv2rXHemzdvZMSIEWqZLZi5JSIiIiIi0l2fWwt9ap0cu8/thAkTpGrVqpI6dWrJmzevmnf27FmJHTu2bN261aZtMrglIiIiIiLSEzzmx9KjfpwdO3ObK1cu+ffff2XRokVy5coVNa9Zs2bSvHlz1e/WFgxuiYiIiIiIdCQ69LmFuHHjSseOHSWiOP4eExERERER0WfOMaybHNDJkyelfPny4ufnF2yZr6+vWobyZFswuCUiIiIiItITHQ8o9dtvv0mFChXEzc0t2DJ3d3epXLmy/PLLLzZt2zH3mIiIiIiIiMwyODkZS5NDnpzEER09elTq1q0b4vLatWvLoUOHbNq2Y+aqiYiIiIiIyDxrMrNOjpnHvH//viRIkCDE5fHjxxdvb2+btu2Ye0xEREREREShPwrI0uSAkiVLJlevXg1xOUZOTpo0qU3bZnBLRERERESkJzruc1upUiUZNWqU2WUGg0Etwzq2YFkyERERERGRjuj5UUA//vijFCxYUIoWLSp9+/aVrFmzGjO2GGzqn3/+kblz59q0bQa3REREREREeoLA1VmffW4zZcokO3bskDZt2kjTpk3F6b/yaWRtc+TIIdu3b5fMmTPbtG0Gt0RERERERHqi4wGloFChQnLhwgU5c+aM/PvvvyqwzZIli+TLl0/Cg8EtERERERGRnug8uNUgmA1vQGuKwS0REREREZGeRJPgNqIxuCUiIiIiItIRg5OTFQNKOcmX5ssL54mIrOB7br3cX95b7q/8Xh5u/0UC3r8Ocd33T27JrVlN5fWdk1HaRnJ8b9++lWbNmkrePLmlevVq8vjx42DroJ9Rz549JE/uXFK6VEm5ceOGXdpKjmvjtp2Sq0QFyVGsvMxeuCTY8op1G0uh8tUlb+nKMuq3iXZpIzm2d2/fSte2zaVSsfzSon4tefrkSYjr7tq2Rb7ycJd/Ll+K0jaS4zwKaMqUKZI+fXqJHTu2GtH42LFjohcMbnXmw4cPMmLECMmWLZvkzJlT8ufPL/Xq1VOdsaNKuXLlZM2aNeo1Rjn7448/RI+8vLykdOnSVq1bo0aNUB82HdTw4cPVA6rr1KljnNezZ0/1hwIjwgX9vqpUqSJ58uRRfQ7QptOnTxuXoZN9iRIlVCf7woULy8WLF63aZvny5SVx4sS6/X7szTVpRklZ/2dJ9fWvEjNhKvE9v97seghMnh3/W+KkyhPlbSTHN3fuHMmQPoOcPXde6tatK+N/+y3YOlu2bJYnT57IufMX5IfBg2XIkB/t0lZyTB8/fpT+w36SrSsXy7GdG2T8nzPkydNngdZZvXCWnNi9WU7u3ixbduyWM+c//ztBBMsWzZe06dLLjiOnpWqtOjJj0vgQg+C506dInvwFo7yNFEbIylozhdHSpUulT58+MmzYMDl16pTkzZtXqlatKg8fPhQ9YHCrM23btlWBz+HDh1WQg9fdu3cPU+BFn3h6esr+/futWnfTpk3GZ3BZq3nz5rJu3Trjzw0bNpQDBw5IunTpgq27bNkyOXfunApQ8QcFNw00nTt3lk6dOqlnfg0YMCDQstC2uXv37kDBNYVNHM+c4hzDVb12TZZZ/F89Nbveq2v7JDbWjeMexS0kPdi0cZM0a9ZMvW7atJls3rwp2DobN240rlOtWnU5euSIumlCBMdPn5UcWbNIqpQpJH68eFK1QjnZsSfwv11uCRKo/3/48FE+fPxofKwGkWbn1k1St1FT9bpuw8YqO2vOjCkTpFmb9hI7TpwobiGFlcE5hlVTWI0fP146duyoYg48lmfatGkSN25cmT17tugBg1sdQQZv9erV6uRKlCiRcX6lSpWkSZMmxp9//fVXKVKkiBQoUECqVasmt2/fNmYTGzduLLVr11ZZwFq1aqkhuHE3Bj/j4iogIECt++LFC3ViYzvIKCK4ev/+fajt27lzpxQvXlxlk5FVnjVrltn1Hj16pDKVuXPnVtvGLw+cP39eSpUqpdqNX6affvrJ+B60HfuItmNZhQoV5OnTp8ZsdteuXdU+FCtWTD0MGtll2LNnT6AR2LC/yHTCrVu3JGHChMZluBgYPXq02ucMGTLInDlzjMvwHi0zinZlz57dOLqbdnwtKVOmjKROndrsMtN2+Pr6Gi9McJfsxIkT0qJFC/Xz119/LXfv3pVr165Z3KYl7969Ez8/v0ATmffy3z0SJ1XeYPNRqvzi6i5xy1XDLu0ix+ft7S0pPT2Nv+fPn/sGW8fH21vdbAP87idMlEhlconA2+eBeKb0MP6M1/d9fIKtV7bm15I6ZyGpUKak5M2VI4pbSY7uoY+PeKT49HfGzT2h+PkG/1t0785tOXvyuFSvXc8OLaTILEv2C3K9h2tAc3Ctf/LkSRVbaJydndXPSKxFBjc3N2N3HNPXtmJwqyPI0uKBxig1DcnixYtVFhcnIEoJkD1E4KdBoDR//ny1DgLYDh06yIoVK+TSpUty+fJl2bx5s1oPASLKY1Fjf/bsWRX0TpgwIdT2IShFFhHtREZ05MiRcu/evWDrLVy4UAWPCGaRrfztvzI9BJAIkNFu/GKtXLlSjhw5Ynzf0aNHZe7cuaqtyZMnl+nTp6v5M2bMUIE/Mtn4XGzTVrFixVL7jOOAkl+Ug5l69uyZunmANiLYPXTokHh4fL7oCI9WrVpJmjRpZMiQIbJgwQI1D4FsypQpJUaMGMYL37Rp08qdO3fC/XljxowRd3d344TPpuD8LmxC7bHEy1Qi2LLnp5aJe5664mTDnVEiooi0d+NKuXXuiJy9cEkuXmY1F4Xd2BE/yveDh9u7GRSmAaUsT4BrPNNrPlwDmoNxIfz9/YNd2+JnHzM31SKCaaVSRFQt8YpMx65fv64yeW/evFF9MpFpRF/Y48ePS8GCn/pK4AQ1hYyplvVFMIpgLsF/5UzIuCJIBGwHATJKEwCf4eLiEmp7kGlo3769Kp9FMIafkSkNmllEdvX3339XATQyj8gua5+BQBxBI+4SIbDDa6wPWC9JkiTqNTLECI4BATEymzFjxlQ/t27dWmbOnGnTMcXNAECfZuwDfpFN2487Sl999ZX6PBzLmjVr2pw5DQo3HWDevHmq/Bil0JFp0KBBqgRagzt5X3qA63dpi7y4slO9TllnlLy9f05e/rtXUtQaYXb9d49vyqtbx+XJoVkS8NZP3tw9I8nKdZc4qYNneenLMX36NJn7X+VHihQpxNvLS5ImTSrPnz+XhAmDl6+nSJlSjQFQoEBB9Q/782fPjH/riFKm8BAv7wfGn/G6cH7zf2MSxI8v5UuXkK2790rO7GHrSkPRz8LZf8nShfPU62QeHvLAx0sSJ0kifr7Pxc09+N+ii+fOSpfWn7pIPHr4QNo1bSBzlq2Rr7Jmi/K2k2WIAy3Fgob/luOaGtewGlz/R1cMbnUEwSfKUZE9RICaKVMmFfwhm6kN8IQLIwQtKCM2B6OeaRCsBv1Zy1RiO8icotTXWl26dFEDL+F9yDAieMZIoUEhMEW7d+zYIatWrVKZSmR7f/jhB3UBiNcILBs0aBDo/SG1NSjTvkbYjmmAb649pix9BuYhm4yMLUqeEXj//fffVg9MZQ0E5ziWuDmAYBNljWgH9gXfC7K2yN6GF/6wRec/brZwy1FNTfDu8Q15emyBpKgxVJxjfj4vTKU0CXof7Z0i8TIUY2BL0rlzFzXBn3/+qf5G5M6TR5Ys+Vv1qQ2qevXqquqmVq3aanCpIkWLss8kGSGQvXjlH7nv7SPubglk66498kOfHsblvn5+8v79B0mWNIkqNdy+e7/07NzOrm0mx9CiXUc1wby/psna5Uske87csnbFMilf+dO/daZ2H/9c+da8fk0ZNvoXBrYOLMBgUJOldQCBrWlwGxJch+Na98GDzzfUAD/jZq0esCxZR5AxxGibyI4iA6B59eqV8TVGTkbHb9P+qKYj71oL2/n555+NwR0Caq2fZ0iwDgY2wkXZvn37VDmzOTdv3pT48eOr/r+TJk1Smd6XL1+q9yMLiiAOZdPbt2+3qq3of4sLQ+wrJi0DChkzZlR9YtHPF7RyX1uhlBu/4AhmEZSjj7Atx9cUvktkbTS4UYGsDcrPUX6NmwQo5QbcOMAxQnk6Ra5nxxaJ4f0bebB1rNxf1U+eHPxUDfDu0XV5vG+avZtHOoExBW7cuK4e84MxE/r07avmb9y4Qf73v5HqdfXqNdQNy9y5csqon36SkSP/Z+dWkyPBv4k/D/9BqjRoJoUr1JReXTpIksSJpM43bcXL54E89/VTrwuWqybFKteRMiWKSs0qFe3dbHIwTVq0lts3b0rFovlk8/o10qlHbzV/55ZN8sfPo+zdPLKBwcopLFxdXVX1J6oiNeiaqI2rowfM3OoMsrSjRo1Sz5zCP3i4IMIjZ1DGqpXVIuOHx8AAgtN27dqprG9YoGx44MCBasAklAjjs8aNGxdqUDV27FhVVvy///1PvQ9tNAcZT5Q7a5nRX375RdX///jjj9KyZUtVlousNIJWa2A0YZQoY6ApHI9ChQoZg0UM0tK/f381SBT6CyBDEh4Y7AkjFOOGAoJ43HBAptXadmJUVJQ6YxAvlIPjhgG22ahRI1WWjWON73PDhg3GzA36FmOEZAx2hbtupgNdhbRNCr8UNYaYnR8rWSY1BZWsbLcoaBXpTZw4cWTJ0mXB5tesWUtNgN/7yZOn2KF1pBe1q1VWk6l1iz//W3B42+eR+YnMwejHU+ctDja/YrUaagpq0eqNUdQyslWA4dNkaZ2wQpc1XNviehrXz3ikJK57tQFgHZ2Tgc8boGgAGVUEdsjcIsDHXSct4LcHjO6MjKy9nzGLoBg3Gnr16mVxXfS5xU2GtK3mirNr3ChpH0U/FyZ8CtiIwiPmy8AlcUS2uCMhD8BJZI0XL/ykQOY0KhFhTVlvVNCu127f97bYJj8/P0mXKmWY2z958mSVfELyBNeREydODDFpFV64fke1J6otTV/biplbihYwRDn6GqFPLUqFMdKxPaHsGiXQGM7c9Fm3UQnZezzuqGTJknb5fCIiIiLSV+YWunfvriY9YnBL0QIeE+RIvv/+ezXZ0+7du+36+UREREQUeaJD+W2LFi2MWWXT17ZicEtERERERKQjkZm5jUpTp041+9pWDG6JiIiIiIh0BMMmWRo6yfAFDq3E4JaIiIiIiEhHAv6bLK3zpWFwS0REREREpCP+AZ8mS+t8aRjcEhERERER6QjLks1jcEtERERERKQjLEs2j8EtERERERGRjiAnaykxaxDHduzYMTl8+LD4+Pion1OkSCHFixeXIkWK2LxNBrdEREREREQ6EmAwqMnSOo7o4cOH8vXXX8vBgwclbdq04uHhoeY/ePBAevfuLSVLlpSVK1dK8uTJw7xt50hoLxEREREREUVm5taKyRF17dpV/P395fLly3Lr1i05evSomvAa8wICAqRbt242bZuZWyIiIiIiIh0JMHyaLK3jiLZu3Sr79u2TrFmzBluGeRMnTpRy5crZtG0Gt0RERERERHpisNznVhw0uI0VK5b4+fmFuPzFixdqHVuwLJmIiIiIiEhHAsRg1eSImjRpIq1bt5bVq1cHCnLxGvPatm0rzZo1s2nbzNwSERERERHpCLK2FkdLNohDGj9+vOpX27RpU/n48aO4urqq+e/fv5cYMWJI+/bt5ddff7Vp2wxuiYiIiIiIdETPfW5jxYolU6dOlZ9//llOnjwZ6FFABQsWFDc3N5u3zeCWiIiIiIhIR/ScudUgiC1fvrxEJPa5JSIiIiIi0hG99rldsmSJ1evevXtXPQs3LBjcEhERERER6Yh/gMGqydGgHDl79uwybtw49UzboHx9fWXTpk3yzTffSIECBeTJkydh2j7LkomIiIiIiHTEP+DTZGkdR7N3715Zt26dTJo0SQYNGiTx4sUTDw8PiR07tjx79kz1v02aNKm0adNGLly4oJaFBYNbIiIiIiIiHQkwGNRkaR1HVKdOHTU9fvxYDhw4ILdv35Y3b96ooDZ//vxqcna2rcCYwS0REREREZGOIHD112lwq0EwW69ePYlIDG6JiIiIiIh09yggS8GtfHEY3BJRIBXnDxFXjjVHNjrUr6y9m0DRQBHP5PZuAkUDvybIYe8mkM69FwfstKrzPreRjcEtERERERGRjui5z21kYnBLRERERESkI/5W9Ln1/wKDW9YeEhERERER6UiAsd9tKJPoi7+/v5w5c0Y9EshWDG6JiIiIiIh0xD/AYNXkyHr16iWzZs0yBrZly5aVAgUKSJo0aWTPnj02bZPBLRERERERkY4Y/utzG9pkcPCy5BUrVkjevHnV6/Xr18vNmzflypUr0rt3bxk8eLBN22RwS0REREREpCP+BusmR/b48WNJkSKFer1p0yZp1KiRZMmSRdq1ayfnz5+3aZsMbomIiIiIiHTEUtY2wIrRlMNr1KhRUqJECYkbN64kTJgwzO/38PCQS5cuqZLkLVu2SOXKldX8169fi4uLi01tYnBLRERERESkIx/8A6yaItP79+9VtvXbb7+16f1t27aVxo0bS65cucTJyUkqVaqk5h89elSyZctm0zb5KCAiIiIiIiIdsabs2D+Sy5JHjBih/j937lyb3j98+HAV2N69e1cFybFixVLzkbUdOHCgTdtkcEtERERERKQj1pQdB/y33M/PL9B8BJFaIGlvDRs2DDavdevWNm+PZclEREREREQ6EhBgsGoCPFrH3d3dOI0ZM0bsLSAgQGbPni21atVS2dvcuXNLnTp1ZP78+eEa5ZnBLRERERERkY4EWDFScsB/MSLKfn19fY3ToEGDQtwuyoHR/zW0CY/rCQ8ErwhkO3ToIPfv31eBbc6cOeX27dvSpk0bqV+/vs3bZlkyERERERFRNC1LdnNzU5M1+vbtqwLM0GTMmFHCA3109+3bJzt37pTy5csHWrZr1y6pV6+eyuC2atUqzNtmcEtERERERKQj/gaDmiytE1bJkiVTU2T6+++/5YcffggW2EKFChVU9njRokU2BbcsSyYiIiIiIoqmfW4jy507d+TMmTPq/3hWLV5jevnyZajvO3funFSrVi3E5dWrV5ezZ8/a1CZmbomIiIiIiHTE34pH/fhHchuGDh0q8+bNM/6cP39+9f/du3dLuXLlQnzf06dPxcPDI8TlWPbs2TOb2sTMLRERERERkQ773FqaIhP6zmJwqKBTaIEtIMsbI0bIOVY85/bjx482tYmZWyIiIiIiIh2JrD63UQEBMAatCulZu+/evbN52wxuiYiIiIiIdAT9af0t9KkNiOQ+t7Zq3bq1xXVsGUwKGNwSERERERHpiL8Vwa2/gwa3c+bMibRtM7glIiIiIiLSkfcfDeL8McDiOnpy+/ZtefXqlWTLlk2cnW0bGooDShEREREREekwc2tpckSzZ8+W8ePHB5rXqVMnyZgxo+TOnVty5cold+/etWnbDG6JiIJ4Lh9khXgZp5lyR27K60Dr7JBHsly8ZJl4yX55IgZxzH9AyL7ev3srI7q3lTZVikm/lvXF9+mTYOu8evlCfuzUXLrUrSCda5eTY3t32qWt5Ljevn0rLb5pJgXy5ZFaNarLk8ePg61z8sQJKVemlCRN5C5bNm+2SzvJsX2QAFkk9+SwBH/EykN5p/49+1vuy0l5bpf20ZcT3M6YMUMSJUpk/HnLli2qVHn+/Ply/PhxSZgwoYwYMcKmbTO4JSIKIqHElIbiqaa6kkJiipOkltiB1ikjSaSReEojSSlvJUBuyRu7tZcc1+bliyRlmnQyd9sRKVW1liz9a1LwdZYtlAxZs8u0tbtk8B9/ybTRQ+zSVnJc8+fNlfTp08upM+ekTt268vv434KtkyJlSpk05U/5ulEju7SRHN9p8ZXkYn502gPyVCpKUmkinnJH3sgTeR/l7SPbBpQKbQpw0OD233//lUKFChl/Xrt2rdStW1eaN28uBQoUkNGjR8vOnbbd6GVwGw4YwvqPP/6I0G16eXlJ6dKlA33Z2bNnl3z58sn58+fV/1+8eBHm7SZNmlRu3boVbP6ePXskTpw4arvatG7dOoloTk5O8vx5xN0JHD58uLqTHRHHODKgfcmSJZM6deoY5/Xs2VNdnOBYnDlzxuz7cNcKy9esWWOcd+zYMSlWrJh6MDbOhXHjxhmX/fDDD6pfQt68edUfia1btxqX/f7775I5c2b1nZLtELR6SmyJGeTPpet/P+OfDX9mbSkEh3dtlYp1PwUbFes0lCO7tgVfyclJ3rx6pV6+eukniZOH/GB7+jJt3rRRmjRrpl43btLUbGY2VapUkjt3HnF24qUdBecrH+S5fJS0EifYslfyUQLEIEnUv2xOkkniqQCXdPAoIEsBrsExr0/evHkjbm5uxp8PHTokZcqUMf6M8mQfHx+bts2/gA7G09NT9u/fb/x52rRpMnToUBUMoQYd/0+QIEGEfmbWrFnVdrXJNCBzVChVsCW4xQOhgx7jyIK7T6Y3Cho2bCgHDhyQdOnSmV0fNx/++usvFcgG7YOAIPb06dNy8OBB+fXXX+XSpUtqGYJ0zD979qzMmjVLGjdurDriQ+/evWXmzJmRuo9fghvySv1Db842eSTz5Z7K7KY3c8FA9OShjyRNnkK9ju/mLi9f+AZbp2bjlnL73yvStFQeGdyhmXQaMNwOLSVH5uPtLZ4pPdVrlOv5+rJslMIGpchFJKHZZa/FX+KZjDEbT1zklfhHYevoSytLTpcunZw8eVK9fvz4sVy8eFFKlixpXI7A1t3d3aZtf1HBbdDsoWk2Exk1BJHFixeXDBkyyE8//WRc7/79+yowQXCZJ08eGTIkeMkYUud4L7JrOXPmVIGGBgFGjhw5VAYN2zh69KgEBARI9+7dVSYOWbeCBQuqYA3twT9cWqYPQRgCmxIlSgTbB6T0a9asKYULF1btmjx5svEzEVRh25jfv3//cGelv//+e5WNhPXr16vtYn/Q4RvZZbh27ZpUqlTJuMw0+wgIynB8smTJIosWLQoUBCLriPdhf0zv1GzcuFHtH44Rtolj16VLF2Ngh3kPHz5U2eyOHTtKkSJF1HYQEL5//6mkply5cupY4vupUqVKoGMc9JiaOy9+/PFHdfzTpEmjbjYgu4ptYdmSJUusPqa4I5U6dWqzy3A+dOjQQSZNmhTsgdam7UPg6urqKokTJ1Y/V69eXWXeAecWHor96NEjq9qDB2T7+fkFmiiw9xIgPvLO7J1uqCLJpKWkVnnb+2JbJQHR8f27JFu+grLkwDkZN2+l/DKwh/qbQEQUEW7Ja3GXmKrLDUUfeg5uW7duLd26dZP//e9/0qhRI1WFiFjINJOLGMMWfBSQCQQQhw8fVncQMmXKJG3btlVlPi1atFBB0YoVK9R65oIH1IcjK+fi4iJPnz5VQVzVqlVVMNO3b1+5cuWKpEyZUj58+KCCCmTaEBDjTgWGuvb19VVBi6mJEyfKuXPnpFevXlKvXr1Ay/z9/aVZs2aycOFCdUK8fv1aZfyKFi2q7oag7QiMEVSj0/aTJ8EHMdFcvXo1UOmqdiclJAj2pk+frgI8XIBpQRGC1Hbt2knnzp1V4K2V0mqZSgRpyDLeuHFDBbO4Q4MAEUE0Snhh7NixKohGEPnPP/+o/di3b5/aRxw77CeW4fOxf1qQimAWwS4ynwjwEOhOmDBB+vXrp5ZjW9hOzJgxzZZnhwYBJX7JELwjgBw8eLA6T9DhvUaNGtK0aVMJL4wYh+Nh+outQTCNfgg47jj3sO8pUqQwux7KOELKDAc1ZswYmzvrf0kXBKkljsQQpxDXcREnySBxVfky1iVat2i2bFq2UL1OnMxDHj/0EffESeSln6/ETxD8TvS2VUukZffv1evMOXKrWnffZ08kUZJPfxfpy/TXjOkyb+6nZ0F6pEghXt5ekiRpUnWt4u5uPgNHZM4DeSfX5ZWqRPooBlWC7CpOUvC/TG5clan9aFwfWVvMI8f2McAgLhaC148OGtwi8YZr+lWrVqlr2uXLlwdajkpFxDm2YHBr4ptvvjFm7hAk3Lx5U6XEEbSa9mXUAjFTCB7bt2+vgqgYMWKony9cuKCC24oVK0rLli2ldu3aKtOGzCW2jxJZBIPly5dXGcuwPM8JASkCY9PACtlLlKt6e3ur7CUCW0C7evToYbEs2VrYn++++05lsxH0a/2AT506pU5G+Oqrr6RUqVIqANWCLWQmAfuOLCaCTQS3ixcvlgULFqjMNSYcf9i+fbtUq1ZNBbaAwDSkEgVkiRFwasOKo5YfNxo0uEGB99uiSZMm6v/ovxo7dmy134AAHTcycKFhmgkOK5wnK1euVMfDHAT8CERxfuLGQNmyZdVna98v4EYJAlUcM9xEsMagQYOkT58+xp9xkwLZafrsuryW7BI/2Hz0sUUZVwKJoS4SbssbSS6Bb07Rl6tO83ZqgtXz/5Kda5dLpmw5Zee6FVK0fOVg6ydL4Smnj+yXrHnyi/fd22r0ZPdESezQcnIkHTt1VhNMm/qnLP37b9WndtnSJVK1WjV7N490pKgkUhNclZfyVD4YA1tASbKTOKlBpBJJTBUIY9BEcmzWZGb9HTS4RcwzcuRINZkTNNgN07blC4JgBxlPTdA+mwhcTNdF8GktlMoimMOgTwgUEcBq20fgggAFmUdk+lDKiiANQQ0CFmR1EYwiM2gtZCdRmmraVxbBONL8QVkb7JhCgB7SsUIAiSxh3Lhx1eeZDnAUls/Fctw4QIZ606ZN6nhg27b0pcXxwHHWjgWCf2Q4NfHjBw9QbD0vtJ/RfkxhOU/MwQ0AZJNxQwDB/pEjR1QmeurUqaqKYPXq1cYbL7gxgIy4dhMB9u7dqzLcKBfHjQprofwZnflNJ/rsnQTII3knaUyysXvliZqHgFZ7FNAK8VZDcOSQiO0LT9FDjcYt5P7tm9KmclHZt2W9NOn06Ubj4Z1bZN6En9Xr5t36yKmDe9VjgEZ0ayO9Rv5q88PrKXpq3aaturmZP29uWbN6tfTu01fN37Rxo4z66X/q9YUL5yVH1q9k7ZrV0rVLZ6lcobydW02ObpM8MGZsS0li2SmPZal4qX/3MLgUOTY9j5ZsTteuXdV1b3h9Uf96IvOGPpuANLg28E5oEBQhy/jbb5+H3TdXlvzs2TOVoUSwgwwcyo4Bgc/169dVpg39VpH1w+i32AY+H5lPDHeNoEYbJMgaCGIQjCDI1CA4RiYR5cIoZ0bQrD0oWet/GpZjhXYCstAIPjXYLvoVo8/wt99+q4IxDHKF0mytPWgLAlfTkc+0ZQjkENChjBjHDe9NkiSJaqNpQIqybmTMtf3AzQGUbwPeo70GlG3//PPPxkAT27X2ZoEt50VEwjFEth3HBROCV5SSYz6eARYvXjzZtWuXWhe/9Gir1g8B5xqqAtDvGf2SKeLEEmdpJWlU2bGmrCSRZBJLjZxcX1KqRwE1Fk91UYARJomCihU7joz4c57M3X5Uflu4RhIm/lSZUrxiNWn93QD1OqlHStXXdvr6PTJt3W4pUrainVtNjgZjKyxeslROnz0vm7ZslaT/VZDVqFlTBv/4aRyQXLlyy6Wr/4rXg0dy4/Yd2b5rt51bTY4oq8SX4v9lcWuIh3EgKQ+Jpf49ayappFAIA0+RA46WbMWkF+hqGRHjv3xRwS0ejYJyWgRh6PuJgMoaKJk9ceKECuhQgms6cJMGmdmBAweq5Qgm0fcVkBFE6TGCESxDf1aUgt69e1cqV66sMrZYhgkly2HJrG7YsEEFY9gG2obyY5Tjomwabahfv74KeND/1dp91SBziAAcg1K1atUq0Ai+GOAKn4f+tDg22kBTGCRq6dKl6jMRxGMgrbRp0xrfh2OB9yCgR7YWAT3KjhGoY9IGiDINOhEQo6QY28QxRUYW0I8Zx08bUArfrfZIIxwPlE5b27fW1vMirNAXGWXq9+7dU4E79s8SZIqXLVum+g7jGOBmAfpg4wYG4DtHH25kbrVHOaF6gIiIiIiiLz0PKBVSFWZEcDJE1JaIyAgBP/riRvRzkMMKzzFGMGxNn2rcLUO5fFtJY3yGK1FYfX31U8UHUXgU8Qy5KwmRtQYk+Dw2BZGtT02YI3dVtaCjdN/SrtdazNonrnFD/1v5/vVLWdi+jEO1PySoykTlK7rghQcHlCKKBChnR1YbfaRMn3UblZCRxujReK4vEREREUUf7zFezEd/y+voBAanjQgMbokiAfpXY7Kn3r17q4mIiIiIoueAUpbWcTRh6VdrS7aZwS0REREREZGOILB11uGjgBImTGjxiSroNYt1TJ9mYi0Gt0RERERERDryMUDEyULw+jEgyppjtd27I3ckdwa3REREREREOqLXzG3ZsmUjdfsMbomIiIiIiHREr8FtUHi6yKxZs+Ty5cvqZzxuFI9RxYjQtuDzPoiIiIiIiHQkOjzn9sSJE5IpUyb1hI+nT5+qafz48WreqVOnbNomM7dEREREREQ6otfRkk3hqR516tRRj66MEeNTWPrx40fp0KGD9OrVS/bt2ydhxeCWiIiIiIhIRxDYWhpQyl8HmVvTwBbwun///lKoUCGbtsmyZCIiIiIiIh3B43IMARYmg2MHt3iO7Z07d4LNv3v3riRIkMCmbTK4JSIiIiIi0hGUHFszObImTZpI+/btZenSpSqgxbRkyRJVltysWTObtsmyZCIiIiIiIr1lbi1kZg0Onrn99ddfxcnJSVq1aqX62kLMmDHl22+/lbFjx9q0TQa3REREREREOqKVHltax1H5+/vLkSNHZPjw4TJmzBi5fv26mo+RkuPGjWvzdlmWTEREREREpCP2Lku+deuWKinOkCGDxIkTRwWlw4YNk/fv31v1fhcXF6lSpYp6zi2C2dy5c6spPIEtMHNLRERERESkIwH+BjVZWieyXLlyRQICAmT69OmSOXNmuXDhgnTs2FFevXqlyo2tkStXLrlx44YKkCMKg1siIiIiIiIdsSYzGxCJmdtq1aqpSZMxY0a5evWqTJ061erg9qeffpLvv/9e/ve//0nBggUlXrx4wUZTDisGt0RERERERNG0z62fn1+g+bFixVJTRPP19ZXEiRNbvX6NGjXU/+vUqaMGljIdCAs/o19uWDG4JSIiIiIi0hMrglv5b3maNGkCzUbfWAzkFJGuXbsmkyZNsjprC7t375aIxuCWiIiIiIhIRwKQ3bTwqJ+A/5bj+bGmJb6hZW0HDhwoP//8c6jbvXz5smTLls348/3791WJcqNGjVS/W2uhry0Cb9OsrZa5RZttweCWiIiIiIhIb8+5tVSWbPi0HIGttf1X+/btK23atAl1HfSv1Xh5eUn58uWlRIkSMmPGDAkLBLfe3t6SPHnyQPOfPn2qlrEsmYiIiIiIKJqLrOfcJkuWTE3WQMYWgS0Gg5ozZ444O4ftKbNa39qgXr58KbFjxxZbMLglIiIiIiLSkYAAESeLoyVLpEFgW65cOUmXLp3qZ/vo0SPjshQpUoT63j59+qj/I7AdMmRIoGfbIlt79OhRyZcvn03tYnBLREQRJmlcV3s3gaKBt5H4bEb6cvzx8ry9m0A6h1GG53imFoctS7bQ59ZgYXl4bN++XQ0ihSl16tRh+tzTp08b1zt//ry4un6+dsDrvHnzqkcE2YLBLRERERERkY4YAj5NltaJLOiXa6lvrqVRktu2bSsTJkyw6Xm2IWFwS0REREREpCMBAQYrypIN4sjQTzeiMbglIiIiIiLSkcgaUCoqvXr1SsaOHSs7d+6Uhw8fSkCQTsI3btwI8zYZ3BIREREREelIdAhuO3ToIHv37pWWLVtKypQpzY6cHFYMbomIiIiIiHTE3z9ABJOldRzY5s2bZePGjVKyZMkI2yaDWyIiIiIiIh1RoyUH2G+05IiQKFEiSZw4sUSksD1pl4iIiIiIiOwKgW2Ahcng4GXJ//vf/2To0KHy+vXrCNsmM7dEREREREQ6Yu/n3EaE3377Ta5fvy4eHh6SPn16iRkzZqDlp06dCvM2GdwSERERERHpSHQYUKpevXoRvk0Gt0RERERERDqinmGr8+fcDhs2LMK3yeCWiIiIiIhIRwwB/mqytI4enDx5Ui5fvqxe58yZU/Lnz2/zthjcEhERERER6Uh0CG4fPnwoTZs2lT179kjChAnVvOfPn0v58uVlyZIlkixZsjBvk6MlExERERER6YghIMAY4IY8BYgj69Gjh7x48UIuXrwoT58+VdOFCxfEz89PevbsadM2mbklIiIiIiLSEYO/v5osrePItmzZIjt27JDs2bMb5+XIkUOmTJkiVapUsWmbDG6JiIiIiIh0xGCwoizZ4NjBbUBAQLDH/wDmYZktWJZMRERERESkI5ZLkv0dvs9thQoV5LvvvhMvLy/jvPv370vv3r2lYsWKNm2TwS0REREREZGORIfgdvLkyap/bfr06SVTpkxqypAhg5o3adIkm7bJsmQiIiIiIiIdCfj4QcTJxfI6DixNmjRy6tQp1e/2ypUrah7631aqVMnmbTK4JSIiIiIi0pEAZGUtZGYDHDxzC05OTlK5cmU1RQSWJRMREREREemInsuSd+3apUZFRvlxUL6+vpIzZ07Zv3+/TdtmcEtERERERKQjeg5u//jjD+nYsaO4ubkFW+bu7i6dO3eW8ePH27RtBrdERERERER68t9zbkObxEGfc3v27FmpVq1aiMvxjNuTJ0/atG32uSUiIiIiItIR9QxbnT7n9sGDB2afb6uJESOGPHr0yKZtM3NLRBTEOwmQleItK8RLlomXXJYXwdZ5K/6yRR7KUrkvS8VLfMWxRyQk+3j39q307dhS6pYuKJ0a15ZnT5+YXW/jqqXSoHxRaVixuIwf+WOUt5Mc29u3b6Vdi2ZSvEBeaVCrujx58jjYOiuWLpFyJYpI+RJFpVHdWuJ1/75d2kqOadPmzZInfwHJlTefzJk7L9jyXr37SLoMmaRk6bJ2aR+FnSEgwIqy5ABxRKlSpZILFy6EuPzcuXOSMmVKm7bN4JaIKIiY4iR1xEMaiqfUlxRyWnxVMGvqoDyTTBJPmkgqaSApJK6EPhw/fZlWL5kvqdOml7X7T0qFGrVl7pQ/gq1z6/q/smT2DFmwfoes2HlY2nT9zi5tJce1aP5cSZs+gxw+dVZq1qkrk34P3hctfYYMsnbTNtl96KjUqd9ARo8cbpe2kuP5+PGjDBj0g2zeuEGOHDwgv0+YIE+eBL7R1rhxY1m9aoXd2khfVp/bGjVqyJAhQ9SNu6DevHkjw4YNk1q1atm0bQa3OoeHHmfNmlXy5ctnnM6fPx/m7dy6dUsSJkwYIW2aNm2a/PLLL6Gus2fPHtVWc7y8vKR06dISkcqVKydr1qxRr9u0aaM6sofX8+fPZezYsYHmdejQQXbv3q1eDx06VBYtWhTisOe5c+eWTZs2qZ9Xr14tefLkUccEo8cNHjxYDAaDWvbq1Stp27atWj9btmwycOBA4zJ8b9g3dL4Pejwxyhzm4bPQVrKeszhJzP/+PPqLQXC0Px3xz5ndx/JOvpJ46mesq61PZGrfti1S8+vG6nXN+k1k344twdZZ/fd8adquk8SLn0D9nDhpsihvJzm2bZs3SaMmzdTrho2byvYtm4OtU6hIUXH/79/xfPkLio+3V5S3kxzT8RMnJXu27JLK01Pix48vVSpXlh07dwVap0TxYpIkcWK7tZFszdxanhzRjz/+KE+fPpUsWbLIuHHjZO3atWr6+eefVVyDZbgWtgX73EYDS5cuDTFQtMfdwS5duoRrG56enjYP/x2V+6kFtwg2NTNnzjS+HjlyZKjbwD5qNxTwsOq6deuKs7OzvH//XkqVKiWFChWS+vXry+jRo8Xf31+VaOBz69SpIytWrJBGjRqpUeZ++uknNWx60D8CuEFw5swZFdxS2CGAXSc+4icfpagkkjgmmdkX8lFii4vslEfyTD6Ip8SWYpJIBcVEph498JZkKTzV6wTu7vLCzzfYOndv3lC/+63rVhEXFxfpPeR/kjt/ITu0lhyVj4+3pPD8VKKHANbXN/QblksXL5SyFSpGUevI0Xl7e4vnf+ePdp3l5e1t1zZR+KmsrKU+twGOmbn18PCQQ4cOybfffiuDBg0yJm1wzVq1alWZMmWKWscWTDVEU0jpN2nSRGUB8+bNq0Yd08yZM0cFw5iPAArZPw3KAAoWLCiZM2c2ZhXh+PHjUqFCBbV+/vz5Zfny5YEyvgMGDJACBQrI5MmTZfjw4dKrVy/je3EXBllHfF6xYsXk9evXaj4Cta5du6r5eJ7ViRMnAm1T07x5c/W5yGzWrFlTfHx8zO7z4sWLpWjRoqp92Ob69etDPD4IFEuUKKHuGLVu3VodL3jx4oUamrxIkSLq8zp16qSCTUCGtGfPnlK8eHF1PBHEY30cS7QvPBniBAkSqItbQInGu3fvjEGpNqIcfkbnezzkesGCBWpZ4sSJVSAcL96nDGJY4DPwfDHTiT6LJc7SSDylmaSSa/JKXpuUJSOX+1DeSV5xl68lpbyRALkqL+3aXtKvj/4fxfveXZm9arMMGvWrDO7e0fgPPVFYbd6wXk4cPyadvu1m76YQUSTSc1kypEuXTsUajx8/lqNHj8qRI0fUa8zLkCGD2IrBbTSAINa0LBmB2pYtW1Rm8dKlSyo4WrJkibEcGBnFzZs3q/n79u2T5MmTq2XI/iGgw9DbCFJ79+6t5mM7CPJQYosAdPv27dK3b1+5/99gFdrDlk+dOhUoqIV58+bJypUr5cCBA+rz8LmxYsVSy65cuaICS8zv0aNHiOUHCBDxuQhIkY1E8GwO7vTgF+P06dOqtAFBKgI4c/BLtHXrVrl8+bIqffj999/VfOwXPuPYsWOqXQEBATJhwgTj+/755x91zPDwaZRfIyhFdlQLzMMDd7BwEwDfB24kIJMLuNmAmwnYl5cvX6rg2fSGhK3GjBmjypm1KU2aNOHeZnSEvrRJJKb4yNtA8xJIDEkqruIkTpJe4shj+XQThGjp3L+kadXSakrqkUIe+XwqD33h6ysJ3NyDrZ88RUopV6WGytp+lT2nuMaOLc9DGHiKvhyz/5ouFUsVV5OHRwrx8fqUafN9/lzc3c13Izp96qSMGjFU5i5aYvy3lggD83j9d/5o3b9Spkxh1zZR+AUE+Fs1ObpEiRJJ4cKFVWIJr8OLwW00KUtGgKVNceLEUZlLBG7IjGK5Ntz2xo0bpWXLlsYRyOLGjasmiB07tjRo0EC9Rnby+vXrxqDrxo0bUr16dRU8o4QWrl69qv6Pbbdo0cJs2zZs2KAynAieACctLuAA2WFkWoN+nrmMLDKjuXLlUmW/2Edzbt68qdqI9erVq6eCVswzBwMnIDBFW9q3by87duxQ8xE4or8w9hMZYJQOX7t2zfg+7GdoQ5eHBzLJ6C999+5ddYNBK81G2XPatGnVsULmGr/8GCI9vFAGghsT2oTPpU+QpX0vAcbyZG95J+7y+XuPJzFUmbLffyMke8lbSWSynL5sTdp0lCVb96upTKVqsnHlMjV/4+qlUrpi1WDrl61cXU4cOaBee927I69fvRT3ROz79qVr17Gz7DxwWE1VqlWX5Uv/VvNXLFsilaoGfz7kndu3pVvH9jJjzgJJYeMooxQ9FS5UUC5dviT3vbzUTfJt27dL5YosW9c7g3+AxefcGvwjt88tusrhGhUxBGILxBi4eWJPDG6jqYwZM6qsLcpZDx48qAK+Z8+ehfoe3OXVSmER9KGfJ6A8DplZ0wD6zp07KrsICI61ktqwwC+CBp+HMuWgkPGdOHGiKlHAkOHjx483O7IaNG3aVA3ohPXQRgyaENK6QWn7jX1FplnbTwTw06dPN66HbUa2ZMmSqVHktNJv3KxA9hjt2bt3ryRNmlR9H+GF7xt9dk0n+uSlfFT9bZeLl/p/LkkgScRVNskDeSWfztMSkki2y2O1zgcxSHb5NBgQkan6zVrJ3Vs3pE6pArJjw1pp2+1TdcvebZtk6q+j1etSFapIzJiu6jFAfTu0kKHjJtr0N5Wir+at28qtGzekWP48sn7NaunRu4+av3XTRvl51P/U6z9+HSfPnj6VHl06qmxv2+ZN7dxqchS4IT529GipVqOmFC1RUr7r0UOSJEki9Rp8bex727FzFylXoZKcv3BBMmXJJitXrbZ3s8mCAP/3EvDRwuQfuVVl5cuXl2XLlqnrZVw/I1HVsGFDsScOKBVN3bt3T2VJcUcFAS4yksjM1a5dW/UFRQdu3GHR+r9ayigiA4rsppa1RaCF/ryW4PMnTZokX3/9tcreosQZGVNrISDH+vgjjL6vpoGmuXW1Gv2FCxeGGsxjQCaUICNwRB9kbb+Q8UUfYXwO/jHANjBcPrLMQSEYRAk42uXq6irhgRJt9P/FBS368SLD3qpVK7UMfWHRFtxEwPcwdepUVXZNkSe5xFKPAQqqhnwe3CCZxFL9bYlCEztOHBk/K/io6WWr1FCTdnNtwP/G2aF1pBf4t2ru4k/di0xVrVFTTTB+0hQ1EZlTq2YNNZlas2ql8fVf06fZoVUUHqo/rZN9B5Tq/V8XRq0PLaoNcS394cOHSKt0tITBbTTpc4t/+DToP4qMpTb6GDKiKBNAf1pt0Cj0T8UFFYIyBHqhQZCMYOv7779XASFOWJQgaAMnhUYrT0CAjAANAx9pJcDWQGCOQBXDgiPARRCq9fUNCtlN3C3CYFTIKqONIUFtP47Bo0ePVEm01lcYxw6/mChLRqCJNmOIcnPBLQZzQgCK44qMbnj63aJ0XCsfR8Yc+4EsNKAkHGXUaAsmtFEbHRs3JxAUoz8uSotTp06tjjn60xIRERFR9GT48NZy8Or/qftU0EFDUb0X0f3y0R0Q4/Pgmt9egS04GTgkI1GUw40FZIUj6tnCEfFZ+MOH7HpbSSOu7LFANup813yfeKKw8EzAPuwUfu4xHPMZn6QfuDby8EytEgiO0n0LCSxUKob09JCgkIBBX2tTSHSFNEBrWOGJKRiIFgkXPBUF4+0gIWUvvIIlsgM8u6ts2bKBHrcU0TAgFTK8+Cz23yMiIiLSP4xZg25qpoOChjbdu3cv2DxUd4YEFYxIjIQ2oTudpl+/fupJJdu2bVNj6KCq0Z65U2ZuiUhh5pYiAjO3FBGYuaWIwMwtRcfMbWR79OiRGm/G0sC15sabQSCNR0viSSvo9mcP7HNLREREREREgqd2YLJFQMB/j1F8907shcEtERERERERWe3o0aNy/PhxKVWqlBp8Fo8BGjJkiGTKlMluWVtg7SERERERERFZDY+oXLVqlVSsWFE91aR9+/bqCSJ79+6N8JGYw4KZWyIiIiIiIrJa7ty5ZdeuXeJomLklIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYiIiIiISPcY3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYiIiIiISPcY3BIREREREZHuxbB3A4iIKPrwfvnO3k2gaCB74pj2bgJFA05HVtu7CaRzTq/e2LsJFEbM3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYiIiIiISPcY3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYiIiIiISPcY3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYjM8JMPsl58ZKl4yXLxkg8SYFyG15vkgSyV+7JMvOSC+Nm1reS43r97Kz/1aCcdqxaXga0biO+zJ8HWef3yhQzr3Fy6168o3eqWlxP7dtqlreS4Nm3eLHny5ZdcefLKnLlzgy0/fuKEFChUSHLmziOjx4yxSxvJsW06fEZytx4gOVv1l9kb9wRb/veOQ1Kg/Q+Sr+0gGb90k13aSBQRGNwSEZmxR55IIUkoTcRTaouHuIhToOX5xF2aSCqpLynkorwQX/lgt7aS49q6YpGkSJNW/tp6WEpWqSnL/5oUbJ0tyxdKhqw5ZPLqnTLw9xkyY8xQu7SVHNPHjx9lwMBBsnnTRjly6KD8/scEefIk8E2SXr37yLw5c+XcmdOyZes2uXDhgt3aS47no7+/9J+6WLb8OkCOTh8pvy/bLE98XxqXP/Z9ISPmrpKdfwyWkzNHyZ7Tl+Sfu952bTORrRjcikj69Okla9aski9fPjV16NAhwj+jTZs28scff0TY9tasWSNHjhyx+f3Yx927d4uelCtXTu13eOA78PHxkcjm5OQkuXPnlk2bPt39PH78uJQoUULixo0r9erVM/ueN2/eSI4cOdQ5qJkzZ47xvMSUNGlSadCggXH5L7/8Irly5VLvq1+/vjx//ty4LawfP378cB+zL9FTeS/O4iQpJbb6Oba4qJ81McVZPP9bhtfuElNei7/d2kuO6+iubVKhTiP1unzthnJs93azfy/evPp0ofnqxQtJnCx5lLeTHBeystmzZ5NUnp7qb3qVypVlx87P2X0vb2/x//hRcufOJS4uLtKoYUPZvHmLXdtMjuX4lRuSI30qSZUsscSPE1uqFskjO06eNy6/6f1QsqX1lEQJ4omLi7OUypNV1h44adc2E9mKwe1/li5dKmfOnFHTzJkzxdGFJ7j19/dX+1i+fHn50kRVcAv79++XGjVqqNcpU6ZUn/3777+HuP6AAQOkZMmSgea1bdvWeF5iSpEihTRv3lwt2759uwp+Dx8+LJcuXZKCBQvK4MGD1bI4ceKo9QsVKhTi57179078/PwCTfSJr3yUmOIkm+WhrBRvOSW+Ia77Uj6qYDipuEZpG0kfnj70kSQeKdTr+G7u8upF8HOpWqOWcvvaVWlZJq8M7dRM2g8YboeWkqPy9vYWT09P48947eXlHcrylHLf2yvK20mOy/vxc/FMmsj4M157PX5m/DmTp4dcvHlP7j96Km/fv5etx84FWk6kJwxuQ7Bnz55AGTSU+CDDC48ePZIqVaqozFyePHlUAKIFjf369VOZNEw9evSQ9+/fG7dx7tw5lb3LkiWLtG7dWmXXYPHixVK0aFHJnz+/5M2bV9avX298z/3796Vhw4bGzxoyZIjKBq5bt05l7dBGLRhfsGCB2k6BAgWkTJkycvbsWTV/7ty5KpD9+uuv1XaOHTsWKAsaNKv8/fffy/Dhny6u8P/GjRtL7dq1Vbtr1aqljkXVqlXVz82aNZOAgM99ETW3bt2ShAkTyrBhw1TQlTlzZmMWU8tUaFlGQEYS74HLly+r7WN/MU2bNi3Y9l+8eCEdO3aUIkWKqHU6depkPNbjx4+XwoULq2OD/yP4g5EjR4qXl5c0adJELUPwh/3r1auXcbuTJ09Wx0M7bpUqVVL7iMwovjsEkciQZs+eXZ0DL19+LusJTerUqVVbY8WKZXb5jh071HetBa7mHD16VB4+fCh16tRRP+P7LVWqlCRIkED9jEAa54C1xowZI+7u7sYpTZo0Vr83ujOIQbzlnZSWxFJPUsh9eSP35NPvqyl/McgOeSzFJJHK4BLZ4uSBXZItb0FZsO+sjJmzQn4f2NPs31UiosiQ2C2+/NatuTQeNlGq9xsnuTKkERdn/ptG+sQz9z9awINp9erVoa67cOFCyZAhg5w/f14FrL/99puaP2PGDFV+evLkSRU4Xb9+PVCmDsHJ1q1bVfD29OlT4zIEcsjCnj59WtauXauCNmTVoEWLFio41D6rZ8+eKohBgINAGp+DEuODBw/K33//Lfv27ZNTp07JqFGj5Jtvvgn02aNHj1bbKV68eJiOzYkTJ2T+/Ply9epVFVTi81asWKECPezL5s2bzb7P19dXBZ44Hggae/fubVXforp166oAE/uLCcF9UH379pXSpUurQB1BHi4EJ0yYoJa1bNlSfQ84NpMmTTLefBg6dKi6u61l6U1vXoQE2/n555/VvmbKlEkF+Qi2sd+urq4yb948CS8E+f3795epU6eGut6sWbPUvsWMGVP9jPMCQTEy0QaDQRYtWqS+H5xb1hg0aJD6jrTp7t274d6X6CKuxJBk4irxJYbqa5tG4shj+XyjSguAd8ljSSuxJaPEs1tbyfFsWDRbDQ6FKVEyD3ny4FO1yEs/X4mXwD3Y+ttXLZESlT9VeWTKkVv9PvuZGXiKvkyo/MGNWQ1eY17Iy73F02Q5UcqkCQNlYvE6ZZLPmVyoU6qgHPxzuOye8KOkSOIumVN52KGlROEXIwK2ES0g4DENdpC5DUmxYsVUYIoACxnSatWqqfkINBCUadk5BKlTpkxR5aaADKiWZWvfvr1MnDhRfvjhB7l586bK2N27d09ixIihghPMQ7bvwIEDKiDWJEuWzGybEBQjyEPmVoPtaNlhZB3Rr9gWyFAmSvTpjyCywtg/bT+Qbf7333/Nvi927NjG/qEIqBHsW4IA+u3btypbaprVDQpZZ2RkkaUF7Cf6GgFuEiC4x4AbOJ7YJpajVDes0O60adOq1yjx/fDhg3h4fPqDj6xwSPseFt27d1fnQfLkyVUQbc6rV69kyZIlgUrRkY1Hlh3ZdOw7MsqAfbYGvseQMslfuuTiKm/EX96Jv7iKs8ri5pD4gdY5Js8lhjhJAUlot3aSY6rVvJ2aYN2CmbJr3XLJmC2n7F6/QoqUqxRs/WQpU8mZIwckS+784nPvtrx+9VLcEiWxQ8vJERUuVEguXbos9728xN3NTbZt3y6DBn66rgAEsvg34Pz5C5IjR3ZZvmKF/Dk5+MBl9OUqnC2jXLx1X5Udu8ePq8qOB7WoG2idh8/8JHkiN/F5+lxW7Dkm28cPslt7icKDwW0IECCgzFiDgMs04EHmD8HsqlWrVKkwAqqgUHobGm1506ZNZezYscYMZeLEiQN9njVwpx+lzsjOmoNBKMKyr6brI0jV4B/QoD8j22oOAidtH7Ge6WcE/dmW/V25cqUqjTaF0mQE1BgsC8En+pGi5BaZcHPBbWjfc3j2PSxwAwMTAlV8Pm5K4EYEgnLN8uXLJWfOnKo82lTXrl3VBAh8cUPEzc0t3G360mHwqCKSSNbJAzGgrFxiSzqJqx7/U1aSqHlnxE8VI6+QTxmTopJIZXiJTFVt1FzGff+tdKhaTJIkTyE/TPjUjeTIrq3y74Uz0rLnAGn6bW8ZP7CH7N2wSv3N7DHiF3FmSSCZ/Ds1dsxoqVa9hqpS6tO7lyRJkkTq1W8gf/45RQW348f/Jq3btpG3b9/JN82aqq5RRJoYLi7yc5emUrXvWAkwGKRPkxqSxD2+1B30m0zt2071we01cb5cunVfDSg1tnNTVapMpEcMbkOQMWNGuX37tupfi2ypaV9GZFVTpUqlMrHI2iLjhr6X6J+J8l2UA+PCBH1hkfXUoJQX2V4EWRgICOvDs2fPVJmzVvKMnwEBJjLDKHtGCSlo7UEAg1JSDcqUkf3t0qWLyjTiH0CUJ4c2oJAG/WFR3gvIdqJvbKtWrSLsWIb0mSiVRok1bhAgMwkI6jCiMEqstezt48ePg2VvMeIwyoWnT5+u/uHHMUPb8V0gwNWyrShLNhX0uKEdGzduVAEuAmAEzLZmuG2l9TXWKgbQBxg3T4KWJCPbHxQGEkFJ2uvXr1XZNcqbKWKklThqMlVDPpdpdZZ0dmgV6U2s2HFkyOTgzyUtVqGqmiCpR0oZPWeFHVpHelGrZk01mVqzepXxddEiReTUiRN2aBnpRa0SBdRkau2YvsbXi4d1t0OriCIebw2HAH0zEShgECCUISObahqAoL8jyphR7ouBnZAdxKBGKNvFhGUYgMp0sCJkEtG/FoMRYbAlbRn6iiJrixJfZIC1wAwQVKPPK7J22Cb6rgL6Xi5btky9B0E0+p+OGzdOlaZiUCqsjzJWa6DdCJrRLgS12N/IhrLu7777Th0r7DPuQgMCVZRYI/jH4FfYFwSc5t6PmwQ4JujXW7FiRRUkInj96aef1PeG7wj9Yk2hzzLKxbUBpZDlxXeNfUd5L45nZEAWFlnVPn36qDJzvP7zzz+tfi/ain7hQeHmCb5rHCcMLoUSZyIiIiKiL5GTAfWdRBShUFqIbDJuYtgTRsXGTZSQnq1rSivhbitpVD9TIlvUuXzU3k2gaKBCWpZEUvg5HQl+c5woLPxevZHkdbqoqj92+9IHXsESRQIMOlW2bNlAjz+KShhAC9npGzduBOonTEREREQUXbHPLVEkwON57Akl20H77RIRERERRWfM3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYiIiIiISPcY3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLrH4JaIiIiIiIh0j8EtERERERER6R6DWyIiIiIiItI9BrdERERERESkewxuiYiIiIiISPcY3BIREREREZHuMbglIiIiIiIi3WNwS0RERERERLoXw94NICLHYDAY1P/fS4C9m0I69vrlC3s3gaIBPz/+HaLwc3r1xt5NIJ178fpNoGskcnxOBn5bRCQi9+7dkzRp0ti7GUREREQO5e7du5I6dWp7N4OswOCWiJSAgADx8vKSBAkSiJOTk72b45D8/PzUDQD8I+fm5mbv5pBO8TyiiMDziMKL55BlCJNevHghnp6e4uzM3px6wLJkIlLwR5t3Ja2DiwBeCFB48TyiiMDziMKL51Do3N3d7d0ECgPegiAiIiIiIiLdY3BLREREREREusfglojISrFixZJhw4ap/xPZiucRRQSeRxRePIcoOuKAUkRERERERKR7zNwSERERERGR7jG4JSIiIiIiIt1jcEtERERERES6x+CWiIiIiIiIdI/BLRGRiRs3bkixYsXk5s2b9m4K6dTDhw+lRo0acvXqVXs3hYhIAgIC7N0EoijD4JaIyETy5Mnl5MmTsmXLFns3hXQqYcKEsmfPHlmzZo29m0I6Dkb8/f3t3QzSMTwMRQtqnZ15uU9fDp7tREQm4sePL+3atZP58+fLhw8f7N0c0iFXV1fp2rWrLF68WN6+fWvv5pCOmAYjLi4u6vWLFy/U//nkRgoLJycnY1C7cuVK9W/aq1ev7N0sokjH4JaIvlgfP340XjCaXji2atVKjh8/LpcvX7Zj60gPkF0zV/LXokULOX/+vJw9e9Yu7SJ90oKRO3fuSP369SVTpkzq7xGqSRCsEFnr2rVrcuDAASlRooR8//33MmTIEPnmm2/kwoUL9m4aUaRicEtEX6wYMWKoC0b0kTQNbtHnNn369LJ8+XK7to8cH7JrCEiQETENcvPlyyc5c+aUJUuW2LV9pJ+bIvgbtHTpUpX1nzJliqROnVr++OMPuX79ugwcOJA3SijYORRS6fqyZcukXr16MmDAABXQYgyJadOmyaNHj9T/iaIzBrdEFO2ZK+dDMDJ+/HjJnTu3lCpVStq0aSPbt283BizNmjVTF5os46Kg/ddMIXgtW7asFCpUSLp06SLbtm0zLmvZsqWsWLFCnj9/HsWtJUexefPmQH9/tHNIuyliGpzgRtvFixdVCemJEydkxIgRUrt2bfnzzz/Vevh7RF8e/P0oUKCA7N+/P9B8nEOYfH19Zffu3eLl5WVchr9HHh4eqgIA/7ZB9erVpVKlSnLs2DE1cCJRdMXgloiiLe3CMWg539OnT2XYsGHq7nb37t1lwoQJEjt2bBWM4M42NG/eXGVMcJFJZNp/DXBBOXz4cBk9erRUqFBBRo4cqcrckSXx8fFR6zRt2lS9PnTokB1bTlHt3bt3xsD2u+++C3RzQzuHFixYINWqVZP27durv0PaTbS6deuqoART4sSJjYEKqgAOHjzIm21fCASgGNQQf1MwQB3OE9yINbVv3z6pWrWqeHp6Sp8+faRcuXKyevVqtSxjxozqvIkVK5bx3zQoXry4Ogc3btwY5ftEFFUY3BKRruHCsUePHsYLSGRGtEyJNiDL6dOnVf9H00Alb9686kKgc+fO6o52rVq1VHkySpFxcZotWzYpWLCgLFy40E57RlHBXDbWXJb2/fv3Mnv2bBXMarTSddwoadSokXTr1k3dONEGkkqbNq2qCkAgQ9EfvnOUEiObj3MIf1f++ecfSZQokXGdM2fOSJkyZWTcuHGSJ08eiRs3rgwaNEjdYAPMQ1CCgOTZs2dqHm68FS5cWF6+fGmsLqHoSfu3C+eH9vcE8BpBrnbDFucaStZx0wPnFMaIQB/tiRMnqpHate41GP1/69atxu3j3zQEvsj0EkVXDG6JSNdQdoVshnYhiLvSCF6fPHmigto0adKoDAn+4UcZMoIWXGwiq4aLxv79+0uKFClUn7avvvpKBSLatlq3bi0bNmxQ26LoeSGplYbihoZ2YallabUMnLYuLgjxeB+cb+7u7iqgRYD722+/qQtG9HHD/3EOPX78WL2vbdu26uLS29vbbvtJkQ8ZNvw9wd8SZGy1DCtumE2ePNl4LuG8yZ8/v/rbhAAGJcdVqlRRN0T+/fdfiRkzpgpkMUKyaRlq0aJFJVWqVMy4RXO4iQaDBw+W+/fvy5UrV9TPuLGBwcW0cSBwrmFU/zFjxqh/t1DOjgEQjx49aszeIkuL83Hv3r3G7SPYRYCL/tuHDx+2yz4SRTYGt0SkS9odbGQ6kFHLkCGDcT4uGHGBiEFZRo0apS4aUb41Z84c2bRpk3EwKayH0ST/+usvuXTpksyaNUuVIWujJDds2FAePHhgfA9FLwhiEbCmTJlSBSGm5eu///676u+o3ehAeR/OIQS5O3bsUPPixYsn8+bNk0WLFqmRSDE6KYJfXDhqI5KizNTPz09WrVplp72kyITzAX9z8PcE+vXrp4JbDOAD+H/Pnj2Ng0Hh7xQCEpS1I2OLmyHI9CJDp/WpRbbfzc1Ndu3aZfycrFmzqht1GDWZN9uiL/ydAdwAQWk6bq6+efNGPaIOVQGmgxyi2ujq1atSsmRJqVmzpiRIkEDdYMPfNJxfCGyxHfTFxXmjKVKkiPrbhvWJoiMGt0SkG6blolrJMeAfbwSiCEoxH33VkAFBn1kMDIULRWRmcYE4c+ZM9R5k1pBxQwYXFwaAci5cqGJQIGRecHGBQYKQbaHoFYxoWdry5curYAElfrjgw8Xl3bt3VeCKUnfc/NDghkmyZMnUBSfgHPnpp5/U+YNH/+C9Wv9anEMIanHudOjQQZ2PFP3ghoj2twgZepSComQU/WPxnGxkXHPlyqUGFtNgPvr640YaAl0EvnifVnKMvpU5cuRQpaa3bt0yvq9v377qb1SSJEnssKcUFTCYGB7dg79HCGaRvdcGisI5g3MM1UqAfwtxUw2ZW/S/xU22/7d3JlA61u0fv9MhSmpapNWapYjW03ImxSFRYmIqSbKVVrQImRZbhDKTyDrVCamUckrJ0iKKlKnQvphoRZuS6v6fz/Xvut97xkPe/9+Meeb5fs55z8yzzDPN+1x+z/29lu+F0OX88lgirkjckXRz0tPT7fWJSyFKIxK3QogSBxUwb89yECNxUx/a+mjBAqoeXCi6cCUzTbsoP+OigpY+Zt3IYGPyg0ghc02FjYuHFStWmMihRZALSP/9VHdbt25dzP8PiKKAi0EXI3xF5NLmSZxQ5T/ooINMlFAhI1aYcYvPONauXdtW/OTl5QX5+fkmgKmo8D2xw0UlbYQ4knIxScUFWL3Ro0eP3fiXi12VFEkE1XtGHXr16mViFfFKdd+r/hdddJFVZammAQmTZ555Jhg+fLg9xmw28cNZRPx5RwrxF6/SUuUlUSdKx251x28TEz179rSEG1VXWtn5vKLlGFq2bGmfZ95JREcSlVtmtIkNXocYooWZbiRA7GZlZZm3hBCpgsStEKJEQbWVqgUf2nEQI5iz3HbbbdZejHsklQxAyOJu7NlpPui5QKClGMEBiGJmjaikefsfc01kvFmzwEUA80izZ8+2WaS4Ccz2LmpFckEMUI1l1pH2PQQIF4a4HgPz19wGDMXq1atnF4teKSEGiU1m4dyQhY4AvqeqSwWFi1diiAQNlX9RupIihe+nA4SkGk7rdI707t07uOmmm0yAcJYBZxMx41V9zKKILxe7dAIgWjhzfC8ynQAkXjizROnbrU5CNX6uwMiRI82EjFEaOoo4V2rVqmUztAhWkmmMOZBMATpFmMPF9BB3ZczuSKggZmlHpoMAwzK6l6gCC5EyhEIIUUL466+/7Otvv/22zWMzZswIK1asGJ533nlh//79w/33399uf/fdd/b43Llz7b6FCxdGt0844YRwzJgx0Wt8//33YdeuXcNGjRpFv++TTz4Jn3vuuXDr1q0J/1tEcvH3339v97178sknw8MOOyw8+eSTw0GDBoXjx4+PHktLS7P7/vjjj+i+mTNnhqeeemo4ZcqU6L4HHnggLFeuXJiRkRHd9+GHH4bTpk0Lv/766yL7u8TuZcOGDeGIESPCq666ys4iP3feeuutsGzZsnaOOMTfgQceGN5+++3hli1b7L709PTw4osvtu/z8vLCc845J6xatWp40kknhUcddVQ4adKk8IMPPtC5U4rhvc3NzQ3r1Klj7/0pp5wSDh8+PPz222/t8Ro1aoQ5OTn2vZ9D2dnZ4cEHHxyuXr3abi9atMji7f3337fbCxYsCM8666zwkEMOCRs2bBjOmzdvt/19QpQUJG6FEMUqPBLdl+j+OXPmhD/++KN9//vvv4cNGjQIe/fuHT3+9NNPh5UqVQpHjx5ttz/77LPw7LPPDjt06GC38/Pzw8svvzxs0aJFgdd98MEH7XkI3cL8+eefCf9bRMlj1apVluR44403oovBHb13P/zwQ3j88ceH/fr1Syggrr76akt6rFu3Lrrvm2++CTt37hxWr149fOedd8KlS5daciQzMzNs2bJluH79+iL660RxQ+zw7z8RCAbEyIknnhhef/31Yc2aNS25QRIOoco5tHz5cnvu5s2b7Wv37t1NbHAOwdSpU03wegKEeEQs33PPPUqKlCK2F0Pw2muvhWeccYYJWs4ZkmaNGzcOb7nlFnu8TZs2UdLMk618rpUpUyZ86KGHos8nhGz8sxBxTPJFCPG/qC1ZCFFsJlBxN9r42hW/nxbhnJwca9nC3If2TsCYh9UYmGM4zZo1CzIzM80pGXC8paWLVlNemxlbWvowZWEe12G9Dy6kcVOW+F7c+H+jKJmwaodWcto+mUsE2jp572hnpz2P1nVmqx1ii9ls5qdpT/aYpI0Yrr76apuljbfD06ZOqzKxlZGRYS62tMBjxkLLKHNxonSQqO0YmHukzRNjOc4R9tFi+sPZ9OCDD1qMMB/r7cQ+409L+6effhrNS3KeEX/EIWB6h7MyLcxqXy89s9geQ5iEeduxwxws7eh+pjAiw6gN5xnnEHP+xBit7u6+ja8EvwMjKeaviVP2unP2+OcW/hHxMRohUh2JWyFEkeImUMy/TpgwwfY58qHvItJn0TBiQXhizsOHPjORvvYAkcLFgK/X4EOdWSIELhePCBLmj5ib5Xfl5uba85if5EIgLmR91UL8gkSCNnkgyYG4wIEYQYHJE7zzzjtmuII77fz5821+DbMen43l/WbeFtMocGMyv4g89thjzU173LhxNjuJuy0CFpHCGp/p06ebQRQz38SiSF5IbBSeo2c2n3lZEmTM7hNnbtqDiROzjgiPDh062LlDDBBLnFXcZg6SWVriiVlHTOmYkyRuNm/ebGcQ89vsRhbJzz+dj9skRZYuXWpzsjgSk3wlWQvEBklbkq7svia5QWKD75m5Jm6IPZJ1nTt3Nt8HX+HDOcYMt+9OxisCgazPLSESI3ErhChScCFu0aJFULVqVctQ33333SZIEAlkq3EjxvyJiiuiBQdRjDMwaMGpFrGL8OBiksoaF4z+oU5FF3zNBr8DYx921voS+9tvvz3agRsnUZVGlEy4iHSXURyuuchDaHLh2LdvXxOtJEkQEFRCELc40hIz2dnZ9hpNmjQxkUElP/66VOaIMcBYiotQBPI111xjCRmgsoYDtwthkZx4lZ7EBv/+EbC834DJGEk3KmAkxDingBhAYDRt2tTER7ly5cyQjkQbRlHly5e3FS0Y9rDCBbdb3LJJrJFkI0lHIg4wIxOlA+84IoZGjx5tK8H43CGZxmfbu+++a6ZOCFEqrlRXceDHLIozB5MoErPcpguFM4yqLt0AfE8ShM8tjOkwLCNOE32OCSES8E97shBC7HKYSWvfvr0ZqTA7BMwaMWeGKc+1115rs2f77LNPeO655xb42V9//dVm1O699167PXHixLB+/fpm+sPMJI/36tXL5uCOOOIIew73M59bGJm0lJ75tU8//TSsVatWuNdee5mB2KhRo2w+7aefformG5944gmbteY5GEi9/vrrdv+FF15oJi6YsDiPPvpoOHTo0ChOvvjii/Cjjz4qtr9RFD8YgLVq1cqMeTB24ny65pproplZZmE5k5wqVarYc9xECph9ZIbSDew43zAba9asWThgwADNQCYh/Pv/N88Ff/yFF14Ily1bZmZOzOrjCYExGDO0PkPNTP7RRx9tc/4wbNgw+6xasWJFgdfE/PDmm2+OXhsTsvnz5xeY/xdC7DwSt0KIImPs2LEmMHB2jBtHIUb4wN9jjz3Czz//PGzatKmZaWDgExej3bp1M2dbQMz66+Fge+ihh5pzMsZT++23XwFBsjMXKSK5kiQIDlxGiQlMw/bdd19zmI2zceNGEyF169a1+Jo+fbolP9x8Zc2aNZZswWWb1+D1iKP7779/h0YwouTz5ZdfmumTG4wlAld0EmTEBgL0lVdeMeMnzqG4I/bHH39siRNMoICYw3kd92w39cFk6pJLLrGkm0huCn9W8JnEWbEjiBmM5hCsgJsxZlEk1dzpmFgh1o488ki7TXKE5xxzzDEWNyTZrrvuOhPGgwcPDn/55Zci+xuFSCUkboUQRQICFsHKqos4LlxxnqUyi9sxF5b16tULlyxZUuBiY/HixWH58uXDlStXRj+PKyluk7glu/sxGXNWcojkhJiIi0t//xG1JDeGDBliQgKx6i7XJDYuuOCCAo7FEyZMsAvJd999N6qAIGBJhvgF588//2wrgfr06WMXmPHVPyJ5IbGBcO3Zs+d2uzV4DqKEGKF6CwgKqmvuWAt0f5AkOe200+w21XxECJVe3GyJKRJqdJ6sXbu22P5GUXQQG5wztWvXDo877riwbdu2FhO+yslxF+ObbrrJYim+eufhhx+2uIhXXEm27LnnntFnG50nOK5T4Sexhhh+8cUXi+3vFCIVkLgVQhQZCJPWrVvbhUNhyGKzToULSFoBaR+lghYHkUN7YPzCE1yQUGGhnZmLBVFy+W+q6N6+Ho8hLiJpPwa/2Hz88cfDypUrh6+++qrdRhwPHDjQ4smfM2vWLKviVqhQIXzsscd24V8kSmJcESMkzBLhyZPmzZtbjMTbhokbWt1JfDgkz+gS8RZTzhwScnQQUNFVUiS52N7KOSBBRps6XR4kvBCgiFbahwt3dHjS5O2337ZzifZkh885OkomT54c3cc6u9NPPz3acRxf31N4t7oQYtcgQykhRJGBwQrGGhhqFAanUXctrVChghn2vPrqq2YMBDyGYQcrEHCGdDATGjhwoJlQ1a9f356Dy6koubgBGCZQvN++wsLBBOriiy824ya+YtDjxk+9evWyr5iKxVettGvXzl4X4yjcaTEIqlmzpsUPrtsYQo0aNcpW/Dz88MPmpC1Kj7kYFHaLPeecc+x8wFnWn1sYnGhxLfZzBjp27Ghre+IrwzCm4+fHjx8fxR1GY6zv4TU8DkXJhs8RdzUuHC++xqd///62Vmzy5Mnmwo5xE6ZgGEIVNh50l/VGjRqZ8zFGiBhEAU7H5513njlkuxs3Bng4bfP6cTCYkkGdEEWDxK0QosjAXfSLL74IXn75ZXOKBN8vCjiOcpHgz507d250EeAXEYgSX+XDxQhOyjiRXnjhhbamg3UtLnxEyYUdsTjQ+i5hXK9h48aNwV133WXvLW7ZuI7igs1eUUDschGIaygXjPysixtW/7z44ovRPlsELw7KP/74oznf4pSN8y33cyEqkh/efxcFrH/ivPB4wC39rLPOMsfZwuLWRcoll1xiZxFnkgsQ3NtxVmedj0OiZebMmSZ8RfLC5wgxQ5K1X79+dtaweg64n8QanzucNw0bNizws4mSI+DxxhofXI/dVR1IfODWvmbNmuh3kKB78803i/CvFEIUYBdVgIUQIiHp6elhjRo1CswmQU5OTlizZs1oFok2P2ZsEyFzqOQjbh4GOFszy9a/f39zDO3YsaPdT1wwe+btfsw3XnHFFdby5060tLYzo+atpP6auCCXKVMmfOqppxL+bpH8xGdn+Z73HmM5WtIPOuigsGHDhhZL/p7n5uZaO3G8xdjxuGnXrp2Z2OHU7owcOdJckXHdFsnfdsz3bkRXrVo1G29hvpX3HR8HH1PIy8uzs+bNN9/caWd9/z1fffWVzWHPnj07eozPMea+MaUSQuweJG6FEEUK6xKYOUKEdOrUKRwzZoytTzj88MPte0eCpHSQaEaNGVhW8BADmPewMoVZNMjKygq7dOlixmKs1GBmjVlszFn8ORiucEFKLBWGVS6LFi0qpr9O7A42bdpkK5swf0KMMB+LeRjiYsaMGeZsjCM2juqY+aSlpUVO2vFzxYUL8YKgefnllwuYSGkGMvnYkRh977337H3u3Lmz+Tr48zEv9OQGM/sIX/d72FnXdP+9eEVgdoeQFkKUDNTwL4QoUmghpnWURfR5eXnWekqr8aOPPhocdthh0fMKz0OJ5MLn2rz986233rIZW9qRy5UrZ3PRffv2Dc4///ygZ8+e0c9VqVIlGDRokLUEdurUKcjIyLD2Uti6dat9bdasmbWizpo1y9rY+Z72dloOaSkUyR0zK1euDMqXLx/UqVOnwOOLFi0KjjrqKJt/ZEaRmVfmp5ltbNu2rc3tX3TRRdaCPnv2bJvZZ+6WdvWJEycGXbt2LfB6PurQuHFja0OOzzzutddexfRXi12Jv6d8xjz22GPB5s2bbUyF2Wi+4vvAKAtnEd4OPJ9Y+vbbb4OKFSsGlStXDurWrWtzsszpJ2pFZnxmv/32Cw444IAoZv38Yb6bzzHiVwhRMtDMrRCiyOHi4oYbbjBzFmbdhg4dahcEbvYhko/C7x0XfMy6Ll682Mx4mjZtGlx66aUmaplJY3aWubYnnnjCzHucNm3amMjA+InnurBdu3ZtkJWVZSIZLrvsMvvqv9MvakXyQszw/iJUmVMEBCoGdNzfpEkTm3kdMGBA8MYbb5hhGDP8hx56qAlbn5llXp/Xevvtt+12hw4dghUrVlgMJTIRAuIU4SOSGz5PSHoQJ3vvvbedO8TK+++/b48TW0uXLg0+//zzYMGCBRYrxBhmUSTdmLdu0aKFzeEuXLhwG5MnkmcYGsZnaMGfR1IOsSyEKDnsQfl2d/9HCCFSCy5K3ehDJDdeyRg3blzwyCOPWCWWC0wcizHoGT16tCU2rr/++uD777+3SsmMGTOCzMzMqPqBCQtihqobwgTzl9zc3CAtLc2qujIMK93/9qnMrlu3Lvjuu+9M2CI+jjnmmKBLly4mTBCiNWrUsOcSZ3feeWeQn59fQIg0aNDABA7dARiMETP8/D333BPFqChdECtU7jlTcEYn6VEY4uqEE06wii7VV2KN84XECS7GdBHhnI3RGAaFV155pYldXI5x6n/mmWeC5s2bm6OyECI5UOpbCFHsuGOuSA4S5UC5sERI4IDs7eeIilWrVpnIoOWPNj9WPNFeykUm1TZu00KKW7JXXxHAtCSz/ocKLy7HuN5OmDBBwrYUEHdIL/xvH7fZDz74wKqsOFvzXAQHrces+2K1T7wyRuUNN22SH/66VHOJvUqVKtltnj9s2LAgPT3dbuusKZ3gZs0qsBEjRmwjbDmziA86hIgnkh9UbqdOnWoJE7qJevToEYwdO9ac1Gl3b9++vZ05nFtnnnmmJetIkHDOCSGSB4lbIYQQO8TFAZW1+MUjazRoCwRakamQMJfmqzIAkbp+/fpo/QY7bFnfRFWEWbb77rvPfoYZuTlz5gTz5s2zFkIELmJYJD/xFvJp06bZLCzreljJQ9soyQ4qtbSJgldambWm0osoAb6vVq2adQGw0qV79+4WS1TbmMWm+uYCGuHSunXr3fQXi6KGGOG8oC34iCOO2OZx4seTcsQYM7YkQYCK/6233hrceOONQZ8+fSxRQsdJdna2+ULwlbZm2txJuhXedSuEKNlI3AohRIrxj1P+NvcjHnyOMc6WLVtMlFKR9WoZwpMWPwTvK6+8YvdR7eBxZt4cBApmPX4fr0H1jYtLBA0XqBs2bLDHaAX0mVuRnCSKH3bRUhmjaoYoxdxn4MCBNoONwCUpUr16dYsRBIgnU7iP9lHMocBjlp8dMmRIVO2lavfAAw9YtVekBsTI77//bmcG4w7bew6wE524ZNes71snkUJVlhikesvOZD/XqPQidoUQyYnErRBCpAguTLnoS9SqSYWC//38888294ioBcQpc220iNLS51CtpRUUgQqtWrWyi8glS5ZEz2FWEhGLcFm9enU0N8ncLQZUL730klVuRfImReKxVbjKRRUf4YlhGA7puNpSvR08eLCJDQzGgHlrxCr3+evhQMsMNm3ttCL7jC0tpRiM0ZaKORmi+eijjy7iv16UNGhbp9LKyMP2OgZwXMclGYdsukzoCoknYYYPH27jEKeeemqx/rcLIYoOiVshhEjBtRm0htLGSQXMV+4w+0grJzOLGEJRdUWQAN8jiGkndurXr2/CFUGC8MXNtl69etbSF3dEphJCdc0vKKmwnXjiiVEbqkjupIjHFkmRnJycoF+/ftbSSZUMQYqwOPDAA611mNU+ngghVjy+qOYjZl3ceqwSO5gBUfktjCq1qQ0rnzZt2mSt6Zw/EE++YDJ1xx13RK3JOGjj3A6eKNEKHyFKHxK3QgiRwmszqMS+99579jjtn7QIc5udkQhXdtIiVjGCqlWrVrB8+XK7oAReA7Hy8ccfW6XXRTAtfj6LC4hoXg8xLEpfUgR4f4kPHLKp0iM8ELluNoYxmFfuAaMfRC+VN9xqaQNl9yx7Q3ltxAhGPsQX91HBFSIO7ey4JVN9xfzJOwVIquByjNkUzwGSdsSfm4wJIUovErdCCJEC4G7MWh2qqytXrrQKW7du3YJnn33Wdj7S2oe4xSkUkULLMXuJDznkEHMQpd2Umdr4jC1gFsXM2/Tp06OKHOKZipujnbSlMyniYpWECLHCbCPJDwyixowZY/9DECNkaSHFQMxNfagAI3qZcaRFHWhdpmOAVuWyZcuaczawmkWt6yIRuGLjckzskEAhfhiFwHSMZAnnkVd0ZVAnRGqgPbdCCJECMOfau3dvq7IWdhel7ZR5RyqrtB2ffvrpZtZCyx5tfU8++aTN0SJiqaYhYBCziBucbHkebX7sFEX8iNTaJcp+UKr8VPzr1KkT3c8cI4KD5Ajxw75jBDJx6K+NIRTxhPM2+O5jIf4b6ByhCwDzMjoC2GErhEhN/rMBXQghREquzXDjFSpps2bNMnHrAoNZSHbZ0u7HGpasrCwTKVRLuI/qHNURTFtE6d0lSlIk0S5Rd61NS0szsx7ELTOyJDnatWtnSRXihPvpEHj++ecjccscLpU2Kr6OhK34v0C7sVqOhRCgTxEhhCjl7MzaDGYeuThkdhIx4mZPiN3atWtH85VU4hA8tCYzK4mAkbBNzaSIg3sxiRHiAjx2aIHfuHGjvQ4mZRhIUV1btWpV9LO4JMfFrRBCCPH/QeJWCCFSgH9bm1GxYkVrGWW1D+2kzN9mZ2cHjz/+uM3hIk58ioX5R+2jLf3sTFIEjjzySJuLJTFCjHn1ddKkSdHMI2RmZgaLFy+2FmZNRAkhhCgKJG6FECLF12bwlXlZWkbZO0tbMsJ28uTJwYABA8x4Cra3BkakZlLE4wHzJxIgzDoicqnmU+1lJrt79+7RuhVEMNXc+M8KIYQQuxIZSgkhRIpw2WWXmTsyM7RXXXWVtRrzETB37txgypQpQadOnYKMjAx7LjtLqdiJ1IbdoFTy77zzTnOgpQXZZ21h5MiRljQZPHiwuSYvW7bM3JJpX2dtkPaICiGEKE4kboUQIkXIz883kUJFlvlHqmvMzuJ0zCoNxAtiJC5ehNhRUmTq1KnWzq65WSGEECUBiVshhEgxtDZDFEVSRAghhNjdSNwKIYQQ4l9RUkQIIURJR+JWCCGEEEIIIUTSI7dkIYQQQgghhBBJj8StEEIIIYQQQoikR+JWCCGEEEIIIUTSI3ErhBBCCCGEECLpkbgVQgghhBBCCJH0SNwKIYQQQgghhEh6JG6FEEIIIYQQQiQ9ErdCCCGEEEIIIZIeiVshhBBCCCGEEEmPxK0QQgghhBBCiKRH4lYIIYQQQgghRNIjcSuEEEIIIYQQIkh2/gcJ+oVm/avDTwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 940x515 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    control = list(dataset.target_names).index(\"Control\")\n",
-    "    crc = list(dataset.target_names).index(\"CRC\")\n",
-    "\n",
-    "    # Constrain counterfactuals to the control class's plausible range.\n",
-    "    bounds = mf.plausible_range(Xc_train, yc_train, reference_class=control,\n",
-    "                                q=(0.05, 0.95))\n",
-    "    cf_bounded = mf.explain_counterfactual(\n",
-    "        cf_model, query, background_data=Xc_train, y=yc_train,\n",
-    "        total_CFs=1, class_names=list(dataset.target_names),\n",
-    "        permitted_range=bounds,\n",
-    "    )\n",
-    "    print(\"concordance with Control — unbounded: {:.0%} | bounded: {:.0%}\".format(\n",
-    "        mf.counterfactual_concordance(cf, Xc_train, yc_train, control),\n",
-    "        mf.counterfactual_concordance(cf_bounded, Xc_train, yc_train, control)))\n",
-    "\n",
-    "    mf.plot_counterfactual_heatmap(\n",
-    "        cf_bounded, Xc_train, yc_train,\n",
-    "        reference_class=control, comparison_class=crc, top_n=12,\n",
-    "    )\n",
-    "    plt.show()\n",
-    "except ImportError as e:\n",
-    "    print(\"Plausibility section skipped —\", e)\n",
-    "except Exception as e:  # DiCE may find no CF within tight bounds for some samples\n",
-    "    print(\"No in-bounds counterfactual for this sample —\", type(e).__name__)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "68937d5b",
-   "metadata": {},
-   "source": [
-    "### Cohort-level counterfactual importance\n",
-    "\n",
-    "`mf.counterfactual_importance()` aggregates counterfactuals across many samples\n",
-    "to rank **which taxa most often have to change to flip predictions**, with a net\n",
-    "direction — a local-aggregated importance that complements the global feature\n",
-    "importance from section 7."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "2c7a6b02",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T16:39:55.776488Z",
-     "iopub.status.busy": "2026-07-12T16:39:55.776411Z",
-     "iopub.status.idle": "2026-07-12T16:40:20.758793Z",
-     "shell.execute_reply": "2026-07-12T16:40:20.758471Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.24it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.24it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  1.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  1.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.33it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.33it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.37it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.37it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|          | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -1256,7 +905,112 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.41it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.42it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "concordance with Control — unbounded: 96% | bounded: 100%\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAAHcCAYAAADiCjaNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtLFJREFUeJzs3QV4FFcXBuCTBJfgFtyKuxd3K9LixYuWUooUbSlSKC2lSCnFi1Mciru7uxR3t+CS7P98h3+2m2SzSZaE7CTf+zzTJju7s3dmh82cOfee62axWCxCREREREREZFLu4d0AIiIiIiIiovfBwJaIiIiIiIhMjYEtERERERERmRoDWyIiIiIiIjI1BrZERERERERkagxsiYiIiIiIyNQY2BIREREREZGpMbAlIiIiIiIiU2NgS0RERERERKbGwJaIiIiIiIhMjYEtERG5rB07dkiuXLkkatSoUrt2bXFlly5dEjc3Nzl8+LC4gv79+0vevHnFbJYsWSKZMmUSDw8P6dy5s0RGpUqVktmzZ4vZmfUc9G/q1KkSP37899pG0aJFZeHChaHWJiIKiIEtEZHJ3bp1S77++mvJkCGDRI8eXVKnTi01atSQDRs2fPC2ILBDYBJaunbtqhfGFy9e1ItLV2wjha527dpJ3bp15erVq/Ljjz9KZLN06VK5ffu2NGzY0M/jhw4dknr16kmyZMkkRowYkjlzZmnTpo38+++/ofr+H/rfx927d+XLL7+UNGnS6PdX8uTJpXLlynpTy5AuXTptF5aYMWPq7/Xr15eNGzd+kDY2aNDAz3F2JmD//vvvpVevXuLr6xsGLSQiYGBLRGRiyBIWKFBAL/B+/fVXOXbsmKxevVrKli0rX331lZjVmzdv9P/nz5+XcuXKSapUqd47Y0Lhx8fHJ1gX9E+fPpU7d+5oYOPl5SVx48Z16v1ev34tZvX7779Ly5Ytxd39v0u05cuXa8bv1atXMmvWLDl16pTMnDlT4sWLJ3379v3gbQzN41unTh0N2qdNm6bBIwL7MmXKyP379/08b+DAgXLz5k05c+aMTJ8+Xb8PKlSoIIMHD5awhmA6adKk77WNqlWrypMnT2TVqlWh1i4i8sdCRESmVbVqVUvKlCktT58+DbDu4cOH1p8vX75sqVmzpiV27NiWuHHjWurVq2e5deuWdX3z5s0ttWrV8vP6b775xlK6dGnr7/j566+/tnTv3t2SIEECS7JkySz9+vWzrk+bNq0Ff1aMBb8blixZYsmXL58levTolvTp01v69+9vefPmjXU9nv/nn39aatSoYYkVK5a2x3ZbWKZMmWJ5+/at5YsvvrCkS5fOEiNGDMtHH31kGTlyZIB9nzx5siV79uyWaNGiWZInT2756quvHLYxOPu/atUqS/HixS3x4sWzJEyY0FK9enXLuXPnrOsvXryo2zx06JDdz6p3796WwoULB3g8d+7clgEDBujPmzZtshQqVEiPAd7n448/tly6dMkSmKtXr1oaNmyonwdeU6BAAcvu3bt1HT6bPHnyWJ+7d+9eS4UKFSyJEiWyeHp6WkqVKmU5cOCAdb2vr6++JnXq1HrcUqRIoZ+3YcyYMZZMmTLpZ5g0aVJLnTp1Am0XPiu0/59//rFky5bN4uHhocfn5cuXlm7dulm8vLy0vTge2Gdj3/1/5sa6bdu2WUqUKKGfeapUqbRdtuc8PseBAwdamjZtquc3Ps/gvm7w4MGWli1bWuLEiaP7Pn78+GAf46DO7aCOqX937tyxuLm5WY4fP2597NmzZ5bEiRNbateubfc1tv/ON2/erOePcd737NnTz78zZ/8NG+fSxIkT9d8e2hic7xX/56C9tuN90G5H0I4RI0YEePyHH36wuLu7W06fPh3oa7H9xYsX+3kM5ybOUdt/twsXLrSUKVPGEjNmTP03uXPnzgDns/Gzve+m4HzWOM+aNGnicF+JyHkMbImITOr+/ft6gfnTTz85fJ6Pj48lb968eoG/f/9+vSjHxblt0BbcwBYBES7c//33X8u0adP0/deuXWu9KDcu8m7evKm/w9atW/V1U6dOtZw/f16fj4tjbMeA1yFY+uuvv/Q5COawDbwOgSt+fv78ueX169d6Mbtv3z7LhQsXLDNnztRgY+7cudZtIUBGIIPXnTlzRgM646I4sDYGZ/8XLFigF79nz57V4BVBeK5cufT4BiewRbCC9bbBsPEYtokABBfP3377rT7n5MmTeswQPNjz5MkTS4YMGSwlS5bUAA7bwHEwLsj9BxUbNmywzJgxw3Lq1CnddqtWrTSw8fb21vXz58/X471y5Up9zz179lgmTJig63C8EZzOnj1bP5uDBw9aRo0aZQkMjm/UqFE1MN+xY4cGHgjQWrdurY/hnMA+/vrrrxoQ4nx69eqVfl5GkIHPB4/heQic8BniedgeAskWLVr4CXzQ9mHDhunzjSU4r8NNCgTtOH5DhgzxEygFdYyDOrcdHVN7Fi1apG02zinjMRwT20DLnmvXrum/hQ4dOuhnjGAOAbFt4Orsv2FsA+2qUqWKfvZHjhwJ1vdKUIEtznncUOjcubPe9AhpYGt8B/7yyy/vHdhmzZrVsnz5cj0H69atq+9p3BSwDWzxPYSbMzly5NBjZHw3BeezHjt2rJ8bfkQUuhjYEhGZFC6ccEGGC19HcNGKoOTKlSvWx06cOKGvRdAXksAWF7G2kB1CVsjRRWT58uUDBN8IsJDRsH0dLm79s70ADQyysbbZQ2QDv/vuu0Cfb6+Nwdl//+7evavbOnbsWLACW8BFPjKLtlncIkWKWC/Sg5O9MiCziCwZXmdPUEEFAhO8ftmyZfr7b7/9phlw3DzwD4EmLtqNIDgoRlbr8OHD1sdwsY/z8Pr16wHODxwH2wyekakFBOBt27b18xoEmQhAX7x4ob8jWPCf0Qzu62wzaMi64QYLApDgHOOgzm1Hx9QeBG8IpG0haMMxefDggcPX9unTx5IlSxbdBwMCdgSORqDs7L9hnEu4UWEEusH9XgnqHDRuGCF7jJtRuOmBcwGBc3ACW8DNmS+//PK9A9tJkyYF2A/cIPAf2Aa2X8H5rNGDAeef7Y0LIgo9HGNLRGRS767ZgobxeCgohcWQPXt2HaOGdSGRO3duP7+nSJFCx0Q6cuTIER0fFydOHOuCojcYL/f8+XPr8woWLBisNowZM0bHFSdJkkS3NWHCBLly5YquQ1tu3Lgh5cuXl9B29uxZadSokRbp8vT01AI2YLx3cDRu3Nha7Raf399//62PQcKECaVFixY6vhTFv0aNGqXHKDCovpwvXz59XXCgIBGOO4oOYWwm9gFjWo32ozDRixcvdP/wvMWLF8vbt291XcWKFSVt2rS6rmnTpjrO0/azsydatGh+zheM/8ZY248++sjPubBlyxYdS+3o/EHhMNvX4BhhzC6KigV2/gT3dbZtRHEiFC8yzumgjnFQ57ajY2oPnovCUM7+Oy9WrJjug6F48eL6GV+7ds3u/gb33zDg88e/OWe/V7Zt2+bnOOEcMsbY4t8sxtZWqVJFNm/eLPnz5w92sTgcH9t9dpbtccExgeAcF0NwPmuM1cX5h7HSRBT6ooTBNomI6ANAgIILutOnT7/3tlCoxv8FtFHAyRam3bGF9w+qKBAurAcMGCCfffZZgHW2F/GxY8cOsp1z5syRb7/9Vn777Te9iEdxIRTN2rNnj/XCMaz2H8EmLu4nTpyohY2w3zlz5gxRIR0Exj179pSDBw/qRTAq/6LiqmHKlCnSqVMnLQA2d+5craS6bt06LRzkX0j3tXnz5lqQBwEz9gMVaHEMjfYjQEFhnvXr1+t7dujQQY8tAk8cZ7QZQcfatWvlhx9+0Mqw+/btC7SoF9pnG3DgPMAUPgcOHND/20KgExi8DpWScVz8QyXdwM6f4L7O0Tkd1DEO6tx2dEz9vy8kTpxYHj586Ocx3AgA/DvH5/W+nPk3HNx/n47gxoPtVFio7mx7rHDzBAuKYbVu3Vr69eunN3ocwfmMqsrp06cP9DnYv5B+txnnbUgqGAfns37w4IEeR2e/p4jIMQa2REQmhSwSMlDIYOLi3f+F56NHjzToyJYtmwZQWIzsysmTJ3U9MiyATMzx48f9vB4XofYuvh3B85GVs4XsCy74MDfp+8IUIB9//LFeNBpss30IwJBJxVRHqAwd3DYGtf+4gMY+IKgtWbKkPrZ9+/YQtx/VnUuXLq3ZKgS2uJD3X20VGUIsvXv31kAGGV57gS0yTJMmTdKL5eBkbXHs/vzzT6lWrZr+jvPh3r17fp6DC24E8FhQVTtr1qyaacVnGCVKFK1CiwVBB84tVOO2F9TZg33CcUcWzDiGwYH3xvka0vPH2deF5BgH59x2dEztHSNM34XgNkGCBPpYpUqVNOAdOnSoZgH9s/13jnlSbTOY+MzxbwLnXXDZ+/dhT3C+V/wfh+B+Fnh9cKYcwk0a3JRyNMc1/m3b9nxAz4ugehsEBb0R7B2joD5rfMfgMyaisMGuyEREJoagFhdYhQsX1otaXLShGyCmDDGyOwhEcuXKpV1ekXXbu3evNGvWTAMso/smptTZv3+/TqOBbSBw8R/oBYcRVBoX54DsHraLzNaJEye0fci8IhvpTJYa7VyzZo1ODYLsDrKGtpBJREYXxwD7gn0ePXq0wzYGtf8IMhIlSqTdns+dO6cBHebYdQY+B+z//Pnzrd2QAd1jEczu2rVLLl++rJlRtAUBRGDZX3SbxUU9ApgLFy7oOYDXB3bsZsyYoccfGW68t23mCF0/J0+erPuNbWE6GaxHdhfTzeB4IthH23CckM3KkiVLsPcbmUe8J869RYsW6f7iXBwyZIisWLEi0Nchw71z507p2LGjvj+OyT///KO/O+Ls60JyjIM6tx0dU3sQ9CCItZ3DFTesEFzjGNWsWVMzgpjmC+drjx49pH379vo83OxBkIk5rZHdxb7iPMZ5ajt1UFDs/fuwJzjfK0HBDSP828NxOXr0qJ4T+HeBIL5WrVp+noupctAm7OPWrVulbdu2MmjQIJ3ux1HAjO3/8ccfOqUQjhmOV0hv2Nk7RmgrzivcHELX4uB81uiOjRsVRBRGQnG8LhERhYMbN25oASUUWME0E5j+B1Nw2BbgCWpaDkC1YRRiQZGULl26WDp27BigeBQKKtlCwSVjahVYunSpTgkTJUoUP9U/V69erYVhMJUGihBhmhfbiqH2CrzYKx6FyqmoaovH48ePr0VjevXqFaCQy7hx47SQDgre+J92I7A2BrX/69at06lrUMUX04GgyJNtu4NTPMookIRtoIItqu4a8HmgABLai88RbUObHBWaQYViFM7CMcX2ChYsqEXF7BW4QTVbrEeRnsyZM2sVV9uiPNgPFLLCtnCeFC1a1LJ+/Xpr0SUcCxT5MaZDsa1E7Z//YjsGo6o1Kgcbn82nn35qOXr0aKDFowDFiCpWrKiFkNA2vD+m6QmquJAzr8Mxs60k7OgYB3VuOzqmgenRo4dOL+QfKlN/9tlnliRJkuj5g3MYxbFQqTkk0/048284sCJQ7zvdD/49499v/vz59XzB8cW/2++//14rDdubhgj7liZNGkv9+vUtGzdutAQFxcoqVaqkbcR5j6rF9opH2f679X8e+j+f0W6cE/gOMqpIB/VZo2o1znlMH0VEYUMnIguroJmIiIiIgg9ZyRw5cmgWNLDMLpkPehAgA45eH0QUNtgVmYiIiMhFoOszurSGpNo2uT6Mpf/xxx/DuxlEERoztkRERERERGRqzNgSERERERGRqTGwJSIichGYJxZTtWDKlIgCFXyxT7ZzmNpTpkwZ6dy5s0QGwT0mREQUfAxsiYiIKMxgjlPMI5ozZ84wCd69vb3lu+++0zlDY8SIoWNUMRUNphQKzdFWLVq0cDhfqqvB/mNqGUxTFVgQ/fLlS51vFc+JEyeO1KlTR27fvu3nORjrW716dYkVK5aOE+3evbu8ffvWuh7T6GCaIrwe87dizl8DnlegQAGdCoiIKKwxsCUiIvrAXr9+LZGFh4eHBptRokQJ9W0jOP744491LlnMAYxKwpjjtEGDBjrH6+PHj+VDe/PmjbiCZ8+eSYkSJeSXX34J9DldunSRZcuW6dyxW7ZskRs3bshnn31mXY85shHU4nzFnMDTpk3T+Voxf6+hdevWOlcsjj2O908//WRdh/mkixcvrvNsExGFuTCaRoiIiOiDwDyvv/zyiyVjxow6x2Xq1KktgwYNsq7HHKlly5bV+VsTJkxoadOmjZ/5YzGHJ+by/PXXX3XuTzynQ4cOOueq7byVmF80VapU+h54r0mTJoVo/lDMNYw5RBMlSmQpU6aMPr5ixQqdWxNtw2OYDxN/mjGPJty7d0/nNPXy8tJ5UnPmzGmZPXu2n/3HtjFPb/fu3XWeWczFazsPK2B7mPM0adKkOgdqjhw5LMuWLbOuxzy1JUqU0HZgH7G9p0+f2j3ejx49sri7u+u8qsbxx/tiDk/DjBkzdDv+5wk1frZdjDlUg7Mf/mEeY8wZirlK/cNnbHwGDx48sDRt2lTnHcVxrFKliuXff/+1PteYpxRz0mbNmlW3WblyZZ0jGtAO/+3GHKfG/syZM8dSqlQpPbbYFo7JgAEDdE5pnBOYy3XVqlXW9wvunMehIbD3wueIeVUxn7Hh1KlT+txdu3bp75jzFZ+17dy0Y8eO1blaX716pb/jeOJ18Oeff1qqVaumP58/f17PbW9v7zDfRyIiYMaWiIhMDZm6n3/+Wfr27SsnT56U2bNnS7JkyaxZq8qVK0uCBAlk3759mplav369dOzY0c82Nm3aJOfPn9f/G1kpLIZmzZrJ33//Lb///rucOnVKxo8fr10v4fr161KtWjUpVKiQHDlyRMaOHavTtQwaNMjPe2C70aJFkx07dsi4cePk6tWrmh1D9010E0Xmq1evXgG6iqIr54oVK+T48ePStm1badq0aYCundh27NixZc+ePTJ06FAZOHCgrFu3Ttf5+vpK1apV9X1nzpypxwjHC5lUwH5XqVJFu6EePXpU5s6dK9u3bw9wjAzx4sWTvHnzapdiOHbsmHZ1RZfUp0+f6mPI/pUuXdput+SFCxfqz2fOnNEuyqNGjQrWfviH/ZozZ440btxYvLy8AqzH52NkidGNeP/+/bJ06VLZtWuXdlHGZ2abXX3+/LkMGzZMZsyYoVlfdMH99ttvdR3+X79+fT1OaDMWZIoN+Ny++eYbPTdwvmGfkK3E9nBM8VjNmjXl7NmzElzt27fXfXC0vI8DBw7o/qPbtgHdudOkSaPHCPD/XLlyWf89AfYF3b9PnDihv+fJk0c/I3Q73rBhg+TOndvafnyGcePGfa92EhEFG+N7IiIyK2SDkCWbOHGi3fUTJkzQ7J9t9hFZUtssFDKGadOmtbx9+9b6nHr16lkaNGigP585c0azWOvWrbP7Hn369LFkyZLF4uvra31szJgxljhx4mjmzshG5suXz8/revfubcmePbufx5Dptc3Y2lO9enVLt27drL9j28i22kL2GNuCNWvW6P5iP+xp1aqVZnNtIYOL17x48cLua7p27artgJEjR+qxss1KZsqUSY+9vYwhMp329jGo/fDv9u3bup3hw4dbHEFmFs/bsWOH9TFkwpFpnDdvnv5uZMrPnTvn5zNE1th/Zt+WsW84BraQYR88eHCAfUFPAHvHJLD9O3v2rMMlOAJ7r1mzZmk22T+0E70TAL0bKlWq5Gf9s2fPdHvI5sLx48c1W50mTRpLo0aNLI8fP7ZMnz5dj9W1a9f09ejh8N133wWrvUREzgr9AS9EREQfCDJkr169kvLlywe6HhklZAENGPOHbB8yhkYmKkeOHNYMJqRIkUIzkYBsKtbZy0Aa71GsWDHNWtq+B7KX165d0wwYIPPq/3VFihTx8xi2YwtjHDFmcd68eZoZxlhH7C8K+dgysmS27b9z5461/alSpZKPPvrIbvuRZUZWcdasWdbHkNHEMbp48aJky5YtwGtwLJCVRvuQnUWRIoyjRRYXbTl37pxWOQ4pR/vhX3ALQ+E4I3Nre6xRLClLliy6zoBjmjFjxmC9t38FCxa0/oxsJsaq4hywhd9xrIMLhZqwuDr828E5YLh//77069dPs95ff/21ZrZRyAo9GvAZoIcCEVFYYFdkIiIyrZgxY4bKdqJGjerndwSpCOxC8z1sg+vg+vXXX7Vba8+ePbWbNIJUdAX1X3zqfdqPALxdu3a6bWNBAIZus7aBnq1SpUrJkydPrMWaEMRiQWCLIAddgzNnzhzi/XW0H/4lSZJE4sePL6dPnw7x+wT3vYMbPDvz2YZ3V2TciMB55L86NaoiY53xHP9Vko3fjef417VrV522CTdTcD7Uq1dPjw+KUBnd14mIwgIDWyIiMi0ETwjcMLbPHmQbEaRhrK0BY03d3d01YxccGGOI4Mo2K+X/PYxxm7bvgbGFuLgPDF7nf6zs7t27/fyO7dSqVUuaNGmimecMGTLIv//+KyHNgiJzHNjr8ufPr+NuM2XKFGDBmGB7EFBiu3/88YcGhBibiWAX42yXL18eaHYbjG0i2/s+8Bk2bNhQM83IkNoL2DHuE8cZ/8e4XdusIjL22bNnD/b7od3BabOnp6cG9vjsbOH3kLwfxhfb3mywt7wP9CDAZ2f7bwfHBGOLjZ4D+D96LthmrjGeFvtob1+wLWTBjfHZOF7GOGb8/30/cyIiRxjYEhGRaWHeUmQzMbULpnxBISQEh+gmCygshOc0b95ciy8h64nukSjAZFsQx5F06dLp67/44gtZsmSJds9F5gndg6FDhw5aCArbRfbwn3/+0a6YyFwh+HKUkUNWFPOCIqBA0SvbglVG4I5AAlOtIGBAZtV/Bi0oCDIRdKI4FLaF9q9atUpWr16t63H8sH0EIwiW0CbsQ2DFowzI0CKoNILYhAkTahCJ4lOOAtu0adNqNhQB8N27d60Fp5wxePBgLUiFLq74/BGgo/1//fWXzq2KbeMY4uZAmzZttCgWbnTgRkHKlCn18eDCeYAu2/is7t2753BaH3ymmGYHxwLPR3EpHFsUmAoudEO2d7PBdnEE88niPXFMAO3A77du3bIWAWvVqpWep/h3gWJSLVu21GC2aNGi+hx0MUcAi38vOG5r1qyR77//Xue+jR49eoBCZzhnJkyYYD3v0f16zJgx+loUDfPfPZuIKFQ5PTqXiIjIBaBAE6b3QQEoTF+CIjY//fRTiKf7sYVpeVDMyIAiSl26dLGkSJFCC+6gONJff/0Voul+sE3/MOUOtoUCWCVLltRt2hZWun//vrYNhagwVc/3339vadasmZ/22ts21hvT6BjbadmypU41hOOAaYOWL19uXb93715LxYoV9X0w1U3u3LkDFD/yb/HixdpWTP9ie9zw2OnTpx0WLxo4cKAeJzc3Nz/T/QS1H/Zg2ppevXrp1DI4/ij4VKFCBW2fUdDLmO4HU/qgaBSm8rE33Y+9/TPcuXPHeoz8T/fjvzATzsn+/fvrdD84J8Njuh+jIJb/xXYKJZzXKGiFAmuxYsWyfPrpp5abN2/62c6lS5csVatW1eOWOHFiLVxme24b8BnYFjUDFLjCvwtMD4SpmYxiakREYcEN/wndUJmIiIiIiIjow2FXZCIiIiIiIjI1BrZERERERERkagxsiYiIiIiIyNQY2BIREREREZGpMbAlIiIiIiIiU2NgS0RERERERKYWJbwbQESuwdfXV27cuCFx48YVNze38G4OERERUbjCrKhPnjwRLy8vcXdnPtDVMbAlIoWgNnXq1OHdDCIiIiKXcvXqVUmVKlV4N4OCwMCWiBQytdBYUko0jlIgJ9U/vCW8m0ARQPK40cK7CRQBJN8xJbybQCb35MVL+ajdYOs1Erk2BrZEpIzuxwhqGdiSs2Lzjz+Fgrhxo4d3EygC8IwVI7ybQBEEh2iZA69eiYiIiIiIyNQY2BIREREREZGpMbAlIiIiIiIiU2NgS0RERERERKbGwJaIiIiIiIhMjYEtERERERERmRoDWyIiIiIiIjI1BrZERERERERkagxsiYiIiIiIyNQY2BIREREREZGpMbAlIiIiIiIiU2NgS0RERERERKbGwJaIiIiIiIhMjYEtERERERERmRoDWyIiIiIiIjI1BrZERERERERkagxsiYiIiIiIyNQY2BIREREREZGpMbAlIiIiIiIiU2NgS0RERERERKbGwJaIiIiIiIhMjYEtERERERERmRoDWyIiIiIiIjK1KOHdACIiV/NKfGW53BaLWMRXRHJJXMkmca3r34ivrJO78kTeipu4SXaJIznFM1zbTK7p1auXMrBze7lw5qQkTe4lA/6YLPETJvLznL8n/CHrli549/yXL+Xhvbuy8vD5cGoxuSKcF13at5Izp05Icq+UMnrSdEmYyO95ZNi4dpW0bdJAVm7ZLR9ly/7B20quqeHQqbLtxAUpkyuTzPq2WYD1XSYuksW7j0mqRPFl+9BvwqWNRO8rUmZsEydOLJcuXQrw+ObNmyVmzJiSN29eyZ07t5QoUUKOHj0aqu+NbT958iRUtxkZpUuXTg4fPhzgcXyu48aNE1eAtpQpU0bixYunn3tw18HkyZMlc+bMkjFjRmnTpo28efMm0OOQJUsWmTRpUrC2S8ETVdykpiSTuuIln0pyOSSP5aX4+HlOXoknDSSlrj8hT+Sx2P+MKHJbPnemeKVOK39v3Culqnwis8b9HuA5jdp2lL+Wb9alUZuvpETFquHSVnJdc2dNk9Rp08mGPYel8ic1ZfzvwwMNgKeM/1Py5C/wwdtIrq1DtZIy8euGga6vXzKfLO7T6oO2iSi0RcrA1hEECQiYENB+9tln0rJlyxC9/u3btw7XY9tx4/6X+SH7fHz8BhHB5UqBraenpwwaNEhmz54donUXL16Uvn37yrZt2+TcuXNy+/ZtmTBhQqDvM3fuXGndunWQ26Xgcxc3ifr/r0cfzduKLgas85IY1p/jSVR57i/wJYIdG9ZI5U/r6c+VateTnRvXOHz+xpVLpVz12h+odWQWG1avlNr13gUltes20KysPRP+GCmft2gl0WPE/MAtJFdXKmdGiRMjeqDri2VNLwnjxvqgbSIK18DWzc1NHj16ZDfziczRDz/8IMWKFZP06dPrxbUBGaRvv/1WSpYsqRmo9u3bW9fhArxIkSKSL18+yZMnjyxbtszP67p16yalSpWSNGnS6MX+ypUrNZOK9xs+/L87lmfPnpXq1atLoUKFNNv6xx9/WNctXbpUsmXLpo/36NEj2PtbpUoVOXPmjAarlStXloIFC0qOHDnk888/l2fPnlmzvHisVatWmiH7+++/JWnSpPL69Wvrdlq0aCGjRo0KcAyxD99//718/PHHkjp1ag3IpkyZoscQ6+bMmWPdxpo1ayR//vy6D6VLl5aTJ09a3z9nzpzSoUMHPX5oy/79+3Wdo3bjeBUvXlxfkytXLm2Hfy9evJAGDRpI9uzZ9XmVKlXy857NmjXT/xcoUMBu9tSeGTNm6D5gwed1/fp1fXzq1KlStmxZqVOnjrZn7969+vni88Rxxf937doV5PZxbuEzw2tq1qypj+HcM7aDcwnrAf9PlSqVXLhwQX8fNmyYfua+vr4aUFaoUEHbidctWbLE+h74DH/66ScpXLiwnuv4zOxJmDChnquxY8cO0boFCxZo25MnT67vhX3CeRUcjrbr36tXr8Tb29vPQn67I8+XGzJLrkseiScxxcPu857KW3kgryWxRPvgbSTXd//2LUmcLIX+HNcznjx18O/s0YP7cv7UCSlYvPQHbCGZwZ3btyRZCi/92TNefPF+/DjAc65duSyHD+yTqjV4Y4SIIqdQzdgiYEPwsW/fPvn111+tQQucP39eNm3aJMePH9cgzQhSEHjt3r1bDh06JP/88492u8QFt+Hy5cv6uiNHjsjvv/+ugS0yWTt27NBAGu+J7F6jRo3kt99+0/fG9pDhws937tzRrOvChQs1C5spUya5f/9+sPYHgSWCNg8PDw3AETCi/ejmOXr0aOvzTp06pUEegrumTZtqIIRgGp4+fao/N2nSxO57INDcuXOn7mOXLl30mOHYzJ8/X77++mt9DvYBQem0adN0H9q2bSt169YVi+VdDun06dPSvHlzPUZ4zXfffaePO2o3Av9PPvlEX3Ps2DHp2rVrgLatXr1ajy+CaDzPNtA+ceKEvie227NnT2nYsKG1PYHBc7t37y6rVq3S/UBAb2QaYc+ePRowoj0I7nEs8RniuKLdwcme4+aAkXU3PgO0z9gObgB88827sSN4Hs7T+vXra7A+ZswYDbzd3d2lcePGUq9ePW0nPgvcuMC5aIgePboG39iXTp06BZmpD4krV65I2rRprb/jJgceC21DhgzRc8JYcHOF/hNd3KWeeEkjSSnn5JndjCyyuevlnhSVBNYML5Gztq5ZIcXLV5YoUaOGd1PIhIb0/166fz8gvJtBRBRuQvVKDMGXkcnNkCGDdqk0IPMXJUoU6xhWBLqA51StWlUzf7Vr15YHDx74eR0COARoCRIk0G0iGEMWK2XKlJIkSRLNGCPzhkALwRW2jYAJ41gRkCHIRdYNWUdAgBItWuCZFSPbhwUBI4JJBGwjRozQrDK2tWLFCj8ZSrQLWVQDAjAji4egqFy5cpIokCIPOC6AgDtGjBi6v4AsK44FAksEfMhiYgEEXTdu3LDeOMBrkfUGBITGsXXUbmQuJ06cqEHw2rVrJX78+AHahiwtgnYEg+juGtXmYgvBVvny5fVnBIa3bt2Sq1eviiMI3pERxWcH2O7GjRut3Y7xuSHYNOBmB44rzg0jE4ssckitW7dOjwu2M3DgQD+fHW6IIBOOGywIanFO4dw5ePCgniuAsa7IguKGigGfAWTNmlXPa+y/2fTu3VseP35sXYL6/CKrWOIhiSSq3JKXfh5HB+WNck/SSAzJIEFnyCnyWDRjsnzxSRldEiVNJvdu39THn3g/ljiegRcZ27hiiZT7hNk2emfG5AlSo2xxXZImTS63b97Qx70fPxLPePECPP/k0SPSrllDKV0gp2ZuWzb4VM6eOR0OLSciMkFVZASYtmMfX770e6GHwMz2ubZZrMDWIRj9+eefrQEdulLabtf/6+xtBwEXXmevO6yRtTMgKHbEyPbZmjlzpgZgW7Zs0TGMyBzjd0OcOHH8PP/TTz/VLN7Nmze1i62j7s+B7R/aiSU4mcDAji2ytYG1G11+EUgi6EP2duTIkZoNt4WAHTcH8Jr169frfgTW5dhob0j4f77tcURXboxxRjCMbsToJousIrL5uDkSXMh0duzYUTO26AaPDCyCegOOFTLJOH9sexgE1VZH5/r7Qrd74+YE4OYNHgttyDpjoYCQnY0ibhJN3LVL8k15JdltqiLDXnmkz8kvAW8KUeT2WdNWusCCqRNkzeL5kilbTlm7ZL4UK/duSId/qIR8+fy/kq9oiQ/cWnJVTVu11QWmTRwrS+bPkWw5c8mSBXOlbMUqAZ6/af9/xS4/r11N+g8ZJpmzZP2gbSYiMk3GFplBZA9h0aJF1vGa7+Phw4c6TtEIIPF7SCEYReBmO9YRYySR8USmDsEMsq/w119/+Rn/Gtw2IguN90A2D8GqIwh60I21f//+GqAgS/k+ihYtqt1zEYABugQj62lkPp1pN8bYJkuWTLtQDx06VDPb/l27dk0DOoz3xPhTZICNrB6CLQSdxphQbAvjVR3BGFp0b0a22eg2jKwvAkP/cHMDn5MR0Nl2/XYE+4rsowE/48ZHihQptP22Y6+hV69eev4gG4uxuDhvUNwLWVzjfMJj27dv9xMQhyXcdMANGWSB0WYcJ9wAog8H42aXyi0dY4v/55S4kkiiyUq5Lc/kra4/LN5yV17LArmhy1UJeW8CivhqNGwq1y9flEZlC8nmVUulSbtO+vj29atl8oifrc/bsma5lKhQ1e73IVGDJi3k8sULUq5wHlm1dIm06/Ru+ND61Stl5M//1TQhCkz1AeOl6fAZsubgacncdpDsOXNJPh08WW4+eHfN1PaPOVK2zx9y/MpNXb9o55HwbjJR2GZs0a0VmUgUGkLhn8C614YEiiohW4uusOiy60xmCl1Bly9fLp07d9Y2IquMgA4ZSwR/CGaRRUUXZASZIW03gj+M/0UAhK6qKIJlO97SHnRHRnEhjO983wsVvOesWbO0HcgMols2ujgHlSF11G4Eo7iRgGOCYkn2KgkjmEZ3VQRXeF+MeUWXZqNgFgJlnA/YBoobGe1BN25kf7283hW6MKArMMa0GoE+xnSiO7Q9RnVfHEN8lsEN7NA+tA3vhYwzAkS8Fo/hc0d3dwPOGQTaGCsbK1YsLVaFbtUY84zjje7PCISxX5hOJ6Tn5vPnz+Wjjz7SLDMCbAT+OIYY2+poHdo9YMAALe5lFFFr167de78nBV9Sia5T/fhXTZJZf24n/42DJgoMqtP+NH56gMdLVKiii6F245BV4KfIJUbMmDJuesAighWqVNPFv9lL/PbAIlrRL+B1xOLv/pveZ0JH3kAn83OzBFXxh8gfBLa4iRDcSsgUdjDWGRWbQ2POWqO7d0tJrV1wiZzR+Py7quxE78MrLodJ0PtLsXV8eDeBTM77+UtJ0ayvJguQdCHXxqtXIhNDJh4Vt5FRJiIiIiKKrELUFZnI6BrLbK1rQFEsIiIiIqLIjhlbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREphYlvBtAREQRR6EUscO7CRQBXHj8OrybQBHA2Tnrw7sJZHJP37wN7yZQCDBjS0RERERERKbGwJaIiIiIiIhMjYEtERERERERmRoDWyIiIiIiIjI1BrZERERERERkagxsiYiIiIiIyNQY2BIREREREZGpMbAlIiIiIiKKxMaOHSu5c+cWT09PXYoVKyarVq0SM2FgS0REREREFImlSpVKfv75Zzlw4IDs379fypUrJ7Vq1ZITJ06IWUQJ7wYQERERERFR+KlRo4af3wcPHqxZ3N27d0uOHDnC5D3fvHkjt27dkufPn0uSJEkkYcKE77U9BrZEREREREQm8fLlS3n9+nWQz7NYLOLm5ubnsejRo+viiI+Pj8yfP1+ePXumXZJD05MnT2TmzJkyZ84c2bt3r+6H0U5kjStVqiRt27aVQoUKhXjbDGyJiIiIiIhMEtQmihlHnotPkM+NEyeOPH361M9j/fr1k/79+9t9/rFjxzSQxXvgtYsXL5bs2bOHWtuHDx+umeCMGTNqhrhPnz7i5eUlMWPGlAcPHsjx48dl27ZtGtwWKVJERo8eLZkzZw729hnYEhERERERmQAynAhqm0lKieagXNJr8ZXpT6/L1atXtRiUwVG2NkuWLHL48GF5/PixLFiwQJo3by5btmwJteB23759snXr1kC7NhcuXFi++OILGTdunEyZMkWDXAa2REREREREEVRMNw+J5hZ4YOthcROxiLXKcXBEixZNMmXKpD8XKFBAA9FRo0bJ+PHjQ6XNf//9d7Ceh+C7ffv2Id4+qyITERERERGZSFR3N4nmYInq7ndsrTN8fX3l1atXEpbOnTsna9askRcvXujvGG/rLGZsiYiIiIiITMTD7d0S6HoJmd69e0vVqlUlTZo0WuBp9uzZsnnzZg06w8L9+/elQYMGsnHjRi0cdfbsWcmQIYO0atVKEiRIIL/99luIt8mMLRERERERkYl4uLkFuYTEnTt3pFmzZjrOtnz58toNGUFtxYoVJSx06dJFokSJIleuXJFYsWJZH0ewu3r1aqe2yYwtERERERFRJM7YTp48WT6ktWvXauCMKX5soVjU5cuXndomA1siIiIiIiITCSor6yHvP8Y2LGGOXNtMrQHT/gQ1z25g2BWZiIiIiIjIRNz+H8gFtriJaytZsqRMnz7d+jvG2aJY1dChQ6Vs2bJObZMZWyIiIiIiIhPR6scOMra+mO7HhSGAxVje/fv369y8PXr0kBMnTmjGdseOHU5tkxlbIiIiIiIi042xdVQ8Slxazpw55d9//5USJUpIrVq1tGvyZ599JocOHZKMGTM6tU1mbImIiIiIiCJx8agP6c2bN1KlShUZN26cfPfdd6G2XQa2REREREREJmLm4lFRo0aVo0ePhvp22RWZiIiIiIjIRNz/n7ENbHF33bhWNWnSJNSnGGLGlojIn1fiK8vltljEIr4ikkviSjaJ6+c5/8gteS2+uj6TxJICEj/c2kuua+XKldKrd2+t9Nita1dp2bKln/X79u2Tdu3by6tXr6Tx559Lnz59wq2t5LpevXwpPTq0ln9Pn5RkKbxkxIRpkiBRIj/P2btzm3Rq2Vi8UqfR32vVayTN230VTi0mV9Nl5yHZf/eBFEmaSIYVyxtg/YorN+Sv0xfFYrFIzXQppUWW9OHSTgq94lE+Ll486u3bt/LXX3/J+vXrpUCBAhI7dmw/64cPHx65M7bp0qWTLFmySN68eSV79uwyZsyY99re1KlT5fTp0++1jZEjR8qtW7cktF26dEn7pUcGYXUMHenfv7+8fPnS+vsPP/wgs2bNCvbrN2/eLDFjxtRz8c6dO/oY/vHmypVLokSJovtkq0WLFpIyZUp9Ppbu3btb12HsAV5nrJszZ4513fPnz6VRo0aSKVMm+eijj2TBggXWddhGmjRppHbt2k4fh8gqqrhJTUkmdcVLPpXkckgey0vx8fOcqpJU6omX1JMUckVeyD15HW7tJdf9o92zVy9ZtXKl7N61S0aMHCn379/385zOXbrItKlT5eiRI7J6zRo5fvx4uLWXXNeC2dMlVdp0smrnQalYvaZM+mOE3ecVLVlGFq3frguDWrL1eaa0MqhQLrvrHr56LX+eOCdTyhSW+ZWKy747D+TSk2cfvI0UMo6ytR5BjL91Bfh7lz9/fokbN64WkULRKNvFGREuYzt37ly9+L98+bLkzp1b50jC/50NbOPHjy9Zs2Z1uj0IYMqUKSPJkycPsA538MHd3d3pwLZ9+/YS0Tk6hmFlwIAB0rlzZ4kRI4b+PnDgwBBvAzdZDh8+bP0dd6PmzZsnQ4YMsft8BKJ4T3uPDx48WH++fv26ZMuWTSpUqCCJEyeWYcOG6STW586dk4sXL0qRIkV07q9EiRLJr7/+Kjly5JAlS5aEuO2Rnbu46QI+mrcVXWxF+/99Qd//Z3WJ/Nu3f7/+e8VNK6hUqZKs37BBGtSvr7/fuHFDfN6+1RtXUK9ePVm1apVWiiSytXnNKun2w7u/QzXq1JdG1StI936DwrtZZCKFkibUgNWea8+eS/q4scUzWlT9PX+SBLLx+m35ImuGD9xKiixjbGHTpk0S2iJUxtZW2rRpNbDAHYAnT55ImzZtpHDhwhrktm3bVudLAgRMX3/9tRQqVEizXt26ddNuGJMmTdJ5lbp06aKBMrqT+fj4aJCBiw4seJ2xHTwfWWI8Fxcpe/bs0WAIFy4NGjTQxxHkIBNYp04dqVy5sm7j5s2bsmbNGi11jcAHbTQ+aGT98JxmzZrp/7HeCJQQ0J45c0a3W7NmTX0M7f344491H7Ed2zmgVqxYofuYJ08efQ3aB3hv3C3Ba0qXLi0nT560vmbKlCn6XLymYMGCGkw72hYmVn706JH19Qi88BoE8B07dtQLPLwG+2GbDTUE9xg+ffpUvvjiC+vngCDUgM8Tn2GpUqU0W9m3b1/97HB8kdG37dbw7bff6n5gu3g+jqdxbAE3RYyMKzKqRpZ12bJlerywDu//zz//BOucxL7jGIT0RgZurhiw7zg/jZsiuJFjtDd9+vS6/4sXLw7WdtH10dvb289Cfrsjz5cbMkuuSx6JJzHt1BdcIrdkulyTlBJDEku0cGknuS58v3t5eVl/x8/4PnO0/rrNeiLDndu3JFnyd+eKZ7z48uTxY7vP27dzu3xavrh81byhXL544QO3kswqTZxYct77qdx+8VJe+fjIjlv35M6LV+HdLAoCrkocZmzFteFaHjGaf5j2B+ucEeEytoZjx45pN2IEEwh0EKRMnDhRgwIEuaNGjbJ290Qwt3PnTi09jQDn77//ltatW8vMmTM1g2Z05Rw7dqyOhzpw4IB4eHhoQDlixAjp2bOnvgfeL0WKFLodBA3InqH7qZFFBmTPdu3apSn2ZMmSyYULFzTYRYDp6empmTe01QgiMVEx2jp9+nTN9jVs2FBOnTql2Vq0zQh0EWBj7ifsI4Lm7du3awCN7eFCCuO6tm7dqtlntA9dWBGwff755xpAI5BEV9u6devqe27ZskWDShwX7BOeD7hRYG9bjhw5ckQ2bNig20VQ9/jxY4kWLWAQENxjiOONdaim9uLFCw1a0RYEv4BsPW4OIFBDMPvw4UPZtm2bHgfc7MA/FgSL2A4ynoDuvd98842sXr1aj+348eP1NbZBpeH777/X9cWKFdMAM7QCQnzO2FcE5IMGDbLuL/z+++/atf7atWt6AyBp0qT6+JUrV/QmjgH7i8eCA5lj25sC5Fd0cdeuxs/FR9bKXckgsSSWvz8TtSW5jrNdJ3flgbyWhAxuiSicZM+VR9buOyqxY8eR9SuXSfcvW8m81aGfEaGIJ160aNI9T1YdhxvN3V0+ih/X5QsPEYpDOc7YujtY5wqmTZsmP//8s3ZFtoVre8Q9uCaWyJ6xNTJ77dq10wOSOXNmDSbRLROP58uXTwMWBHwGZERRdjpWrFhaoQuDmO3B48jcoesnxkkiQF63bp2uK1++vDRt2lSDE3QJjRMnTqBtrFatmga1gEAKbUFAjfYhsETwZwQnCFSwbahfv76ONb169WqAbSLbiNchqAUEe3gPBL5oI+aKMrpUY1/jxYunGVEEtEY3uMaNG2vwh+6uyMpifxBkAo4NlsC25UiGDBl0rBkCSpzECFrtZS2DewzxOeDYYxsYaI7Pz/gcAMcQNx4SJEig7/3JJ59oNhndAZMkSWK9aYDXIDhF1hVBvG23YUfQTgTBQ4cO1eDaXvAbUuhqfP78ed1eq1atpGrVqpqdNXTq1Ek/Y9xo+OmnnwKM03NG79699SaDsdg7r0g0mE0kUeWWBOxlYHRJRsb2qrz44G0j14bvT9sMLX42vlMDW+9ls54it9lTJspnFUrokiRZMrl969254v34kcS183c3TlxPDWqhQrUacuv6Ne1pRhQc5VImk9nli8nUskUkSYzokiaO30I+5HrMOsbW29tbrzuRbETG1rbnIJJR6GlpJHAksge2yOwhQEEAgAAHcOAWLlyoj2NBgICMW2AQBAWH7fOwfdx1QNCGwNW2wI9/tgEb2laxYkVr27AgsERAHth7OtO+DwHBpO0fUaO7MQJfDBBHdhgZWXTjtb2x4MwxdLSfxrhYo03+f0eQjRsH6B6NrDzahvey1z3aHnRnRjdtBPrNmzfXAPd9Ieg2gv1PP/1Us/dG12hb6IGA5yLLDsjuIkNtQNCOx4IDN2jwPrYLvYMsLTKxRpfkm/JK4sm7sUfGYy/+X0wKY3CvykuJb7OeCAoVLKg9gvCdjhtVa9eulYoVKvjpeozvJPQwwnfn/Pnz9buPCD5v2cZaCKpMxSqybMFcfXzZwnlSusK7m9i27t19V6gQDuzZJQkSJdbziyg4Hrx81/X43stXsubqLama5sPVNaH3qIocxOKKkBBKmDChXr+j8CkSUcaCYYxIhH31lXPF7yJcYGsPuhL/8ssvGtAA7gbYBlYIbhBMIfU9e/ZsLcwDuNDHHQUDHkdqHN1+sS10CUUxEPyMbBvGoWLcJgLqvXv32t2Gf8iwIgNpO0mx8VojUDHG3KLiLbKwqVKlCrBddLFFt1gjc4nAHtldZIHxHujqbFR4xr7itUWLFtULKqMKJ4I7BE1YatSooccFY8AA3Y2xBLYtwBhlY7ztokWLtI883L17V3/GsUK2EVlo27G8EJJjiM8B817hpgC2O2PGDN12SGB7yDYjY4Lt/PHHH37Wo1tEYJ8b9h1FmRAYf/nll7J79255X+hibMD2kJHF8QTbY4VjhG7sGItsFJsxqmMjy42Al1WQ399TeStL5ZaOscX/c0pcSSTRZKXclmfyVoPelXJH1y+Um+Il0SWtxArvZpOLQc+en4cMkSpVq0qRokXlm06dtLAb/o0amdrhI0ZI8xYtJFfu3FKpYkUWjiK76jZuLlcuXpAqxfLJ2mVLpHXHLvr4xjUrZfTQd8UF1yxdLDVLF9UM74jBA+Tn0ZFj5gQKnnZb90mP3Ydl+627UmnFZjly/5F8tf2A3Hnx7qb+T4dOyWdrtkv7rfula+4s2j2ZzFE8ytHiihDXYIgirr8R22zcuNG6YCglkk+YEcQZEXaMrS2Mg+3Vq5cGeciK4WIDWTYjcEBBn+LFi8uDBw+kVq1aOo4VUGQK4z7xegRk+B2BBYotAQr1YJwr7rTj7gJej22juysyekYXUnSbRXYPVZb9QxsQTKPrNAJHBM3oLo3HAAEUXoftYFwqxv/iDgeynliHiyB0t126dKkGk3ge2owsJU4WZIfxHmgPulkjEMUdXARDKDCFcbXoyovAEndKkDHA9tE1ul+/fhrI4ne8N7bnaFs4Tnh/jEGtXr26XsABurjiGOD5OFY41uhqayskxxAFofCYbSVRdNMOCbwWnzOOoXGhaQvHEJl0vCeyLLYwzySyqTgmWI+x18GBtuPY4MYKusdjfC8KUeHzRhf327dv6/HENEH4HIwu3j169NCgFYE4jg2CcJyzgHHiOG4ZM2bU12Id7nbR+0kq0XWqH/+qybshBFBH2GWUgoahEFhs2VYqL1K4sBw8cCAcWkZmEiNmTBk99d11ga1ylavpAo1btdOFyJ7xpQoFeGxMiQLWn+3NbUuuDWNo3U04xrZ06dL6f1zbpk6d2qnZYQLjZkG4HIkZwakrZrmQfbMtEEXm4SqfHYJpXEQHZ8ofjG1AMN1SUlunsiEKqZHPT4V3EygCuPCY80LT+3vz9buikkTOevrmrZT4Z4P24nOVIVvG9do8r+wSyz3w4QbPfX2k/o2TLtV2/zCbCnpooqCtMeOHAYm3kIoUGVuiDw3ZXHQnRi8BZHydHQT/PpDNRSYfU0ARERERUcTh7uEm7u7my9ga0GsRhWtRgwKBt23NHPzsTGAb6TO2RPQOM7YUGpixpdDAjC2FBmZsKSJnbBdmyC2xHRSIe+bjI3UuHHWptttC4SgUTMRwTwztCw3M2BIREREREZktY+tgTh93ce2MLWYMQM2c0ApqgWkZIiIiIiIiE3Fzdw9ycWUoULt///5Q3SYztkRERERERCZi9oxt9erVtR4MprXEbCWY/cNWzZo1Q7xNBrZEREREREQm4ubhpkug68W1A1tM5QkDBw4MsA7FozAVaEgxsCUiIiIiIjJdYBt4d2M38Tt9jqvxP71PaGBgS0REREREZCIeUdx1CXS9m2uPsbX18uVLiREjxntvxzx7TEREREREROLu4R7k4srQ1fjHH3+UlClTSpw4ceTChQv6eN++fWXy5MlObdO195iIiIiIiIjsjrF1tITEkCFDpFChQhI3blxJmjSp1K5dW86cOSNhZfDgwTJ16lQZOnSoRIsWzfp4zpw5ZdKkSU5tk4EtERERERFRJA5st2zZIl999ZXs3r1b1q1bJ2/evJFKlSrJs2fPwqT906dPlwkTJkjjxo3Fw8PD+niePHnk9OnTTm2TY2yJiIiIiIhMJKjuxu6Wd+u8vb39PB49enRd/Fu9erWf35FNReb2wIEDUqpUKQlt169fl0yZMtktKoWg2hnM2BIREREREZlJUNlaj3cZ29SpU0u8ePGsC7ocB8fjx4/1/wkTJgyT5mfPnl22bdsW4PEFCxZIvnz5nNomM7ZEREREREQm4hHFQzyiegS+Xiz6/6tXr4qnp6f1cXvZWntZ086dO0vx4sV1zGtY+OGHH6R58+aaucX7LVq0SMf0oovy8uXLndomA1siIiIiIiITcfdw0yXQ9b7v1iGotQ1sgwNjbY8fPy7bt2+XsFKrVi1ZtmyZDBw4UGLHjq2Bbv78+fWxihUrOrVNBrZEREREREQmElSBKLf/B7Yh1bFjR82Ybt26VVKlSiVhqWTJklqoKrQwsCUiIiIiIjIRNw93XQJd7xuyUkoWi0W+/vprWbx4sWzevFnSp08vYWnfvn3aBblIkSJ+Ht+zZ49WSS5YsGCIt8niUURERERERCbi7vFfd2T7i4S4+/HMmTNl9uzZOpftrVu3dHnx4kWYtB/vh/G//mHMLdY5gxlbIiIiIiKiiFQ8yuIbou2NHTtW/1+mTBk/j0+ZMkVatGghoe3kyZM6ptY/VETGOmcwsCUiIiIiIopIY2w93ELcFflDQnXm27dvS4YMGfw8fvPmTYkSxbkQlV2RiYiIiIiITDjG1tHiyipVqiS9e/e2zpcLjx49kj59+rAqMhERERERUWTg5u6ui6P1rmzYsGFSqlQpSZs2rXY/hsOHD0uyZMlkxowZTm2TgS0REREREZGJuHu46+JovStLmTKlHD16VGbNmiVHjhyRmDFjSsuWLaVRo0YSNWpUp7bJwJaIiIiIiMhMgupu7OHagS3Ejh1b2rZtG2rbY2BLRERERERkIu5Rooh71MBDOXffD1sMyhUwsCUiP0psWyux4sQN72aQSfmuHhfeTaCIoNgX4d0CigCijp4b3k0gk4v6xFvknzTiit4ViAp8uh83Dx+JbBjYEhERERERmUhQlY/dTNAVObQxsCUiIiIiIjIRd3d3XRytj2wY2BIREREREZkIM7YBMbAlIiIiIiKKSMWjfHzF1SRIkEDc3NyC9dwHDx6EePsMbImIiIiIiEzEjBnbkSNHhun2GdgSERERERGZiBkD2+bNm4fp9hnYEhERERERmYi7h7sujta7Oh8fH1myZImcOnVKf8+RI4fUrFlTPBxMY+QIA1siIiIiIiITcXN3EzcHlY/d3IM3ljW8nDt3TqpVqybXr1+XLFmy6GNDhgyR1KlTy4oVKyRjxowh3qbrh/JEREREREQUoCuyo8WVderUSYPXq1evysGDB3W5cuWKpE+fXtc5gxlbIiIiIiKiiFQV+a2PuLItW7bI7t27JWHChNbHEiVKJD///LMUL17cqW0ysCUiIiIiIjIRNw8PcXcwFtXNyXGqH0r06NHlyZMnAR5/+vSpRIsWzaltunaOmoiIiIiIiCJUV+RPPvlE2rZtK3v27BGLxaILMrjt27fXAlLOcO09JiIiIiIioggV2P7+++86xrZYsWISI0YMXdAFOVOmTDJq1CintsmuyERERERERCaCisiOqyK7i6tCdtbb21vmzJmjVZGN6X6yZcumga2zGNgSERERERGZSFBZWTcP1w5sEcCeOHFCMmfO/F7BrC3X3WMiIiIiIiIKwD2Kh1ZFDnSJ4rrFo9zd3TWgvX//fuhuN1S3RkRERERERGHKzd0jyMWVYVqf7t27y/Hjx0Ntm+yKTEREREREZCYIXB0Fr+6uHdg2a9ZMnj9/Lnny5NHpfWLGjOln/YMHD0K8TQa2REREREREZoLiUI4KRLm7dsfcESNGiJubW6huk4EtERERERGRibh5eOjiaH1Ibd26VX799Vc5cOCA3Lx5UxYvXiy1a9eWsNCiRYtQ36Zrh/JERERERETkV5SoIlGiOViihniTz549067BY8aMkbDm4eEhd+7cCfA4CkphnTOYsSUiIiIiIoqA89h6e3v7eTx69Oi62FO1alVdPtSUP/a8evVKx9w6g4EtERERERGRmbgFUTzK7d261KlT+3m4X79+0r9/fwkvv//+u/4f42snTZokceLEsa7z8fHR7tBZs2Z1atsMbImIiIiIiCJgVeSrV6+Kp6en9eHAsrUfsmiUkbEdN26cn27HyNSmS5dOH3cGA1siIjsObl0vf/8+RK5f+Fd+mbdOUmcKePcQX8qTB/eW43u3Saw48eSbX/6UZKnThUt7yfU0/Pkv2XbivJTJlVlm9QhYJKPLhIWyeNcRSZU4vmz/tWu4tJHM4dXLl9KjQ2v59/RJSZbCS0ZMmCYJEiXy85y9O7dJp5aNxSt1Gv29Vr1G0rzdV+HUYnI1PIcib1dkT09PP4FteLt48aL+v2zZsrJo0SJJkCBBxCwehQg9S5YskjdvXsmePXuoD1xeunSpdOnSJdS2sXnzZm1raLl06ZLTdyj8ty2snD9/XvLnzy/58uWTKVOmhNn7LF++XMqUKSMfEj7LJ0+eOHwO2rRkyRK763744QeZNWuW/ozPEVXlHJ3n6H4Bvr6+0rVrVz3nc+fOrf/Qz507p+uOHTsmpUqV0i4ZOXPmlC+++EJevHhh3Ra6ceTKlUvbjmXbtm36OJ6D39G9I7D2kmMp0maQzr+Ol6z5iwT6nEPbNsiTRw9k5NIdUrd9V5k96qcP2kZybR0+KSUTO30e6Pr6JfPL4u/bfNA2kTktmD1dUqVNJ6t2HpSK1WvKpD/eZTz8K1qyjCxav10XBiRki+dQBM7YOlpc2KZNm0I1qHXJjO3cuXP1gvzy5ct6kV+yZEn9vwFBALg7MTdTzZo1dXkfobGNoALb9u3bh/i1b9++DdO2GRYsWCCFChWS8ePH221DlCgud0oFu32HDx9+r+0PHDjQ+nNQn6Fxnhs3JHbs2CFHjhyRqFGjyqBBg6RPnz4yb948iREjhvzxxx/6bwDjDj7//HP55Zdf/IyNQDAbP358P9vHJNfYnw99cyCiBbZBObBlrZSsXkd/zleyvEz8sadmcUN7XjYyp1I5M8nW4+9uUtlTLFt6uXwn5BPQU+Szec0q6fbDu78xNerUl0bVK0j3foPCu1lkIjyHIh63qFHFLWrgRZbcor4VV4br2qlTp8qGDRu0OrIR4xk2btxo7oytrbRp02pW699//9WL+Dp16kjlypU1a4V5lWbMmKEX+1iqV68u169f19fhAJUrV04DPGTAkO1CwGiss52LCRm1HDlyaMarcePG8vjxY30c79egQQOpUaOGbgPbe/Dggd1tIFhq1qyZtqtAgQLW4OjWrVuaecNjeI+OHTv6+cAQnOB9UVK7aNGi8vz5cw2Gzpw5owGPEaCePXtW9w/BJPYVQY4BF88YAI51vXv39tM2/9nk48ePa6YQcDwQCPXt21ezr5kzZ9bACtlevAb7guf7N336dO0Xj24DeN7Jkyc1cOrUqZMUK1ZMKlWqpM8bNmyYFC5cWLddpUoVvUlhHNfOnTtbt4d9MeawevPmjXTo0EHbgtfiLo4tfN5FihTRbeIzRRBofB4VKlSQRo0a6fEsWLCgXLhwwXoMcOxbtWql7cVcXEEdz0ePHunPp06d0vPNOMdsM+nbt2/XGy4ZM2b0E8BiX0aOHGl3Xx3B+6IC3MuXLzUoQvW6VKlS6TocD+PGDsYgoN3G+fy+8J54L9uFQubh3duSIGly6+cY2zOePHn0MLybRUQRzJ3btyRZci/92TNefHny/+sV//bt3C6fli8uXzVvKJcvvvtbSAQ8hyIgJPmCWkLo6dOnGssY8Qy6DePnK1euSGj75ptvdEGAi9gDMZHt4gyXTa+hC+bp06d1xxBk7dq1Sw4dOiTJkiXT37t3766TB6dMmVIGDx4srVu3llWrVulrEaThQ8iWLZsMHTpU2rZtK2vXrvWzfTz3r7/+0u0iyMNzevXqJWPHjtX1e/bs0e0nSpRIGjZsqBlKBI/+nThxQkaNGqVBHzJseC6CImxz2bJl2hUUH1itWrWs66dNmyYLFy7UAClevHjy8OFDHciN4AnBkHEy4XUI2GbOnKldURH8IghGgIcAxwh29u3bZw3yggtBPILuH3/8USZPnqxBHNqLwBUB/4ABA2T+/Pl+XoMAHkEjgj8jgAPcfEAFM2QbZ8+ercE5jivahoAUAeuKFSsctmfChAn6OhxPQHsM+Dz//vtvfQ8cJ2Qokbk0nov9xzFLnz69foa4aWBklPFZ/Pnnn7qPOJ44do6Op3GzAp8XjgGOP9y7d89Pd2wE3gjGceMD+4rA3lm4gYLtJU+eXOLGjavn9JYtW+zOLYbuy0OGDPHzePny5bXN+D8+z9ixYwfrfbEd7CMREZlf9lx5ZO2+oxI7dhxZv3KZdP+ylcxb7fcmMZEjPIciZvGokNi/f78m5gwYKgfNmzcPUZwRHHPmzNHYqFq1aqG2TZfL2CJTiuxau3btNPBExgqw0whqAUEAMoEIAACBE9LVCFzg448/1qAWELAic2esM6xfv17fy+jC+eWXX8q6deus67F9BLWAoAXBjD3IgiKggPr162umFtXHkJ3t2bOnBuYYj4oTxQhYMX4UmT4EtYD+5fYmIjYCPQTDOCbYL4wBRabUgDGXzkAXVyO7iywnAnDjREbGFJnN4GrSpIkGtYDxnDi2CJrRZtxYCM5dHnRDQOCMamhYbPfrn3/+0QwtAlBs8+uvv9YMujHWFJ8Pglp7n1WGDBmkdOnSwT6exvOQPTWCWkicOLH1Z5w36NKM7r7YTmDnRnDh3MDNGvQ6uHHjhp5P/rsyv379Wt8XWfFPP/3U+jiy4bgBs3PnTrl7967e8Aku3KjBDQ5jwXkb2a2dO1V6Naiky+uX/41lDkyCJMnk4Z1b+jOy7c+8H0vc+KE7XoSIIqfZUybKZxVK6JIkWTK5feuGPu79+JHE/f/1g604cT01IIEK1WrIrevXAlz7UOTCcyhic3P3CHIJKfTExPWM/yW0g1rA9X6mTJlCdZsul7G1HXtoy3aOI/9CYzyb/20g8DMg6ERGLLjbwTJ8+HDtL47ML7aFOx4IlkICJ1LChAkdjv0M7Lgg8LL9MvL/3ralvrF/zu6v/zagzQiYcEMhpG0K7PPANnGn6Kef7BfmcdR2/20L6ngGx/scK3uQ7Ud3d+MmC/bV6NYNyAwjqE2RIoX2DrCVJs27yoXI0uIGj73jHhhHE3RHVpUatNAluPKVrCDbli+QgmUrayGpj3Ln5/haIgoVn7dsowvMnDROli2YK1lz5JJlC+dJ6Qr/9Woy3Lt7RxInSao/H9izSxIkSmz3pjlFHjyHIji3ILobu7lc/tKPbt266XUthgWG1rWTa+9xIJBZXL16tWa3AF14keUy/vGhayi6MQO6buL5/v9hYlwm0t/GuEJ0XbUNJoIL4x2N8aAorISsMsZHonsxupYiCEIW17ZbL8bPos3GmF507UXAh1LcxmOAMcZ4zLb6MKrlGuN9HUGmEtk8ZPEAXYI/BGSBsW9GGxGUoQs54K4MspPYV3QDRnds288DXYTxfGQnbfcZxwvrjMwvsuHYTkgF93jiebFixdLuzwbbrsihDZ8Vehxgv42MPsYaAIJmZJgRkKO7tu0/fJxjOI7GMcFNIfQOoNCBQPWrygXl7NGDMrh9IxnZvZ0+vn/zWpn/57uK1/lLVZA48eLLNzWKy4Jxv0nDTgGHK1DkVb3/WGk6bJqsOXhKMrceIHvOXJJPB02Qmw/efc+3Hf23lO01So5fvqnrF+18v5tuFHHVbdxcrly8IFWK5ZO1y5ZI647vZkDYuGaljB46WH9es3Sx1CxdVLNzIwYPkJ9HOz/LAkU8PIciHrcoUcUtSjQHS1RxZRiSidlEULMGw/I+++wzP0uEyNgGBy76MQ4U3YUhderUMnHiROt6dDFFN2AELehOjIyYf1WrVtXun+i6igrLKNCDsZghheJESM+jgBJS6giGEHxgMHTdunV1vZeXlwZuhqZNm2pQjnYii4lsG7rvog14PvYPwQ6q5SLIwbhbjH1FQIgusRjHGhS8Z48ePbRbMYJt7O+HgCJc9+/ft3ZrRmCGbsUIuHCSIsBHN3EE/3jMCMzatGmjnwfGrKJrNoozoYst4Gd0aUYXXGwPASAKQKELdUjgWAfneOJ56P6MLs/IEuP8QDYU3ePDwldffaVjgdFtHV26cUPEKFaFYBXFunBuGEFr8eLFdSos3LxBm3C+4bigsJb/jC45D1WOx6wJeAOlYJlKugDOjTZ9h4ZD68gMVvT/MsBji7//r1fFhK//G+5A5EiMmDFl9NSAf/vLVa6mCzRu1U4XInt4DkVAQRWIcnft/CV6KtoOrwsNbhb0z4xAEGRinCfn7iRXhXHZOD9Dcw5kR2MlEMjbVvIODHovYNz35G2nJFacuGHeNoqYal6cF95NoAjgUjHn6kcQEYWmp0+8pchHabRHJXr9uQLjeu3Brn/EM07gBUO9nz6ThMVquVTbw5prh/JEEVCSJEm04Ba6yYcVFNZC4Iwq1rZjgomIiIgoAlVFdrSYAIZNolsyFmMIpbNM2RXZEcwlasyNSuSKjOmZwhIqNr9vkSwiIiIiijzT/XxImMYSw/4wZBS1YgA1kTBLyujRo7XeTUgxY0tERERERGQibu7uQS6uDDPGbNmyRZYtW6aFdLGgxg0eQ8VkZ0S4jC0REREREVGE5h5FxCOq4/UuDLOjYEYZ1IMxVKtWTXsd1q9fX8aOHRvibbr2HhMREREREVHAeWrdzDuP7fPnz3XmFv+SJk1qnTUlpFx7j4mIiIiIiMgPi5t7kIsrw5Sr/fr1k5cvX/opfjpgwABd5wxmbImIiIiIiMzE5BnbUaNGSeXKlSVVqlSSJ08efezIkSM6m8eaNWuc2iYDWyIiIiIiIjNxc3u3OFrvwnLmzClnz56VWbNmyenTp/WxRo0aSePGjXWcrTMY2BIREREREZkJqh47qnzs7toZW8CUPm3atAm17bn+HhMREREREZGVxT1KkIsrOnDggJQtW1a8vb0DrHv8+LGuQ5dkZzCwJSIiIiIiMuMYW0eLC/rtt9+kXLly4unpGWBdvHjxpGLFivLrr786tW3X3GMiIiIiIiKKUIHtnj17pFatWoGur1GjhuzcudOpbbtmjpqIiIiIiIjssri5OZzSx+KixaOuX78ucePGDXR9nDhx5ObNm05t2zVDeSIiIiIiIopQGdskSZLImTNnAl2PCsmJEyd2atuuucdERERERERkn7tH0IsLqlChggwePNjuOovFouvwHGewKzIREREREZGJoBuy467I7uKKvv/+eylQoIAUKVJEunXrJlmyZLFmalFY6t9//5WpU6c6tW0GtkRERERERGaCwNXRXLVurhnYZsyYUdavXy8tWrSQhg0bitv/xwIjW5s9e3ZZt26dZMqUyaltM7AlIiIiIiIyk6DG0bq5ZmALBQsWlOPHj8vhw4fl7NmzGtR+9NFHkjdv3vfaLgNbIiIiIiIiMzFxYGtAIPu+wawtBrZERERERERmEgEC29DGwJaIiIiIiMhELO4eYnGP4nB9ZBP5QnkiIiIiIiIzQ9GloBYnjBkzRtKlSycxYsTQysV79+4Vs2BgS0REREREZMauyI6WEJo7d6507dpV+vXrJwcPHpQ8efJI5cqV5c6dO2IGDGyJiIiIiIhMOI+toyWkhg8fLm3atJGWLVvq1Dvjxo2TWLFiyV9//SVmwMCWiIiIiIgoAmZsvb29/SyvXr2yu7nXr1/LgQMHpEKFCtbH3N3d9fddu3aFyS54enrKhQsXAvzsLBaPIiI/BkzcI+7RYoV3M8ikaoxqH95NoAgg09Pb4d0EigCuSMLwbgKZXFR358apfgi+4qaLo/WQOnVqsYVuxv379xf/7t27Jz4+PpIsWTI/j+P306dPS1jA/LX2fnYWA1siIiIiIiIT8bVYdHG0Hq5evarZUEP06NElomJgS0REREREZCIIWx3lOC3//z+CWtvANjCJEycWDw8PuX3bb48Z/J48eXIxA46xJSIiIiIiMhFfS9BLSESLFk0KFCggGzZssD7m6+urvxcrVkzMgBlbIiIiIiIiE8GYVEfjUi1OjFnFVD/NmzeXggULSuHChWXkyJHy7NkzrZJsBgxsiYiIiIiITCSorKyvE7WYGjRoIHfv3pUffvhBbt26JXnz5pXVq1cHKCjlqhjYEhERERERmQgCV59QDmyhY8eOupgRA1siIiIiIqJI3hX5Q2vSpIm1sJXtz85iYEtERERERGQivv9fHK13dWPHjrX7s7MY2BIREREREZkIErKOkrIW10/YhjoGtkRERERERJG8eJTZMbAlIiIiIiIyER+LRRdH6yMbBrZEREREREQmgrDVYVdkiXwY2BIREREREZmIr8Wii6P1kQ0DWyIiIiIiIrNlbINY78r27t0ru3btklu3bunvyZMnl2LFiknhwoWd3iYDWyIiIiIiIhMxa/GoO3fuSJ06dWTHjh2SJk0aSZYsmT5++/Zt6dKlixQvXlwWLlwoSZMmDfG23cOgvURERERERBRW/j/dT2CLuGhg26FDB/Hx8ZFTp07JpUuXZM+ePbrgZzzm6+srX331lVPbZsaWiIiIiIjIRMxaFXnNmjWydetWyZIlS4B1eOz333+XMmXKOLVtBrZEREREREQmYtauyNGjRxdvb+9A1z958kSf4wx2RSYiIiIiIjIRR92QLUZ3ZBfUoEEDad68uSxevNhPgIuf8VjLli2lUaNGTm2bGVsiIiIiIiIT8RWLLo7Wu6Lhw4frONqGDRvK27dvJVq0aPr469evJUqUKNKqVSsZNmyYU9tmYEtERERERGQiQWVlLa4Z12o347Fjx8ovv/wiBw4c8DPdT4ECBcTT09PpbTOwJSIiIiIiMhFfi0UXR+tdGQLYsmXLhuo2OcaWiIiIiIjIRN74WIJcXM2cOXOC/dyrV6/qXLchwcCWiIiIiIjIRJCR9XGw+LpgxhZdkLNlyyZDhw7VOWv9e/z4saxcuVI+//xzyZ8/v9y/fz9E22dXZCIiIiIiItNN9+OoK7K4nC1btsjSpUtl9OjR0rt3b4kdO7YkS5ZMYsSIIQ8fPtTxtokTJ5YWLVrI8ePHdV1IMLAlIrLj8dFl8vTMRhF3D4nqmUwSl/5K3KPFsvvc1/cvyY0lvSRpxe4SK02BD95Wcl0vX76Uli1byMkTJ8QrZUqZMWOm/tG2ZbFY5JtvOsnmTZskXrx4Mm36DMmQIUO4tZlcz4q1G6Rn/8Hi62uRbzu2ky+aNPSzvnyt+vLY+4m8eftW6teuId916xRubSXX9OrlS+nyZSv599RJSZ4ipfw+aZokTJTI7nM3rl0t7Zo2kBWbd8lH2bJ/8LZS8Pj4vlscrXdFNWvW1OXevXuyfft2uXz5srx48UL/NubLl08Xd3fnOhWzK7LJvHnzRgYMGCBZs2aVHDly6Idfu3ZtOXz48AdrQ5kyZWTJkiX6M+6ojBw5Uszoxo0bUrJkyWA9t1q1anLmzJlgb7t///6SJEkS/Ydr6NSpk6RLl07c3NwCfF6VKlWS3LlzS968ebVNhw4dsq47e/asfPzxx/LRRx9JoUKF5MSJE8HaJgbkJ0yY0LSfT3iLljiDpPj0F0lZZ5hEjZ9SHh9bZvd5CEoe7vtbYqbM/cHbSK5v6tQpkj5dejly9JjUqlVLhv/2W4DnrF69SrtbHT12XPp895307ft9uLSVXBOmw+jRb5CsWThb9m5YLsP/nCD3Hzz085zFMyfL/k2r5MCmVbJ6/SY5fOy/vxNEMG/WdEmTNp2s331IKn9SUyaMHh5oADx1/BjJnY83ac1SPMrR4soQyCKG+eabb6RXr17SunVrrYrsbFALDGxNBpMWI+jZtWuXBjj4uWPHjiEKuugdLy8v2bZtW7Cei/7+WbJkCdH2GzdurN0tDHXr1tU7U2nTpg3w3Hnz5snRo0c1OO3ataveMDC0a9dO2rZtK//++6/07NnTzzpH29y0aZOfwJpCJqZXDnGP8m5utWhJMonPswd2n/fs3FaJgefGjPeBW0hmsHLFSutE8w0bNpJVq1YGeM6KFSusz6lSpars2b1bb5gQwb5DRyR7lo8kZYrkEid2bKlcroys3+z3b5dn3Lj6/zdv3mrWFjc7iWxtWLNSatV7l+mvVbe+ZmXtmTBmlDRq0UpixIz5gVtIIfXGYpE3vg4WS+T7O8LA1kSQuVu8eLH89ddfkiBBAuvjFSpUkAYNGlh/x6TGhQsX1kHXVapU0RS/kUWsX7++1KhRQ7N/n3zyifZfr1y5sv6OCytMmAxPnjyRNm3a6HaQSURghYmTHdmwYYMUK1ZMs8jIJk+ePNnu8+7evasZyly5cum2EazDsWPHpESJEtru7Nmzy6BBg6yvQduxj2g71pUrV04ePHhgzWJ36NBB96Fo0aLSrVs3zSrD5s2bNQtqwP4iwwmXLl2S+PHjW9fhQuCnn37SfU6fPr1MmTLFug6vMTKiaBcGvmO7WIzjG5RSpUpJqlSp7K6zbQcGzhsXJXfu3JH9+/dLkyZN9Pc6depolbhz584Fuc2gvHr1Sry9vf0sZN/Ts5slZso8AR73ff1cnpzZKJ45q4VLu8j13bx5U1J4eVn/nT969DjAc27dvKk32gD/9uMnSBDighkUcd28dVu8Uvw3zgw/X///vI+2SlevI6lyFJRypYpLnpzsPkp+3bl1S5Ilf/c94xkvvng/DvhddO3KZTlyYJ9UrVE7HFpIIeXjawlyiWwY2JoIsrOZMmXS7qWBmT17tmZvkdE9ePCgZg0R9BkQJE2fPl2fg+AVaf8FCxbIyZMntTrZqlWr9HkIDtEldu/evXLkyBENeEeNGuWwfQhIkT1EO5EJHThwoFy7di3A82bOnKmBIwJZZCl/+3/XPASPCI7RbkzYvHDhQtm9e7f1dXv27JGpU6dqW5MmTSrjx4/XxydMmKBBPzLYeF9s830mjcY+4zigmy+6gNnCwHbcOEAbEeju3LkzxAPbA9OsWTNJnTq19O3bV2bMmKGPIYhNkSKFRIkSxXrRmyZNGrly5cp7v9+QIUN0PJ+x4L0pIO/jK3WW89gZPw6w7tHBeRIvdy1xc2e5AiIKX1tWLJRLR3fLkeMn5cQp9uKikPt5wPfy7Xf9w7sZFEyWILohW5ixJTM5f/68ZgzRRdbIemLs6/r167WPOtahnLZtEIRMKbK9CJAQiCKzGTduXA2ckGlFgGhs59dff9Vt4HEEjEaWMDDIMNSrV09y5sypGVX8jgypf8iqInBE8PzPP/9oRTTAwHEE2sjk4jnIhNqOG0X2OdH/Cx0gM4z9BwTDyGhGjRpVl+bNmzt9THEjADCGGccE1dn8TyadOXNmfT8E1sgao5JbaMANBwSyyAijy3FYQzU6ZIeNBe8d2XmfXC3XF3XXxffta3l+eb88PbtFkpT9xu7zX927KPd3Tparc76S5xd3y72t4+TFtSMfvN3kWsaPHyfFihbRJXny5HLzxg19/NGjRxI/fsAu68lTpNAx/4ALkUcPH1q/64hSJE8mN27etv6On70CuaEaN04cKVvyY1mzacsHbCG5qpl/TZQa5UrokiRZMrl96933jPfjR+IZL+B30YmjR6R980ZSpmAuOXxgn3zR8DM5e+Z0OLScggPT1Aa1RDYMbE0EASaCS2QNIWPGjBr4IUAxHsNFEX7H41iQFcVisA3CPDw8AvxuZCixHWRMje0gw2tkSAPTvn177UqM98Nr0DUYFUH9Q1CK9UWKFJFFixZpQSQfHx/p06ePDiRHxhdZYgTdtq8PrK3+2Y4tQnCKbRvstcdWUO+Bx5BF7ty5s3YTRgAe3HG6wYXAHONjcWMAWVR0ZbT9XHCjAlnb94XsNAJ12yWy88xeRVJ+9qsubx5dkwd7Z0jSSj3EPar9mxcpPhkgqRuO0SVW+qKSuFR7iZkqYJdlilzatWsvu3bv0aVqtWry999/6+Nz5vytY2j9q1q1qvU5KCRVuEgRjpEkq0L58siJ0//K9Zu35OmzZ7Jm42apWLaUdf1jb2+5e+++dYjJuk3bJEumjOHYYnIVTb5oI8s2btelXKWq8s/8Ofr4PwvmSdmKVQI8f9O+o7J5/zFd8hYoJH/NWSSZs2QNh5aTGYpHDR48WIubxooVy8+QOmfheh3xgRHTOIOBrYkgU4iqmq1atdI7/4Znz55Zf0Z1sXHjxvkZf2pbYTe4sJ1ffvnFGlDhJAsqY4vnoIgRLsi2bt2qwak9Fy9elDhx4uh4X8xjhaJIT58+1ddjvCiCUQTS69atC1ZbkR1GF2zsKxZkPg2YMgOZX4zrBaOLr7PQffv27dvaTRtdhhHIO3N8beGzNLI1RrYc2Rp0OUeXa2TW0X0bcLMBxwhd0ilsPdw7SyyvX8jtNT9rBvf+jkn6+Ku75zUzSxQc6E1z4cJ5yZ0rp9ZI6Nqtmz6+YsVy+fHHgfpz1arVtCdNrpw5ZPCgQTJw4I/h3GpyJfib+Ev/PlLps0ZSqFx16dy+tSRKmEBqft5Sbty6LY8ee+vPBcpUkaIVa0qpj4tI9Urlw7vZ5GIaNGkuly9elPJF8sqqZUuk7ddd9PENq1fKyF8Gh3fzyIRjbF+/fq09Nb/88kunXo8kkVGPB0Ft6dKl9ZoXSR3UyHEGB4aZDMaY4g4Jsp34Y4eLIUwrY3RdRVdaZPow1QsgMP3iiy802xsSI0aM0NLb6IqMstt4L3RrdhRQ/fzzzzqe98cff9TXoY324GQdPny4NSOKLs8Y4/n9999L06ZNZdq0aZqNRsAaHKgajCwxikrheBQsWNAaKKIgS48ePbQgFMbCIjPyPtBlF5WIcTMBATxuNgS36zPaieqn6N6Mgl3oAo6bBdgmvhjQFRvHGp/n8uXLrRkbZMpRCRmFrZBVtS1qFdg26f0lr9bX7uPRk2TUxb8kpb/6AK0is4kZM6bMmTsvwOPVq3+iC+Df/R9/jAmH1pFZ1KhSURdbS2f/97dg19r/KvAT2YMqx2OnzQ7wePkq1XTxb9biFR+oZeQso/qxo/VhCdOPGrGJM1DjxyiOumzZMk18nT59WpNQ3333nezYsSPE23SzRMaRxRThIJOKoA4ZWwT3GGP8IcapBgZVnJGJDe85ZBEQ4yYD7ooFBVWRcYMhTbOp4h4t1gdpH0U8x0e9C9aI3kfUp/+NKSVy1hUJvNgmUXA8eeIt+TOl1iSEqwzZMq7XJm8/JbHivJvqy57nT59IqxLZtIaKbdsxFA1LaEFgi+tM296kwYHhf0jGoCciZl9Bl2ZcNyPAzZMnj1OzdbArMkUImPIIARwKT+EfLyoahyd0tcbdp/CcRxZZ+y1btliLcxERERFRxODrawlyAXTttZ0FA7NiuAL0pMRMJ+iGvHr1aqlY8V2vlOfPn2uvTmewKzJFCJgKyJV8++23uoQnFKAiIiIioojHN4jKx77/X2cvYxsYDENEjR1HMD0oZg8JjRoUqLeDaS0x/A5JKuOa3tntM7AlIiIiIiIykaAqH/v+f11IZr7AVJwYxuYICrOG1rA9TBGKwBu1ZoyAG9laBNjOYGBLRERERERkIm98fCWKj6/D9SGFAqZYPhQUZPUvuEVZ7WFgS0REREREZCI+4rgrsk8Yv/+VK1d0elH835iDFjCDCmrNOOLr66tFpxYtWiSXLl3Srsjp06fXQBczpDg7lzsDWyIiIiIiogjYFTms/PDDDzpFp8GYWhQ1XsqUKRPo6zAhD4qrrly5Uqsfo/ArHsPYXXSDRrC7ZMkSp9rEwJaIiIiIiMhEfCwWXRytD0vIuDozhy1es3XrVtmwYYPO4GFr48aNUrt2bZk+fbo0a9YsxNvmdD9EREREREQmgul8fBwsvkZZZBfz999/S58+fQIEtVCuXDktHDVr1iynts3AloiIiIiIyEQcBbU+/19c0dGjR6VKlSqBrq9ataocOXLEqW2zKzIREREREZGJvH5rEfe3vg7XuyIUnEqWLFmg67Hu4cOHTm2bgS0REREREZGJBJWV9XHRjC0qKEeJEngIinls375969S2GdgSERERERGZiFkDW4vFotWPo0ePbnf9q1evnN42A1siIiIiIiITFo9ytN4VNW/ePMjnOFMRGRjYEhERERERmW26H9/wm+7HWVOmTJGwwsCWiIiIiIjIRMzaFTkwly9flmfPnknWrFnF3d25iXs43Q8REREREZGJvHrrG+Tiiv766y8ZPny4n8fatm0rGTJkkFy5cknOnDnl6tWrTm2bgS0REREREZGJmHUe2wkTJkiCBAmsv69evVq7J0+fPl327dsn8ePHlwEDBji1bXZFJiIiIiIiMhGzFo86e/asFCxY0Pr7P//8I7Vq1ZLGjRvr7z/99JO0bNnSqW0zY0tERERERGS24lFBLK7oxYsX4unpaf19586dUqpUKevv6JJ869Ytp7bNwJaIiIiIiMhEzNoVOW3atHLgwAH9+d69e3LixAkpXry4dT2C2njx4jm1bXZFJiIiIiIiMpHXKA7loEDUaxctHoV5bL/66isNaDdu3KhVkAsUKOAng4sCUs5gYEtERERERGQiPhZf8fH1dbjeFfXo0UOeP38uixYtkuTJk8v8+fP9rN+xY4c0atTIqW0zsCUiIiIiIjIRsxaPcnd3l4EDB+pij/9AN0Tbfo92ERERERER0Qdm1jG29nTo0EHH274vZmyJyI/y0/tKNN7zIift7F46vJtAEUBhr6Th3QSKAIbFzR7eTSCTey2u2Z0XMITWzUHw+tZ1mx7AzJkz5dtvv5XEiRO/13YY2BIREREREZkIMrLuDgJbHxNlbC2hNDURA1siIiIiIiITQdVji4O07BszpWxDCQNbIiIiIiIiEzFr8Sh7njx5IqGBgS0REREREZGJIKh1M1lXZG9v72A/19PTM8TbZ2BLRERERERkIhiXanEQvFpCadxqaIofP764ubk5fA7ajef4+PiEePsMbImIiIiIiEwEXY19TdYVedOmTWG6fQa2REREREREJuLr46uLo/WupnTpsJ0SkIEtERERERGRiYRnxvbSpUvy448/ysaNG+XWrVvi5eUlTZo0ke+++06iRYsW7O08evRIJk+eLKdOndLfc+TIIV988YXEixfPqXa5O/UqIiIiIiIiChcW36CXsHL69Gnx9fWV8ePHy4kTJ2TEiBEybtw46dOnT7C3sX//fsmYMaO+9sGDB7oMHz5cHzt48KBT7WLGloiIiIiIyGzFoyzhUzyqSpUquhgyZMggZ86ckbFjx8qwYcOCtY0uXbpIzZo1ZeLEiRIlyruQ9O3bt9K6dWvp3LmzbN26NcTtYmBLREREREQUAbsie/ubYid69Oi6hLbHjx9LwoQJQ5SxtQ1qAT/36NFDChYs6FQb2BWZiIiIiIjIRDDVT1ALpE6dWsesGsuQIUMktJ07d05Gjx4t7dq1C9E8tVeuXAnw+NWrVyVu3LhOtYOBLRERERERkYmg6rGPg8X3/1WRESgim2osvXv3DnSbvXr10jlkHS0YX2vr+vXr2i25Xr160qZNm2C3v0GDBtKqVSuZO3euthHLnDlztCtyo0aNnDom7IpMRERERERktjG2vkGPsfX09NQlOLp16yYtWrRw+ByMpzXcuHFDypYtKx9//LFMmDBBQgJjcREoN2vWTMfWQtSoUeXLL7+Un3/+WZzBwJaIiIiIiMhEbLsbB7Y+pJIkSaJLcCBTi6C2QIECMmXKFHF3D35HYB8fH9m9e7f0799fu0afP39eH0dF5FixYomzGNgSERERERGZiK+viJvD4lESZhDUlilTRtKmTauZ17t371rXJU+ePMjXe3h4SKVKlXT+2vTp00uuXLlCpV0MbImIiIiIiEwkPKf7WbdunRaMwpIqVSqn3jdnzpxy4cIFDWxDC4tHERERERERmYjFN+glrGAcrhFY+1+Ca9CgQfLtt9/K8uXL5ebNmzotke3iDGZsiYiIiIiITMTnra+Ih6/j9S6sWrVq+v+aNWtqESkDgmP8jnG4IcXAloiIiIiIKJIXj/qQNm3aFOrbZGBLRERERERkIr7IbDro+usbhmNsQwPG1qZOndpPttbI2GJOW2dwjC0REREREZEJM7aOFlcPbG2rKRsePHjgdEEpZmyJiIiIiIhMRIs1OeqKbHHtwNYYS+vf06dPJUaMGE5tk4EtERERERGRifj6+IpgcbTeBXXt2lX/j6C2b9++EitWLOs6FIzas2eP5M2b16ltM7AlIiIiIiIyEbMWjzp06JA1Y3vs2DGJFi2adR1+zpMnj04D5AwGtkRE/jySN7Je/hv38UjeSnlJLOnlv7uKWP9Q3gj+bKSQ6FJCEoqbBOxSQ5Hb61cvZUi3L+Xiv6ckSbIU8v2oSRIvYSI/z3n29IkM6dpe7t2+KRZfX2n1bV8pXLp8uLWZXM/Lly+l9Rct5eTJE+LllVKmTZ8hiRIn9vOcA/v3S7euneX4sWMyc/YcqVK1ari1l1zTG/GVeXJDMkhsKSYJ/Ky7I69ks9wXH7HIRxJbCkj8cGsnBY8vAlcHwauviwa2RjXkli1byqhRo8TT0zPUts3iUURE/sSXqFJXvHSpJcklqrhJKvE73qOUJJJ64iX1JIW8FF+5JC/Crb3kulbNnyUpUqeVqWt3S4nKn8jciaMDPmfeTEmfJZuM+2ejfDdyooz7qW+4tJVc1/RpUyVdunRy8PBRqVmrlowY/luA5yRPkUJGj/lT6tSrFy5tJNd3SB5LUolud912eaA3cBuIl1yRF3JfXn/w9lHIWHx9glxc2ZQpU0I1qAUGtu+hRYsWMnLkyFDd5o0bN6RkyZLW3//55x/Jli2b9jVHuh7/f/LkSYi3mzhxYrl06VKAxzdv3iwxY8bU7RrL0qVLJbShH/2jR49CbXv9+/fXO9ihcYzDAtqXJEkSnXTa0KlTJ70wwbE4fPhwoP/IsX7JkiXWx/bu3StFixaVfPny6bkwdOhQ67o+ffpI1qxZtdtGwYIFZc2aNdZ1I0aMkEyZMjk9ToHeQcDqJTEkqr+vy2j//x33Q3GHm8ieXRvXSPla7wKN8jXryu6NawM+yc1NXjx7pj8+e+otCZMm+9DNJBe3auUKadCokf5cv0FDWb1qVYDnpEyZUnLlyi3ubry0o4AeyxvtfZRGYgZY90zeiq9YJJH+ZXOTjBJbg1tybWYPbJ89e6ZjbD/++GO9Xs2QIYOfxRnsiuxivLy8ZNu2bdbfx40bJz/88IM0+v8ftMACoveRJUuWMNluWBowYIB07tw5xFXT3r59G+AYh5XGjRv7ufFRt25d6dGjh5QoUcLu83HjYeLEiRrE2mrbtq0MHDhQg2SUQEcg+8knn0j27Nk1QMeXAm5OHDlyREqVKqWBe+zYsaVLly4aDOM42fPq1StdDN7e3qG27xHJBXkmmSWO3XVr5a7ckJeSWmJIOjsXC0T379ySxEmT689xPOPJ0yePAzynev2m8kP7JtKwRG7tuvzzlPnh0FJyZbdu3hSvFF76c/z48eXx49C7UUyRwy55KEUlgdyW//7uG56Lj8S2CQlii4fctPM8ci0YuuIoeLX4umbxKEPr1q1ly5Yt0rRpU0mRIoXdCskhFalu6/nPGtpmMZFJQwBZrFgxnTtp0KBB1uddv35dg5JcuXJJ7ty5NZDwb8OGDfpaBBI5cuSQyZMnW9dNmjRJgxBkzrANVPvy9fWVjh07agYO2bYCBQpoBhLtwR8tI8OHAAxZOdzN8L8PZ8+elerVq0uhQoW0XX/88Yf1PZF1xbbxOIKp981GYxA3spCwbNky3S72J2fOnJpVhnPnzkmFChWs62yzjjBs2DA9Ph999JHMmjXLTwCIbCNeh/25deuWdd2KFSt0/3CMsE0cu/bt2+s6BHV47M6dO5rFbtOmjRQuXFi3g2Dw9et33WjKlCmjxxKfT6VKlfwcY//H1N558f333+vxxyTSuNGArCq2hXVz5swJ9jFF0JkqVSq763A+4B/46NGjJXp0v92EbNuHu1sYWJ8wYUL9vWrVqhrUAs4tDMS3NyeYPUOGDJF48eJZF+wf+fVafOWWvLJ7hxsqSRJpKqk0X3tdnOtBQLRv20bJmreAzNl+VIZOWyi/9vpavxOIiELDJXku8SSqDrOhiMP37WvxfeNgeeva3clXrVol8+fPl19++UWTMN98842fxRnM2NpA8LBr1y65d++eZMyYUQc1o2tPkyZNNCBasGCBPs9e4JA/f37Zvn27eHh4aFYNAVzlypU1kOnWrZucPn1a70a8efNGs2TIriEYPnHihLi7u8vjx4/9VAWD33//XY4ePaofdu3atf2sQzlsZHFnzpypGbznz59rpq9IkSKSNm1abTuCYgTUEyZMkPv37we632fOnPHTXfXAgQMOjxMCvfHjx2twh4svI9OHAPWLL76Qdu3aadBtdJ9Fe4wADZXQLly4oIFs8eLFNThEAI1uu/Dzzz9rAI0A8t9//9X92Lp1q+4jjh32E+vw/tg/I0BFIItAFxlPBHcIcjEgvXv37roe28J2okaNardLtiMIJnfu3KmBO4LH7777Ts+Tffv2SbVq1aRhw4byvoYPH67HAzc4/EMgXatWLT3uOPew78mTJ7f7PHTdMI53UHr37m0tuQ74HBncBrwYSCUxJYqDolAe4qZFpdBlGc8lWjrrL1k5b6b+nDBJMrl355YWjHrq/VjixI0X4PlrF82Rph3fVYDMlD2X9m9//PC+JEj07nuRIqeJE8bLtKlT9OdkyZPLjZs3tGAUrlXixWNhHwo+ZGnPyzPtgfRWLNrtOJq4WQtExRIPXWN4Jj76GLm2oLobW1y8K3KCBAmsiZrQwsDWxueff27N2CFAuHjxomayELDajl00gjBbCBxbtWqlAVSUKFH09+PHj2tgW758eU2z16hRQzNsyFhi++gWi0CwbNmymqlEgBtcCEYRFNsGVchanjx5Um7evKlZSwS1gHZ9/fXXodYVGfuDOynIYiPgN8b9Hjx4UHbs2KHPyZw5s3a5RfBpBFrISAL2HdlLBJoIbGfPni0zZszQjDUWHH9Yt26dVKlSRYNaQFCKz8MeZIcRbCJAhBcvXuhNBgNuTuD1zmjQoIH+H/3/0fUZ+w0IznETAxcZthngkMJ5snDhQj0e9iDYR3YV5yduCpQuXVrf2/h8ATdJ0D0bxyy4XTmQGfafHSa/zstzyWanGzLG1KLrVlyJohcIl+WFJBW/N6Yo8qrZ+AtdYPH0ibLhn/mSMWsO2bB0gRQpWzHA85Mk95JDu7dJltz55ObVy1olOV4Cv5WTKfJp07adLjBu7J8y9++/dQztvLlzpHKVKuHdPDKRIpJAFzgjT+WBvPFT9RjdkFHVHwWjEkhUDYJRIJFcm9kD2x9//FF7y06bNs3PXLbvI1IFtgh0kOk0+C8+ZDteE89F4Blc6B6L7B0CFAQWyOAa28djyIKiUBOeg27OCEgR0KBvOcpeI3uGwAZBcXAgK4m7HPYCUv/Fn5zps452+D9WceK8u8BH8IigGu1u3ry5Zmq//PLLANsI6n2xHjcNkJlGUJo0aVJtO07ykMLxwHHGTQN7jLaHxnlh/I72YwnJeWIPgn9kkXEzANAVGxlo3KCoV6+eLF682NrlGTcFkAnHDQQjsMU5hMw2uojjJgWFjlfiK3fllXY3NmyR+5Jd4mh3Lkz3gzvf6IaM4lLZJW64tpdcU7X6TeSnru2lRcUikihZCun7+yR9fNeG1fLv8SPS/Jue0virrjK0R0fZtGyRfqd0HjgsRDc6KeJr3qKltGrZQvLlySUpUnjJ9BnvegSsXLFCDh06KN9931eOHz8m9et8pjdb16xerT3P1m18N60GkT0r5baUlkQa2GLKug1yT2/cZpbYWkiKXJvZA9vffvtNzp8/L8mSJdNEl/8EFBJmIRWpAltk3DBGE8HlokWLtItpUBAQIbuIg4/gE9Ad1H/W9uHDh5qZxEUJAlR0NQYEPQhakGHDgm7OqHKLrCeCJGQ8K1asqMEJsq3ItAYHAhiUyEb3UwQ1gK6yCHbRRRiPofszsp1//fWXdbxpSI4V2gnIPq9cuVKaNWumv2O7GEeMBQHw2rVrdRwvgnm0B92A0RYjaDVgHboZ43ggmEMXZFR6jhs3riRKlEjbiG62BnTlRtEkYz+MrsjI2uI16L5tZErRVRt99PF6tAmfB9qN/QiL8yI04aaA7Y0BjAk2up8j4EYhqI0bN0q5cuX0/EFbjS7EONfQGwDjnDEOmUJPdHGXZuK3azYuAAyfSopwaBWZTfQYMWXAn9MCPF6sfBVdIHGyFDq2ligwqKUwe87cAI9Xq15dF8iZM5ecPHM2HFpHZpLFphdSNfmvAnsyiS715V2BMjIHsxePqu1vmGVoiFSBLaY/QREhjFVE118EU8GBbrLoyotADncTMN4R3T79dxft0KGDptXRNRdjXQGBCbobo8sqAi4ExAjwrl69qgEggjU8B+Mr0U0ZhaqCA9tavny5BkDYL2wDXXjRrRfjghHMfvrppzpuF915g7uvBmQM0eUWBaiMLKEBxazQFRrbRteBsWPH6uMoCIXMNYpYIcBH0aw0adJYX4c2YswtAkcEvLg7g7ZinDACdbQRxaeMY4CAE8cK3YhxnHAjAONrUSAK45ZxQwDvj8Aax6BXr1567JHpwPHBtDjBCWydPS9CCmOPUQwLGVkE7QjOcQPAEezzvHnzdKwwbpLgOOAzx80Lo5s5xmwbNzeM8xVjgYmIiIgoYvJ5+1osDqb38nXx4lH9+vUL9W26WdCHk4hCFTLT6A4W2vMchxS6vyMQDs4YahSPQja8paS2ztFKFFJ1zrzr6UH0Pgp7BT58hCi4esb9rxYFkbOzI0yRq9pLED0lXYFxvZagcj9xjxr4tJe+b17KwzUDXKrt9mC45qlTp/RnJBGRBHNWpMrYEn0o6MKOzCmKPfkf8/yhIBONKtGYt5eIiIiIIhAfH7G4OxhH6+PaY2wxXSdqDiEJYwwtRFIIRXVRW8Zesd6gMC1DFAYw7y8GxIdXUAtdunTRcdvr168PtzYQERERUeizWN4Vjwp0sbh2YIthnphVBQVpMWQTCwrrIiONIYLOYMaWiIiIiIjIRLQ4lImLR61evVqTL6jnY8CMH2PGjNHius5gYEtERERERGQiWhHZxNP9+Pr6BpjiB/AY1jmDXZGJiIiIiIhMxPftmyAXV4ZpLL/55hu5ceOG9THMjIKhdJgW1RkMbImIiIiIiEzE4fha33eLK8P0oBhPi+k/M2bMqEv69On1sdGjRzu1TXZFJiIiIiIiMhFfXx9xM3FX5NSpU8vBgwd1nO3p06f1MYy3rVChgtPbZGBLRERERERkIhYfXxE3H8frXZybm5tUrFhRl9DArshEREREREQmEt7T/dSsWVPSpEkjMWLEkBQpUkjTpk39jJcNzMaNG7X6Mboc+/f48WPJkSOHbNu2zak2MbAlIiIiIiIyEd+3r4NcwlLZsmVl3rx5cubMGVm4cKGcP39e6tatG+TrRo4cKW3atBFPT88A6+LFiyft2rWT4cOHO9UmdkUmIiIiIiIyEcubl47H0fq8q4rsPzMaPXp0Xd4Xqhcb0qZNK7169ZLatWvLmzdv7E7jYzhy5Ij88ssvga7HHLbDhg1zqk0MbImIiIiIiEwgWrRokjx5crl1cl6Qz40TJ44WabLVr18/6d+/f6i26cGDBzJr1iz5+OOPHQa1cPv2bYfPiRIlity9e9epdjCwJSIiIiIiMgGMab148aK8fh10V2OLxaIFmmyFRrbW0LNnT5225/nz51K0aFFZvnx5kK9JmTKlHD9+XDJlymR3/dGjR3XMrjM4xpaIiIiIiMhEwS3GqAa1xIsXL8BjjgJbdCdGIOxoMabmge7du8uhQ4dk7dq14uHhIc2aNdNg2pFq1apJ37595eXLlwHWvXjxQjPKn3zyiVPHxc0S1LsTUaSAMRj4AmwpqSUa73mRk+qc2RveTaAIoLBXnPBuAkUAPeNmD+8mkMm9Fl+ZIle1Wq+9YkcRzd27d+X+/fsOn5MhQwbtDu3ftWvXtNvzzp07pVixYg67IufPn18D4Y4dO0qWLFn0cQTMY8aMER8fH53fNlmyZCFuP7siExERERERRXJJkiTRxRm+vu/mzX316pXD5yFgRfD75ZdfSu/eva0ZXmSDK1eurMGtM0EtMLAlIiIiIiKiYNmzZ4/s27dPSpQoIQkSJNCpftC9OGPGjA6ztbZVlFeuXCkPHz6Uc+fOaXCbOXNm3db7YGBLREREREREwRIrVixZtGiRjod99uyZFnuqUqWKfP/99yEqToVAtlChQhJaGNgSERERERFRsOTKlUs2btworoYVYoiIiIiIiMjUGNgSERERERGRqTGwJSIiIiIiIlNjYEtERERERESmxsCWiIiIiIiITI1VkYmIKNS88X030TrR+4juzvOI3t+oDQPDuwlkct7PXsiUmu3DuxkUTMzYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhHZ4S1vZJnckrlyQ+bLDXkjvtZ1+Hml3Ja5cl3myQ05Lt7h2lZyXa9fvZRBX38hbSoXk17NP5PHD+8HeM7zp0+kX7vG0vHT8vJVrbKyf+uGcGkrua6Vq1ZJ7rz5JGfuPDJl6tQA6/ft3y/5CxaUHLlyy09DhoRLG8m1rdx1WHI17yk5mvWQv1ZsDrD+7/U7JX+rPpK3ZW8ZPndluLSR6H0xsCUismOz3JeCEl8aiJfUkGTiIW5+1ueVeNJAUsqnklxOyBN5LG/Cra3kutYsmCXJU6eRiWt2SfFK1WX+xNEBnrN6/kxJnyW7/LF4g/QaMUEmDPkhXNpKrunt27fSs1dvWbVyhezeuUNGjBwl9+/7vUHSuUtXmTZlqhw9fEhWr1krx48fD7f2kut56+MjPcbOltXDesqe8QNlxLxVcv/xU+v6e4+fyICpi2TDyO/kwKTBsvnQSfn36s1wbTORMxjYiki6dOkkS5YskjdvXl1at24d6u/RokULGTlyZKhtb8mSJbJ7926nX4993LRpk5hJmTJldL/fBz6DW7duSVhzc3OTXLlyycqV7+567tu3Tz7++GOJFSuW1K5d2+5rXrx4IdmzZ9dz0DBlyhTreYklceLE8tlnn1nX//rrr5IzZ0593aeffiqPHj2ybgvPjxMnznsfs8jogbwWd3GTFBJDf48hHvq7Iaq4i9f/1+HneBJVnotPuLWXXNeejWulXM16+nPZGnVl76Z1dr8vXjx7d5H57MkTSZgk6QdvJ7kuZGOzZcsqKb289Du9UsWKsn7Df1n9Gzdvis/bt5IrV07x8PCQenXryqpVq8O1zeRa9p2+INnTpZSUSRJKnJgxpHLh3LL+wDHr+os370jWNF6SIG5s8fBwlxK5s8g/2w+Ea5uJnMHA9v/mzp0rhw8f1mXSpEni6t4nsPXx8dF9LFu2rEQ2HyqwhW3btkm1atX05xQpUuh7jxgxItDn9+zZU4oXL+7nsZYtW1rPSyzJkyeXxo0b67p169Zp4Ltr1y45efKkFChQQL777jtdFzNmTH1+wYIFA32/V69eibe3t5+F3nksbyWquMkquSML5aYclMeBPvepvNVAOLFE+6BtJHN4cOeWJEqWXH+O4xlPnj0JeC5VqddULp87I01L5ZEf2jaSVj37h0NLyVXdvHlTvLy8rL/j5xs3bjpYn0Ku37zxwdtJruvmvUfilTiB9Xf8fOPeQ+vvGb2SyYmL1+T63Qfy8vVrWbP3qJ/1RGbBwDYQmzdv9pM5Q7ceZHbh7t27UqlSJc3I5c6dW4MPI2Ds3r27ZtCwfP311/L69WvrNo4ePapZu48++kiaN2+uWTWYPXu2FClSRPLlyyd58uSRZcuWWV9z/fp1qVu3rvW9+vbtq1nApUuXarYObTQC8RkzZuh28ufPL6VKlZIjR47o41OnTtUgtk6dOrqdvXv3+sl++s8mf/vtt9K//7sLK/y/fv36UqNGDW33J598oseicuXK+nujRo3E1/e/sYeGS5cuSfz48aVfv34acGXKlMmavTQyFEZ2EZCJxGvg1KlTun3sL5Zx48YF2P6TJ0+kTZs2UrhwYX1O27Ztrcd6+PDhUqhQIT02+D8CPxg4cKDcuHFDGjRooOsQ+GH/OnfubN3uH3/8ocfDOG4VKlTQfURGFJ8dAkhkRrNly6bnwNOn/3XlcSRVqlTa1ujRo9tdv379ev2sjaDVnj179sidO3ekZs2a+js+3xIlSkjcuHH1dwTROAeCa8iQIRIvXjzrkjp16mC/NqKziEVuyispKQmltiSX6/JCrsm7f6+2fMQi6+WeFJUEmrklcsaB7Rsla54CMmPrERkyZYGM6NXJ7vcqEVFYSOgZR377qrHU7/e7VO0+VHKmTy0e7vybRubDs/b/jGAHy+LFix0+d+bMmZI+fXo5duyYBqu//fabPj5hwgTtcnrgwAENms6fP+8nQ4fAZM2aNRq4PXjwwLoOQRyyr4cOHZJ//vlHAzZk06BJkyYaGBrv1alTJw1gENwgiMb7oFvxjh075O+//5atW7fKwYMHZfDgwfL555/7ee+ffvpJt1OsWLEQHZv9+/fL9OnT5cyZMxpQ4v0WLFigQR72ZdWqVXZf9/jxYw06cTwQMHbp0iVYY4lq1aqlwSX2FwsCe/+6desmJUuW1CAdAR4uAkeNGqXrmjZtqp8Djs3o0aOtNx5++OEHvattZOdtb1wEBtv55ZdfdF8zZsyoAT4Cbex3tGjRZNq0afK+EOD36NFDxo4d6/B5kydP1n2LGjWq/o7zAgExMtAWi0VmzZqlnw/OreDo3bu3fkbGcvXq1ffel4gilkSRJBJN4kgUHVubWmLKPfnvJpUR/G6Ue5JGYkgGiR1ubSXXs3zWX1oICkuCJMnk/u13vUSeej+W2HHjBXj+ukVz5OOK73p3ZMyeS/89e9spMkWRE3r84KasAT/jscDX3xQvm/VEKRLH95OBxc8pEv2XwYWaJQrIjj/7y6ZR30vyRPEkU8pk4dBSovcT5T1fH2Eg2LENdJCxDUzRokU1KEVwhcxolSpV9HEEGQjIjKwcAtQxY8ZoF1NA5tPIrrVq1Up+//136dOnj1y8eFEzddeuXZMoUaJoYILHkOXbvn27BsOGJEmS2G0TAmIEeMjYGrAdIyuMbCPGETsDmckECd59ASIbjP0z9gNZ5rNnz9p9XYwYMazjQRFMI9APCoLnly9fapbUNpvrH7LNyMQiOwvYT4wtAtwgQGCP4ho4ntgm1qN7bkih3WnSpNGf0a33zZs3kizZuy97ZIMD2/eQ6Nixo54HSZMm1QDanmfPnsmcOXP8dD9HFh7ZdWTRse/IJAP2OTjwOQaWQY7skko0eSE+8kp8JJq4a/Y2u8Tx85y98kiiiJvkl/jh1k5yTZ80/kIXWDpjkmxcOl8yZM0hm5YtkMJlKgR4fpIUKeXw7u3yUa58cuvaZXn+7Kl4JkgUDi0nV1SoYEE5efKUXL9xQ+J5esradeukd6931xWAIBZ/A44dOy7Zs2eT+QsWyJ9/BCxSRpFXoawZ5MSl69rVOF6cWNrVuHeTWn6ec+ehtyRN4Cm3HjySBZv3yrrhvcOtvUTOYmAbCAQH6FpsQLBlG+wg44dAdtGiRdo9GMGUf+hu64ixvmHDhvLzzz9bM5MJEyb0837BgTv86N6MrKw9KDgRkn21fT4CVAP+ePr/HVlWexA0GfuI59m+h//fndnfhQsXandoW+iOjGAahbEQeGLcKLrZIgNuL7B19Dm/z76HBG5eYEGQivfHDQnchEBAbpg/f77kyJFDu0Tb6tChgy6AoBc3Qzw9Pd+7TZEdCkUVlgSyVG6LBV3JJYaklVg6xU9pSaSPHRZv7YC8QN5lSopIAs3sEtmqXK+xDP32S2lduagkSppc+ox6N3Rk98Y1cvb4YWnaqac0/LKLDO/1tWxZvki/M78e8Ku4sxsg2fyd+nnIT1KlajXtndS1S2dJlCiR1P70M/nzzzEa2A4f/ps0b9lCXr58JZ83aqjDoYgMUTw85Jf2DaVyt5/F12KRrg2qSaJ4caRW799kbLcvdMxt59+ny8lL17V41M/tGmr3ZCKzYWAbiAwZMsjly5d1PC2ypLZjF5FNTZkypWZgka1Fpg1jLTEeE1120QUYFyUY+4pspwHdd5HlRYCFoj94Pjx8+FC7NhvdnPE7ILhERhhdndFtFIz2IHhB91EDuiYj69u+fXvNMOKPH7okOyoeZMD4V3TpBWQ5MRa2WbNmoXYsA3tPdI9Gt2rcHEBGEhDQoXIwulUbWdt79+4FyNqisjC6CI8fP17/6OOYoe34LBDcGllWdEW25f+4oR0rVqzQ4BbBL4JlZzPbzjLGFhs9BTDmFzdO/HdDRpbfPxQNQTe058+fa1drdGmm0JFGYupiq5r81zWrnaQNh1aR2USPEVP6/hFw3tGi5SrrAomTpZCfpiwIh9aRWXxSvboutpYsXmT9uUjhwnJw//5waBmZxScf59fF1j9Dull/nt2vYzi0iih08ZZwIDAWE0ECCv6g6zGyqLbBB8Y3ousyuviiiBOygihghK66WLAOxaZsCxMhg4jxtCg8hMJKxjqMDUW2Ft16kfk1gjJAQI0xrsjWYZsYqwoYazlv3jx9DQJojDcdOnSodkdFASo8H11XgwPtRsCMdiGgxf6GNXTl/uabb/RYYZ9x9xkQpKJbNQJ/FLrCviDYtPd63CDAMcE43vLly2uAiMB10KBB+rnhM8I4WFsYo4wu4kbxKGR38Vlj39GlF8czLCD7imxq165dtWs5fv7zzz+D/Vq0FePA/cONE3zWOE4oJIVuzUREREREkY2bBX06iShUoTshssi4gRGeUP0aN1ACmzvXltFtu6Wk1nGlRM6oeWpPeDeBIoByadgNkt6f2+6AN8aJQsL72QtJWrO99vbjUC/Xx6tXojCAAlOlS5f2M8XRh4RiWchKX7hwwc+4YCIiIiKiiIhjbInCAKbgCU/opu1/nC4RERERUUTFjC0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkakxsCUiIiIiIiJTY2BLREREREREpsbAloiIiIiIiEyNgS0RERERERGZGgNbIiIiIiIiMjUGtkRERERERGRqDGyJiIiIiIjI1BjYEhERERERkalFCe8GEJFrsFgs+v/X4hveTSETe/70SXg3gSIAb29+D9H7c3v2IrybQCb35PkLP9dI5NrcLPykiEhErl27JqlTpw7vZhARERG5lKtXr0qqVKnCuxkUBAa2RKR8fX3lxo0bEjduXHFzcwvv5rgkb29vDf7xB87T0zO8m0MmxfOIQgPPI3pfPIeChjDpyZMn4uXlJe7uHMHp6tgVmYgUvrB5NzJ4cAHAiwB6XzyPKDTwPKL3xXPIsXjx4oV3EyiYeOuBiIiIiIiITI2BLREREREREZkaA1siomCKHj269OvXT/9P5CyeRxQaeB7R++I5RBENi0cRERERERGRqTFjS0RERERERKbGwJaIiIiIiIhMjYEtERERERERmRoDWyIiIiIiIjI1BrZERDYuXLggRYsWlYsXL4Z3U8ik7ty5I9WqVZMzZ86Ed1OIiIgiDQa2REQ2kiZNKgcOHJDVq1eHd1PIpOLHjy+bN2+WJUuWhHdTyKR8fX3Fx8cnvJtBEeh8IooMGNgSEdmIEyeOfPHFFzJ9+nR58+ZNeDeHTChatGjSoUMHmT17trx8+TK8m0MmDEDc3d3Fw8NDf37y5In+n7MzUkjgfLE9n4giA57pRBRpvX371nqxaHvR2KxZM9m3b5+cOnUqHFtHZoCsmr1sSJMmTeTYsWNy5MiRcGkXmZMRgFy5ckU+/fRTyZgxo34foReJm5tbeDePTATni3E+LVy4UG/WPnv2LLybRRSm3Cy8BUhEkRzGRCZOnNh6EYBgJUuWLNKoUSP58ccfw7t5ZAK4YIwZM6afzEiuXLmkQoUKMmLEiHBtG7kefMfYBh6Ay7F58+bJli1bJG7cuPL8+XOpVKmSfPfdd5IsWTIZNmyY5MmTJ1zbTeZx7tw5uXXrlvTo0UNu3rypN+Dy5s0rgwcPlpw5c4Z384jCBDO2RBTh2bt/h0Bk+PDhGnyUKFFCWrRoIevWrdN16AKIoHbu3Lm8w00BuvXZmjNnjpQuXVoKFiwo7du3l7Vr11rXNW3aVBYsWCCPHj36wK0lV7Fq1So/3z/GOYTvGAS1tuNoEeieOHFCs2v79++XAQMGSI0aNeTPP//U5+H7iMiAcyKwcdi4QVK7dm3p2bOnfP7551oMcdy4cXL37l39P1FExcCWiCIs44++/y58Dx48kH79+ukf/44dO8qoUaMkRowYGojgDz80btxYzp8/rxeYRP6za48fP5b+/fvLTz/9JOXKlZOBAwdq13ZcRCJLAg0bNtSfd+7cGY4tpw/t1atX1qD2m2++8XNjwziHZsyYIVWqVJFWrVrp95BxA61WrVqancWSMGFCfQw3TXLkyCE7duzgjbZICOdP/vz5Zdu2bX4ex80RLPgu2rRpk9y4ccO6DucMziF0acdNW6hatar2INm7d69W/yeKiBjYEpHp/+h//fXX1otHZESMDIlRfOXQoUM63tE2SEGXvsWLF0u7du30D/4nn3yiXZLnz5+vF6ZZs2aVAgUKyMyZM8Npz+hDsJeFtZedff36tfz1118ayBrSpUun5wtuktSrV0+++uorvWliFI1KkyaN9gZAEEMRHz7zVKlSaRYf5xC+V/79919JkCCB9TmHDx+WUqVKydChQyV37twSK1Ys6d27t95cAzyGoAQ32B4+fKiP4aZboUKF5OnTp9ZeJRSxIfhEZX7cLEOVddwAQe8iW1u3bpXKlSuLl5eXdO3aVcqUKaN/0yBDhgx6HkWPHt16sxaKFSumN1dWrFjxwfeJ6ENgYEtEpoY70shiGBeB+KONwPX+/fsa0KZOnVozIyjEgq7HCFhwoYlsGi4YMf4oefLk0qtXL8mcObMGIca2mjdvLsuXL9dtUcSD4MPoDoqbGcYNESM7a2TejOciK4IpfHC+xYsXT4NZBLe//fabXkii6x/+j3Po3r17+rqWLVvKmjVrdIwbRVwIQPB9gu8SZGqNzCpulv3xxx/WcwnnTb58+fS7CcEtuhljHC1uhpw9e1aiRo2qQSwqIdtm6IoUKSIpU6ZkQBLBGd9BODeMG2WAnxHgGr2QcBNl5MiRmsnHzRIUO8TfuN9//12nGgPMx47p6/D9Y8DNWnxH4buMKCJiYEtEpmT8gUeGA5m09OnTWx/HxSIuDseMGaOFMnDBiDvbU6ZMkZUrV+rzokSJos/bvn27TJw4UU6ePCmTJ0/WrsdGNeS6devK7du3ra+hiAUBLC7wUqRIoQGIbZd1FHzC+EbjJgcyHziHcOG5fv16fSx27Ngybdo0mTVrlvTt21eLtSDwRSXk48ePW7uWent7y6JFi8JpLyks4XzAdw6+T6B79+4a2GJMI+D/nTp1slbHxvfUkCFDtPsoMrUIMpDhRQBjjKFFlt/T01M2btxofR8Us8NNOlRH5o22iAs9QwAFw65fvy6nT5/W35GtR4Vs9BAB3ETBtHQ4l3BDFmOz8Xdrz5491qwtsrO40YJiZAYEughucT7u2rUrXPaRKCwxsCUi07DtImp0MwaMLUIQij/seBxj05D5wBhZFIHCRSIysrg4nDRpkr4GGTVk2pC5rV69uj6GO924SEUBIGRcMEYJBYGQZaGIFYgYmZGyZctqoIDsBwJZBLBXr17VoBXd23Hjw4CbJUmSJNEsPuAcGTRokJ4/mN4HrzXG0+IcQkCLc6d169Z6PlLEg5shxncRMmPIkiGbhvGwmAcbmVZUoEURMQMex9h+3ERDYIIgA68zuhmjy2n27Nk1C3fp0iXr67p166bfUYkSJQqHPaUPAd8hgKw+/v7gu+bFixc6vzq6uRuBLWD4zJkzZ6R48eL6HYRK2ug1gpt1uHGCoBbbwd9H3BAxFC5cWL/r8HyiiIaBLRG5HGS+jDvXBgQitgV80JUPd6cB2Q5cJBpBK/5wo4soXmMEFOjGh7Ft+AOPgj4IUPCHHZk1/OE/ePCgBjjoFoiLR+P9kdWtWbPmBz4CFBZwU8QIRPB/BLjo2onzBNl9TPmEgASZMZwr6PpnO6bxo48+0ukyjh49KteuXdPgFxec+BnnDgJiZFhQoAWZW1yQAqqQtm3bNhz3nELrhog9yNpjeEPnzp01UEXgiqy+ke1v0KCBZmMRbABulixdulR++eUXXYex2Dh/8F2E88/oiYLzzzY7i+wubtJRxIWK2B9//LHeaEMgi+7oRlEo3AzBzRMMvzG+z9BTBBlbjLdFzxEEufgeMr63cMMEvVHwfWQoWbKkbp9T/lBExMCWiFwKsqzIVuBOtC0EIijE8v3332uXYhTTQAYDEMSiirHxxxsXgMjEoRsx/sgDAmJ0wUIGzejyh+5euCBAxUlcEKCb1j///KNdtGwLvgR2QUvmgnMAWViMX0NmA8EHCqygujFgvDV+BxQPy5YtmwYbxoUkzkGcm+giaIxRQ08A/IxsLi4wMdYS5xBuziDjQhHrhoj/x9HzAzfUUFEdPUa6dOki3377rQ5fwHcZ4LsJ54yRzUcxH5xfRqCLrBxuwOE7B92SAT0AcNMF31kUceD7wf/0c8bvuNnx5Zdf6t8uZFsxLhs3YtHNGKpVq6bniTE0BkNs8HcS31n4m4ft4PsK3ZYxvAbwd+2HH37QIolEkQEDWyJyGbhQxDgidOH0XwESwagxNghBA8au4WdcWCJrhgwbMrdG4Qx0wULFUWO8EeBiEnewp06dqr+jiyguEpBxQbEWjHkzuoLZVsX1f0FL5ptvFjDOFcVW0C0UF4Po5ongExd+OFeQLUG2zYCxjsi6btiwwfoYzhMEJsZNlGbNmml2BMHy5cuXtXhLzJgx/UwNROaGzxLZ119//VUDD3wX4XsHj+OmB3qOIFsLGO7w888/6/mE7Bp6fuDGG7Jw06dP1+fgeww9RlBYDDdEUBgIQybwXWRUR44WLVq47jOFDYzFxk0SZGFtb5jBsGHDtJI26kJgiAxumGXKlEn/hiFYRQ8RjNnH3yvA3yr8vUTlflRRRsV2nKf4PsPfP3SJx3mIcwvZX6JIwUJE9IH4+vrafcze48uXL7c8fvxYf3758qUlV65cli5duljXL1myxOLp6WkZPny4/n7x4kVL2bJlLZ9//rn+fu3aNUvz5s0tVapU8bPd8ePH6/Pu3bsX4D3fvn1rty3kek6ePGnp06ePZc+ePfr769evHX529+/ft+TLl8/Su3dvi4+PT4D1HTp0sOTNm9dy48YN62O3b9+2tGjRwpI+fXrL4cOHLbt377a0atXKUr9+fUu1atUsN2/eDKO9ow8N5w7+/duzbt06S9q0aS0FChSwdOrUyZIxY0bLZ599Znnx4oXl6NGj+j20f/9+fe7z58/1/23atLHkyZNHv4dgypQplkSJEllu3bplPR+HDh1q+fXXX62PUcSG752pU6dasmTJoudT4cKFLb/88ovlzp07uj5DhgyW0aNHW7/P4Pfff7ckSZLEcurUKf198+bNlqhRo1pOnDihv2/cuNFSpkwZS7JkyfR8w7lKFJkxsCWiML9gtBdI2AtCtmzZon/Ir1+/bnFzc7NMnz5dH8cf/nTp0lnmzp1rfe6zZ88srVu3tuTMmdMa/OJCMWnSpNZtY1u4mNy3b5/1dXhecNpCrgvnRYwYMSwNGjSwnDlzxs+606dPWwYPHmz566+//ASeixcv1ovJXbt26e/GOfnmzRv9//Hjxy3u7u6WTZs2BQigP/74Y73ojBIliuXHH3/0E/xSxIbvi2LFilmGDBlifQw3OTw8PCwjR47UoLREiRKWb7/91s/5hBtucePGtaxZs0Z/x400fKfNmzcvnPaEPoTAbo7A9u3bLcWLF9dgFt8h+I4qXbq0pUePHrq+du3aesPE9jzCDVt8L02bNs164xVBrO1NXvx9fPDgQZjvG5EZsK8UEYUpo+ATxrtOmDBB52tEFyyj+5Ux9gxFVzBvLArxYBwsxkAaFSBR7AlTshhTaOCmHLpYVaxYUccfYZwRumVhPBHey+hqjO6mX3/9tZ8qokZXY9txs7bTvJBrQ1dgdBlGN3KMR0RBJ8BcjhiDhiq06DqMbn0ozGOMhcXnjfG1KBAFRldhY5oWdFFGN9KxY8fqWEl0V8YYR4yzRRfmv//+W7slY4w3zkUyL3RV9z9uHmPxMT4WXUHRzRznmTGOEQWb0AUUBeo+//xz/d7BOYBzCd9V+B3dQ9FFHecTuoBiSAS6j+K8ef78uX4HYfwj5j6miFtUzBi2gmEyRldjA8a9YjgMxvLj/MG5g7oRmPcaY28xnAbnGLq5G99L6OaO90C3dhQSw98q/E3DGFxjbC66tdvWhCCKzBjYElGYQrXhKlWqSNq0afUPOMafIRhBgIA/5qg6jGIZKOSDgAWVQjGWCMVYMHYRgS6CDlwIoBotLhaNQBRjccGYSgPvgTFrmJPWmMevX79+1jlubXHcrHngAs4ouoJK1phmB0Hm6NGjpWfPnhqw4gYJggdcKCKwReVZnDMY8wrlypXTAANTqNhuFwVacI4BikghOEFwjHGPuBkDGIeLStvGxSaZE84h46YG/v0b46UBY6QRiCBAQOCA7ynAOYACPuXLl9egF2NfMcYWN9lQFArziaJaLcYwYhwtxuCiKjZuquEGG27Q4SYcoPAYRQz/7/EYoKjY7t27dVwsKg/Xr19fv6MA5xnG1aI6P8ZWY0o6FBnDzygehu8WnF+ohN2iRQstYGhM04MbdBh/je89o+ghgmPekCWyI7xTxkQUcWEMWr169SwNGzbULlWALlgYVxYtWjRLx44ddaxZ7NixLVWrVvXzWnQ1RjfiESNG6O8TJ07UbsfoCopupFjfuXNnHfeWKlUqfQ4et9fV2F5XaDJnt74LFy5YMmXKZIkePbolfvz4lt9++0277Xl7e1vHMy5YsEDHVuM5Xl5elp07d+rjderU0XFtGJdmmDVrluWnn36ynieXL1+2nD179oPtI314//77r6V69eo6VrFy5cr6/fTVV19Zx8hiSAO+kwzJkyfX59y9e9f6GLqEomup0XUd329//vmnpWLFipbvvvuOXUMjCXzv4DsIf5cw7hXfJRhPfenSJUv79u21O7pRzwHdjtGFvVGjRjpW1hiPDQ8fPtT/Y6gEuiunTJlS/0Z++umnlqdPn1q7JhORYwxsiSjMjBkzRoML/MG3LRKFP9Io4oMxZ7gAKF++vI4vQrEe20AUY2gLFSqkPyOQNbZXtGhRS4oUKSyffPKJFpmKFy+en2AEr+e42Yh1gwTBBoqu4JxAgTBcME6aNMnP83BxiAAka9asen79/fffeuPDGI+G8be40RInThzdBraH8+iPP/5wODaOXN+VK1d0DLVRTMyelStX6s0xnBsIPrdu3apFnvA9hPGOhnPnzulNEwQogHMuf/78Oj7WGOeIIj0IUHDDjSKG4PzdMNZj7DRqN6BwE4rOobhhmjRpNHg1ioFhjH/mzJn1fAOM08ZN2IMHD/rZ5urVqy3du3e3bvvVq1eWDRs2cCw/kRMY2BJRmEDwimC1YMGCfh43glZUmEVGFkVWcFGZLVs2a2Ef4w/8jh07tEjQkSNHrK9H9VEU30BVZKPKMS4oDhw48AH3jkITzgnbwNL4/BHQ4sYGikEhiECgamQ/cFOjVq1afgpETZgwwZI6dWrLsWPHrBeICF5xI8SoMvrkyRPLwoULLV27dtWgxHiczA03NRC0fvnll4H20sBzEMTiHEHWFpANQ/BhFPAB9PrADRIUjQJk8b/++mvN8KK4D84p3ExDj5OrV69+sH2ksOE/mMXNVtwEcwTnEaqlG0XFULUYmVb0FDG+U/CdhqAW5xsg44/nZM+eXb970HME5xWC4kGDBum5SETvh4EtEYUZBCU1a9a0drOyhT/ymDIFF4/okoUuo8ic+b/gQJdA24tOMC4ckFlBF2ZMwUKuKyTZc6PLuu05hItIdPczglWYP3++VsDetm2b9SKyb9++ej4Zz1m0aJFmb2PGjOmnojZFzPMK5whultlj3DipVKmSniO2XYVx3qB7O256GHDjDL1DjOwbvnNwMw49B5DJ5Q2RiAV/o3AD7aOPPrLkzp1buwDj747xXWIwugSjCja+l2yn10G1dtzwsM20ogcBuh8bN20xlAJ/r9BlHb1FEAivXbv2g+0nUUTH4lFEFGZQTOXYsWNazdE/VBQ1qpPGjBlTi/Ns27ZNiwAB1qE4BqpBolCGAQU0+vbtqwWncubMqc9BNVNyXUaRExR8wudtVPM0oOBTw4YNtUgT/o9iPEaRp86dO+v/UUAMokaNqv+vW7eubhdFolCFFgVcMmbMqOcPqmuj+NNvv/0mHTp0kOnTp2vFbIo4hcTAf/GcypUr6/cDCu0Yz/UPhXlQndj4noEmTZrIhQsXtCKtAUXo8Ppx48ZZzzsUFevevbtuwzgPyVzFnuxB1X2cA6h+js8XVbHxvYHvIv9FBo1q6igcZvydMtSoUUN/X7VqlfUxVEHGeTNq1Cj9HYUMJ02aJLNmzdJiZXguqmoTUehgYEtEYQZVHi9fvixbtmyR169fB7gQQGXRvHnzWp+7evVqOX/+vJ8LCAQkxnQ9uDBBxWRUHK1Tp45OxYEpWYygh1xXiRIltNIsLhQRkKC6NTx8+FAGDhyony2qYg8aNEirXbdv317X4+ISFUPPnTunQTFeawQ2mN5n7dq1emFqBLuoQvr48WO9aERFbFS4xeOoRkrmh8/fqE6NKZ7wfWGcD6iKXqZMGRk/frz+bhvIGAFKo0aN9LsI30nGNC2o0o4K6piyx4CbLPPmzdOAh8wLf2+M6sX+b4QYU/X06dNHz6PJkyfrNGIIPlHZOl++fIEGtvi7he8UVPNHZXVAReNPPvlEp3gyzi1UccdUUcbfNQOm6GGVdaIwEN4pYyKK2EqWLGnJkCGDny5bMHr0aEvGjBmtXbTQtQ9jau1hISjzsS0UBqhgjS5+ffr00QIqTZo00cdxXqBLnjEmEuMZW7Zsqd38jIqz6M6OrntG91Fjm6h27O7ublm8eLHd9ybzsx0ri5/x2aOIHLqhJ06c2JInTx49l4zPfOrUqdqF2LZbscE4b+rWrasF61CR3TBs2DCtfowqtxTxHD161NKrVy/LgAED/PydOXnypH7/jBw5MsBrAvseMc4jows7vrMMKCqF767jx49bH/PfnZmIwg4ztkQUpoYPH66TyaObILqIYl5RdCNG9q5Tp05StGhRfR7uXqPrsj2cr888jEyF8Zkhw4EM2c6dO7UL6Pz58zVDMmbMGF2P7ufI1qOrHjIk6F6OuUORPcufP78+B12T8Twj62FkOpBlQzc+zD1qi+dLxIHzBxn42bNna1f2U6dOyYgRIzSzf+TIEendu7fOA9qtWzedp7hSpUo6byzmmvWftTWybTifNm7cqOejAY9dvXpVM2xk/q7G+BlDFH799VfNwOK7Ahn+rVu36pzEyMYDsv3o8WH87bHtURTY94iRxUWvEvRIwnYN+NuGx+PEiWN9DHMfE9GHwcCWiMIUug2juygCXAQk6G6Ki4y9e/dqYGtgMGJuxkWlcdF34MABHf+KYAIXdhgHnSpVKh2H9uWXX4qnp6c+Dzc9pkyZouNgmzVrpmOy0b28adOmOvYaELzi3MEYOKPbqXEBiu7rpUuXDqe9ptA4ZxCgnjlzJsD6zZs369hX3PDAjQ8EIDhP0OXz008/FS8vL2nQoIHeKMH3CW5+pEiRQruoT5w4McD2jMAW5wu+g2y7gkaPHp1dQ03I+B7w39UYP+NGWM+ePbV7+t27d3U8K/4WIdCdMGGCPHjwQG+a4EYIzh8IbByuLWwb74vzD12K58yZo0E0YOz1n3/+qd3iiejDY2BLRGEO42K/+eYbLcSCsW0//fSTXhQY45/IfPx/drjYw0Xijh07tPAOsiIosIKAFhlYjJVFJmPBggUarBhq166tAQWKteC5xgUhsmc//PCDBsiAQBeM9zSCFDIvnDP4fBGkbtiwQR9DcIpic3i8XLlyOsb1u+++kz179mhxMGTIELyi+JzROwAZf2zr0KFD+vvnn38uBw8e1HPI3rhKwHkaWA8RMg/jewABa6tWrXQMNbL5GPeK2gv4jPH3B9l+4/kIRu/cuaNZ1aRJk2qBJ4yLBXt/j1ALAkGw7XojoEahMtx0iREjxgfbZyIKHK8MiOiDMSqJGpVxcZHBTK05GZ+dcaE3duzY/7V3NyE27nEAx5+7lZoaC6uxkJfMxkRNTLFSFEkzsqNMJjYSKQo1Ql7LZpIk0TSr8U6xUDbExoKQJjEhxNTIy4p6bt/f7X869+C63WtenvN8PyWM49w73X/PPb//7y0CDCYRMzX21atXMc368uXLlbLQrq6uCDbS9Fk+HBKkEIhQor5169YISChDJntLFi99YCQLwoWI02iLrXYq9ty5c7OpU6dmPT09EXCQTX3y5El8jaE7BBWUdyb8muwamftUHUD5+ocPHyrPEkrYKSnmTKH2Akb1g4tSpg5zAULmlQs1LkEePXoUf86lyd27d7PBwcEoP+cZxeUJVQBUkjA4bMmSJdEqcfPmze+y9lSE8BzjTFafn/S62bNnx7mVND78QaPtWP9LSJLGrzRVtBpZtUOHDkVZKH2OrOehLJQPi3ywbGhoiNeRQSF7QuBClp6eajJvTK5NfWhkQ5hISq/kmzdvoid37dq1sbKHzJyKjQuMn2XYL1y4EC0JBKasWiFLn84cE6537twZq3lS7ysBSnNzcwStnZ2d8b5kcWl5YLo2Ze4Ez5wnytyXL18+qt+rRg/PIJ45ZF25UOOSrNbr16/jooP+a55JTDum3YFqAC5OmLrP+eI5xZT99evXR6DLeWPVHBdz9G1T7i6pAEZwMJUkqY68e/eu8uv379/nK1asyBcvXlz5WkdHRz5//vx8aGio8rXjx4/n8+bNy/v7++P3vb29eUNDQ3727Nn82bNn+dGjRyuvZSLt4ODgqH0/Gn19fX15Z2dnnIs0LfbevXt5a2trvn///r9No2Vi7YQJE/KLFy/G7799+xY/b9u2LW9qaor3uXr1apzBRYsW5cPDw2P2fWn0HTt2LCZgv3z58rs/4wylidrt7e15W1tbPjAwUJlq3N3dnTc3N+c9PT3xtefPn+cbN26MCclz5szJGxsb85aWlvzMmTOVcydp/LMUWZJKPkE0IdOV+harkXFlaizlfqm3jEwq2Q+GsjBpFAsXLow/J2ObMPiJwTzpa7wH5YDbt2+PzBtZ2tS/RpbEoSvF9qPzwxAfhj4xJIysKv2Ou3btip5rsvNk1Bjowxkh+5qqA/gambU0CCqdWf7uvn37oqydPcVk6ihVp3pA5cBZ4NlBKTBD6WpVt0lQjkxPLWcrlRHz/GGS9pYtW7LTp09Hdp8qgAcPHsTPlDLTs01LRO0uW0njl4GtJJV8gmjCBzh+fPr0KfrQCGhBYEq535cvX6JfLWFIFNON+YCJpUuXRmBz586dymvolSSAJWhhVUvqx2WSKMOmbty4kTU2No74966RuxCpPlu1QQC9sASdDAfr6+uLIT+s7mHAD72yDBMD68AIVNN0Wt6P/mr6r5mO/PHjx0pfI8OAGCbGyhYGkREwT58+fYS/e40nPL+YRMxl2NDQ0E9fg46Ojngucba4SAEtE5Syc7nC6rG0socLO8qTCXQlFY+BrSSVeIIoma+vX7/G1xnWRE8iw1DYOUy2lWAE/JoPivSdJQztIWjlAyNBL72zs2bNimxH9eRjPiiSVUvZPDJrDA1yv2N9XIiks8WFCH2x9FyT7SKIIBhlINSkSZOylpaWbMqUKZVLEM5KOl9k8QlkU2Cbzipnh/5IMr61zNCWG4PEyLDSR/sjnCGebawN4wwyaIoebaRn0cGDB2M+QNqnLqnYDGwlqcQTRMnAPnz4MP6ckk/Kgvk9k4wJWhnGQ6Da2tqaTZs2LSYaM+gHvAeBytOnTyPDmwJgsh/8sxICaN6PQFj1dyEC/vtyPphoTXaeXbIEuGCwE6tXUsYeDBIj2CAwYXgPGTJ2y7I+hfemfJQdpJwvvkbmVqrGGeNZxN5rLtZQXVHAQKnu7u74NeeJieusHkPK/rumR6ovBraSVJIJonv27Ims6v379yOztm7duuzKlSux+oKsB4Etk4gJUCgzZu/w5MmTsxMnTkSJKT201T21YIoxpYBpDySZOAJnMm2JO2fr80IkBapchnBWKPnk4uPSpUux25MfBMMEsWTXWN2T+hzJ/BLwUvpJWTooV6ZSgPJk1jqx+xhMqbVcXbXozWYqMlnX3t7eSuk7lQJMM75161a8BlSicF4XLFgwxv/WkkaS634kqQToa928eXNkV2uHrVBqSn8jGVVKjdva2qJ/jWwGGY9z585F3ywBLFk0ghcCWT4oshuS15EBOXz4cAQ+KtdKFdakkN0n0z9z5szK1ynvJFPLxQjnZ9OmTREccw7TezP8ifM0MDDwy9VAUi32Ze/evTvWO1HazjApLt54HnFRwiopnk8/Wlkmqf4Y2EpSneMxv2zZsghMqycWVyPg7erqit7XI0eORNYj7aSlZPTt27fR00hZMgEKwQzZEbJyZGnpY1O5LkRSsMBeULK4ZM0YAkVPLBccnCP+/uPHj2P4E6XJL168iCxuwkXK58+fI9sr/Ve0QlDWzgRunlfsqJVUPn81GUiSSjNBlPLPWvQ4UqbHhNkDBw5UBjudP38+mzFjRqWfkgwc02gZFORqnnKvVEmYUkxZMeeCwDadHcreh4eH430YSEZGjfcj0CXDC14v/V88uywzlmS9jySVwK8miE6cODHKRFnfQwkp/bbsc+zv74++WwKTVOBDv6NBbf37NytV0NTUFH2wDJDijKVS4pMnT0Y2P1m1alV2+/btCGotFpMk/W4GtpJU8gmi/Ex/7LVr12KvLD22BLX0re3YsSOGTMEetfL5pwuRdB4Y9MTlByWgBLgrV66MLC892JS3p8mzBMBkcav/riRJv4s9tpJUEqtXr44pyJQab9iwIcqL+V/A9evXs1OnTmVr1qzJ2tvb47WUGpOpU7mxIoUMPgN6GMRD2XH1IB76aLkw2bt3b0xHZicoU5EpWWc1kOtUJEmjxcBWkkrCCaL63Rci9GRTwu7wJ0nSWDOwlaSScYKoRuJCRJKksWRgK0mSfskLEUnSeGZgK0mSJEkqNKciS5IkSZIKzcBWkiRJklRoBraSJEmSpEIzsJUkSZIkFZqBrSRJkiSp0AxsJUmSJEmFZmArSZIkSSo0A1tJkiRJUqEZ2EqSJEmSCs3AVpIkSZJUaAa2kiRJkqRCM7CVJEmSJGVF9ic8nIq+6+XjnQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 940x470 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    control = list(dataset.target_names).index(\"Control\")\n",
+    "    crc = list(dataset.target_names).index(\"CRC\")\n",
+    "\n",
+    "    # Constrain counterfactuals to the control class's plausible range.\n",
+    "    bounds = mf.plausible_range(Xc_train, yc_train, reference_class=control,\n",
+    "                                q=(0.05, 0.95))\n",
+    "    cf_bounded = mf.explain_counterfactual(\n",
+    "        cf_model, query, background_data=Xc_train, y=yc_train,\n",
+    "        total_CFs=3, class_names=list(dataset.target_names),\n",
+    "        permitted_range=bounds,\n",
+    "    )\n",
+    "\n",
+    "    if cf_bounded.n_counterfactuals == 0:\n",
+    "        print(\"No counterfactual found within the control-plausible bounds \"\n",
+    "              \"for this sample (try wider bounds).\")\n",
+    "    else:\n",
+    "        print(\"concordance with Control — unbounded: {:.0%} | bounded: {:.0%}\".format(\n",
+    "            mf.counterfactual_concordance(cf, Xc_train, yc_train, control),\n",
+    "            mf.counterfactual_concordance(cf_bounded, Xc_train, yc_train, control)))\n",
+    "        mf.plot_counterfactual_heatmap(\n",
+    "            cf_bounded, Xc_train, yc_train,\n",
+    "            reference_class=control, comparison_class=crc, top_n=12,\n",
+    "        )\n",
+    "        plt.show()\n",
+    "except ImportError as e:\n",
+    "    print(\"Plausibility section skipped —\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e429ca",
+   "metadata": {},
+   "source": [
+    "### Cohort-level counterfactual importance\n",
+    "\n",
+    "`mf.counterfactual_importance()` aggregates counterfactuals across many samples\n",
+    "to rank **which taxa most often have to change to flip predictions**, with a net\n",
+    "direction — a local-aggregated importance that complements the global feature\n",
+    "importance from section 7."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1516f6ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-12T17:08:04.528316Z",
+     "iopub.status.busy": "2026-07-12T17:08:04.528226Z",
+     "iopub.status.idle": "2026-07-12T17:08:28.985085Z",
+     "shell.execute_reply": "2026-07-12T17:08:28.984819Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
      ]
     },
     {
@@ -1279,7 +1033,69 @@
      "output_type": "stream",
      "text": [
       "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
       "100%|██████████| 1/1 [00:00<00:00,  2.45it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.44it/s]"
      ]
     },
     {
@@ -1310,7 +1126,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.45it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  1.97it/s]"
      ]
     },
     {
@@ -1318,7 +1134,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.45it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  1.97it/s]"
      ]
     },
     {
@@ -1341,7 +1157,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.10it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
      ]
     },
     {
@@ -1349,7 +1165,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.10it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.46it/s]"
      ]
     },
     {
@@ -1372,7 +1188,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.44it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.52it/s]"
      ]
     },
     {
@@ -1380,7 +1196,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.43it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.52it/s]"
      ]
     },
     {
@@ -1403,7 +1219,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.31it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.19it/s]"
      ]
     },
     {
@@ -1411,7 +1227,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.31it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.18it/s]"
      ]
     },
     {
@@ -1434,7 +1250,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.05it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
      ]
     },
     {
@@ -1442,7 +1258,193 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00,  2.04it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.52it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.52it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  2.15it/s]"
      ]
     },
     {
@@ -1486,7 +1488,7 @@
        "      <td>Gemella morbillorum [1302]</td>\n",
        "      <td>8</td>\n",
        "      <td>0.533333</td>\n",
-       "      <td>3.213718</td>\n",
+       "      <td>3.272303</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1494,24 +1496,24 @@
        "      <td>Peptostreptococcus stomatis [1530]</td>\n",
        "      <td>8</td>\n",
        "      <td>0.533333</td>\n",
-       "      <td>2.920292</td>\n",
+       "      <td>3.077608</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
+       "      <td>Escherichia coli [390]</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0.533333</td>\n",
+       "      <td>-1.753140</td>\n",
+       "      <td>decrease</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
        "      <td>unnamed Parvimonas sp. oral taxon 110 [1506]</td>\n",
        "      <td>7</td>\n",
        "      <td>0.466667</td>\n",
        "      <td>2.684563</td>\n",
        "      <td>increase</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Escherichia coli [390]</td>\n",
-       "      <td>7</td>\n",
-       "      <td>0.466667</td>\n",
-       "      <td>-1.361622</td>\n",
-       "      <td>decrease</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1523,30 +1525,14 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>Eubacterium rectale [1630]</td>\n",
-       "      <td>6</td>\n",
-       "      <td>0.400000</td>\n",
-       "      <td>-0.976407</td>\n",
-       "      <td>decrease</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>Streptococcus australis [1420]</td>\n",
-       "      <td>6</td>\n",
-       "      <td>0.400000</td>\n",
-       "      <td>-3.505908</td>\n",
-       "      <td>decrease</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
        "      <td>Parvimonas micra [1505]</td>\n",
-       "      <td>5</td>\n",
-       "      <td>0.333333</td>\n",
-       "      <td>4.751266</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0.400000</td>\n",
+       "      <td>2.929836</td>\n",
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
+       "      <th>6</th>\n",
        "      <td>[Ruminococcus] gnavus [1611]</td>\n",
        "      <td>5</td>\n",
        "      <td>0.333333</td>\n",
@@ -1554,12 +1540,28 @@
        "      <td>increase</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9</th>\n",
+       "      <th>7</th>\n",
        "      <td>unclassified Fusobacterium [1482]</td>\n",
        "      <td>5</td>\n",
        "      <td>0.333333</td>\n",
-       "      <td>1.689221</td>\n",
+       "      <td>1.717173</td>\n",
        "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Eubacterium ventriosum [1629]</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.333333</td>\n",
+       "      <td>0.739660</td>\n",
+       "      <td>increase</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>Eubacterium rectale [1630]</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.333333</td>\n",
+       "      <td>-0.451476</td>\n",
+       "      <td>decrease</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1569,26 +1571,26 @@
        "                                        feature  n_samples  frequency  \\\n",
        "0                    Gemella morbillorum [1302]          8   0.533333   \n",
        "1            Peptostreptococcus stomatis [1530]          8   0.533333   \n",
-       "2  unnamed Parvimonas sp. oral taxon 110 [1506]          7   0.466667   \n",
-       "3                        Escherichia coli [390]          7   0.466667   \n",
+       "2                        Escherichia coli [390]          8   0.533333   \n",
+       "3  unnamed Parvimonas sp. oral taxon 110 [1506]          7   0.466667   \n",
        "4                  Clostridium symbiosum [1600]          6   0.400000   \n",
-       "5                    Eubacterium rectale [1630]          6   0.400000   \n",
-       "6                Streptococcus australis [1420]          6   0.400000   \n",
-       "7                       Parvimonas micra [1505]          5   0.333333   \n",
-       "8                  [Ruminococcus] gnavus [1611]          5   0.333333   \n",
-       "9             unclassified Fusobacterium [1482]          5   0.333333   \n",
+       "5                       Parvimonas micra [1505]          6   0.400000   \n",
+       "6                  [Ruminococcus] gnavus [1611]          5   0.333333   \n",
+       "7             unclassified Fusobacterium [1482]          5   0.333333   \n",
+       "8                 Eubacterium ventriosum [1629]          5   0.333333   \n",
+       "9                    Eubacterium rectale [1630]          5   0.333333   \n",
        "\n",
        "   mean_delta direction  \n",
-       "0    3.213718  increase  \n",
-       "1    2.920292  increase  \n",
-       "2    2.684563  increase  \n",
-       "3   -1.361622  decrease  \n",
+       "0    3.272303  increase  \n",
+       "1    3.077608  increase  \n",
+       "2   -1.753140  decrease  \n",
+       "3    2.684563  increase  \n",
        "4    5.896304  increase  \n",
-       "5   -0.976407  decrease  \n",
-       "6   -3.505908  decrease  \n",
-       "7    4.751266  increase  \n",
-       "8    2.819815  increase  \n",
-       "9    1.689221  increase  "
+       "5    2.929836  increase  \n",
+       "6    2.819815  increase  \n",
+       "7    1.717173  increase  \n",
+       "8    0.739660  increase  \n",
+       "9   -0.451476  decrease  "
       ]
      },
      "metadata": {},
@@ -1612,7 +1614,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8137e587",
+   "id": "76924899",
    "metadata": {},
    "source": [
     "## 9. Compare algorithms\n",
@@ -1623,13 +1625,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "2ffe695e",
+   "id": "8412a2e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T16:40:20.760055Z",
-     "iopub.status.busy": "2026-07-12T16:40:20.759977Z",
-     "iopub.status.idle": "2026-07-12T16:40:21.163180Z",
-     "shell.execute_reply": "2026-07-12T16:40:21.162898Z"
+     "iopub.execute_input": "2026-07-12T17:08:28.986808Z",
+     "iopub.status.busy": "2026-07-12T17:08:28.986658Z",
+     "iopub.status.idle": "2026-07-12T17:08:29.390088Z",
+     "shell.execute_reply": "2026-07-12T17:08:29.389825Z"
     }
    },
    "outputs": [
@@ -1655,7 +1657,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ff3792f",
+   "id": "7f322622",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/src/microfactual/explainability/counterfactuals.py
+++ b/src/microfactual/explainability/counterfactuals.py
@@ -254,10 +254,15 @@ def explain_counterfactual(
         return raw
 
     feature_names = list(background_data.columns)
+    # Iterate over query rows (not over cf_examples_list): DiCE may return fewer
+    # examples than queries — or an empty list — when it finds no counterfactual.
+    # We must still return one CounterfactualResult per query row.
+    cf_examples = list(getattr(raw, "cf_examples_list", None) or [])
+    n_queries = len(query)
     results = []
-    for idx, cf_example in enumerate(raw.cf_examples_list):
+    for idx in range(n_queries):
         original = query.iloc[idx][feature_names].to_numpy(dtype=float)
-        cfs_df = cf_example.final_cfs_df
+        cfs_df = cf_examples[idx].final_cfs_df if idx < len(cf_examples) else None
         if cfs_df is None or len(cfs_df) == 0:
             cfs = np.empty((0, len(feature_names)))
         else:
@@ -277,7 +282,8 @@ def explain_counterfactual(
             )
         )
 
-    return results[0] if len(results) == 1 else results
+    # Always return a single result for a single-row query (never a bare list).
+    return results[0] if n_queries == 1 else results
 
 
 def counterfactual_importance(

--- a/src/microfactual/explainability/result.py
+++ b/src/microfactual/explainability/result.py
@@ -144,7 +144,12 @@ class CounterfactualResult:
             absolute change.
 
         """
-        indices = [cf_index] if cf_index is not None else range(self.n_counterfactuals)
+        if cf_index is not None:
+            indices = [cf_index] if 0 <= cf_index < self.n_counterfactuals else []
+        else:
+            indices = list(range(self.n_counterfactuals))
+
+        columns = ["cf", "feature", "original", "counterfactual", "delta", "direction"]
         frames = []
         for i in indices:
             cf = self.counterfactuals.iloc[i]
@@ -165,7 +170,13 @@ class CounterfactualResult:
             )
             frames.append(frame)
 
-        result = pd.concat(frames, ignore_index=True)
+        # No counterfactuals (or none changed) -> return an empty, well-typed frame
+        # rather than crashing on pd.concat([]).
+        result = (
+            pd.concat(frames, ignore_index=True)
+            if frames
+            else pd.DataFrame(columns=columns)
+        )
         if cf_index is not None:
             result = result.drop(columns="cf")
         return result

--- a/test/test_explainability.py
+++ b/test/test_explainability.py
@@ -155,6 +155,28 @@ class TestExplainCounterfactual:
         assert hasattr(mf, "explain_counterfactual")
         assert "explain_counterfactual" in mf.__all__
 
+    def test_returns_single_result_when_dice_finds_nothing(self, sample_data):
+        """Empty cf_examples_list -> one empty CounterfactualResult, not a list."""
+        from microfactual.explainability import counterfactuals as cf_mod
+        from microfactual.explainability.result import CounterfactualResult
+
+        X, y = sample_data
+        model = _ThresholdModel()
+        raw = MagicMock()
+        raw.cf_examples_list = []  # DiCE returned no examples
+
+        with patch.object(cf_mod, "DiCEExplainer") as MockExplainer:
+            MockExplainer.return_value.explain.return_value = raw
+            result = cf_mod.explain_counterfactual(model, X.iloc[[0]], X, y)
+
+        # Must be a single (empty) result, never a bare list (which broke callers
+        # with AttributeError: 'list' object has no attribute 'changes').
+        assert isinstance(result, CounterfactualResult)
+        assert result.n_counterfactuals == 0
+        assert result.changes().empty  # does not raise on pd.concat([])
+        assert result.changes(0).empty
+        assert result.n_changes == []
+
 
 # === Sparsification & result object (no DiCE required) ===
 


### PR DESCRIPTION
Fixes the `AttributeError` that surfaced in the notebook as **"No in-bounds counterfactual for this sample — AttributeError"**.

## Root cause
DiCE's genetic search is stochastic and sometimes returns an object with an **empty `cf_examples_list`** (rather than raising). In that case `explain_counterfactual`'s final line —
`return results[0] if len(results) == 1 else results` — returned a bare **`[]`** for a single-row query. Downstream, `counterfactual_concordance([])` / `plot_counterfactual_heatmap([])` called `[].changes()` → `AttributeError: 'list' object has no attribute 'changes'`. The notebook's broad `except Exception` caught it and printed the misleading "No in-bounds counterfactual … AttributeError".

## Fix
- `explain_counterfactual` now iterates over **query rows** and always returns one `CounterfactualResult` per row — a proper empty result (`n_counterfactuals == 0`) when DiCE finds nothing, never a bare list.
- `CounterfactualResult.changes()` handles zero counterfactuals (and out-of-range `cf_index`) instead of crashing on `pd.concat([])`.
- Notebook: checks `n_counterfactuals == 0` explicitly with a clear message, and **drops the broad `except`** that masked the bug; `total_CFs` bumped to 3.

## Verification
- New regression test (empty `cf_examples_list` → single empty result, `changes()` doesn't raise).
- Notebook re-executed end-to-end: **0 errors**, heatmap renders (unbounded 96% / bounded 100% concordance).
- **80 tests pass**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)