### PR TITLE
docs: update stale old repo name (ML_Microbiome_Package -> MicroFactual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the unused `BaseModel` abstract base class (it was exported but never implemented — `MicrobiomeClassifier` follows sklearn's base classes) and the orphaned pre-rename `src/microbiome_ml` package artifacts.
 
 ### Fixed
+- Updated stale references to the old repository name `ML_Microbiome_Package` (README CI badge and citation, `CITATION.cff`, `Makefile`) to the current `MicroFactual` repo.
 - **Clean import**: `import microfactual` no longer emits `DeprecationWarning`s. The functional implementations moved to non-deprecated modules (`core.processing`, `models.training`, `visualization.roc_io`); the deprecated `data_processing` / `modeling` / `visualisation` modules are now thin re-export shims that warn **only when imported directly**.
 - **Feature names (T2.3)**: `MicrobiomeClassifier.predict`/`predict_proba` no longer strip DataFrame column names, removing sklearn's "X does not have valid feature names" `UserWarning` and keeping downstream sklearn tooling working (test-suite warnings dropped from ~32 to 2).
 - `explain_counterfactual()` discards DiCE rows that don't actually flip the prediction, so results never contain zero-change "counterfactuals" (previously the default could yield `validity < 100%` and an empty `changes(0)`).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "MicroFactual: Interpretable, sklearn-native counterfactual explanations 
 type: software
 version: 0.2.0
 license: MIT
-repository-code: "https://github.com/simeonhebrew/ML_Microbiome_Package"
+repository-code: "https://github.com/simeonhebrew/MicroFactual"
 authors:
   - family-names: Hebrew
     given-names: Simeon

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for ML_Microbiome_Package
+# Makefile for MicroFactual
 
 .PHONY : venv activate install run test clean help
 # Variables
@@ -34,7 +34,7 @@ clean:
 
 # Help
 help:
-	@echo "Makefile for ML_Microbiome_Package"
+	@echo "Makefile for MicroFactual"
 	@echo "Targets:"
 	@echo "  venv       - Create a virtual environment"
 	@echo "  activate   - Instructions to activate the virtual environment"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![CI](https://github.com/simeonhebrew/ML_Microbiome_Package/actions/workflows/ci.yml/badge.svg)](https://github.com/simeonhebrew/ML_Microbiome_Package/actions/workflows/ci.yml)
+[![CI](https://github.com/simeonhebrew/MicroFactual/actions/workflows/ci.yml/badge.svg)](https://github.com/simeonhebrew/MicroFactual/actions/workflows/ci.yml)
 
 **Interpretable, sklearn-native counterfactual explanations for microbiome classification.**
 
@@ -273,6 +273,6 @@ If you use MicroFactual in your research, please cite:
   title = {MicroFactual: Interpretable Microbiome ML},
   author = {Hebrew, Simeon and Adu-Gyamfi, Lawrence},
   year = {2025},
-  url = {https://github.com/simeonhebrew/ML_Microbiome_Package}
+  url = {https://github.com/simeonhebrew/MicroFactual}
 }
 ```


### PR DESCRIPTION
The GitHub repo was renamed `ML_Microbiome_Package` → `MicroFactual` (confirmed via `gh repo view`). Updates the lingering old-name references:

- README CI badge URL + citation URL
- `CITATION.cff` `repository-code`
- `Makefile` header comment

Left intentionally unchanged:
- The `CHANGELOG.md` line documenting removal of the old `src/microbiome_ml` package (accurate history).
- Domain classes `MicrobiomeDataset` / `MicrobiomeClassifier` — "microbiome" there describes the data domain, not the old project name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)