### PR TITLE
spec-004: docs site — rewrite landing page, preprocessing guide, warning-free build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`mf.counterfactual_importance()`**: cohort-level aggregation that runs counterfactuals across many samples and ranks taxa by how often they must change to flip predictions, with a net direction — a local-aggregated importance complementing global feature importance.
 - **Counterfactual plausibility & visualization**: `mf.plausible_range()` derives per-taxon bounds from a reference class (feed to `permitted_range` to keep counterfactuals in-distribution — cuts overshoot); `mf.counterfactual_concordance()` scores how well a counterfactual moves toward the reference-class median; and `mf.plot_counterfactual_heatmap()` visualizes a counterfactual against the class medians in reference-SD units.
 - Counterfactuals methodology documentation page (`docs/counterfactuals.rst`) covering assumptions, interpretation guidance, and limitations.
+- **Documentation site** published to GitHub Pages (<https://simeonhebrew.github.io/MicroFactual/>): rewrote the landing page around the counterfactual-first API, added a preprocessing-rationale guide (`docs/preprocessing.rst`), and added a docs badge + link to the README. The Sphinx build is now warning-free.
 - `CITATION.cff` for GitHub "Cite this repository" support (paper DOI placeholder pending).
 - End-to-end feature-tour notebook (`notebooks/00_End_to_End_Feature_Tour.ipynb`) exercising the full public API on the shipped Zeller 2014 CRC dataset.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/simeonhebrew/MicroFactual/actions/workflows/ci.yml/badge.svg)](https://github.com/simeonhebrew/MicroFactual/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-live-blue.svg)](https://simeonhebrew.github.io/MicroFactual/)
 
 **Interpretable, sklearn-native counterfactual explanations for microbiome classification.**
+
+📖 **[Documentation](https://simeonhebrew.github.io/MicroFactual/)** — quickstart, counterfactuals guide, preprocessing rationale, and API reference.
 
 MicroFactual answers a question most microbiome ML tools can't: *"what minimal change in taxa abundance would flip this sample's prediction?"* It pairs per-sample counterfactual analysis with a clean sklearn-compatible surface (`Pipeline`, `GridSearchCV`, `cross_val_score`) over microbiome-aware preprocessing (abundance/prevalence filtering, CLR).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../src"))
 
-project = "microfactual"
+project = "MicroFactual"
 copyright = "2025, Simeon Hebrew, Lawrence Adu-Gyamfi"
 author = "Simeon Hebrew, Lawrence Adu-Gyamfi"
 release = "0.2.0"
@@ -25,8 +25,17 @@ autodoc_default_options = {
     "undoc-members": True,
     "private-members": False,
     "show-inheritance": True,
-    "inherited-members": True,
+    # Don't pull in inherited sklearn base-class methods — their docstrings
+    # reference sklearn-internal labels that don't resolve here (noise).
+    "inherited-members": False,
 }
+
+# Suppress cross-reference warnings that originate in third-party (sklearn)
+# docstrings — e.g. the auto-injected metadata-routing methods — and harmless
+# duplicate-object refs from package re-exports. Our own .rst uses none of these
+# (no ``:ref:`` labels or glossary terms), so this only silences sklearn noise.
+suppress_warnings = ["ref.python", "ref.ref", "ref.term"]
+nitpicky = False
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/counterfactuals.rst
+++ b/docs/counterfactuals.rst
@@ -167,8 +167,7 @@ Limitations
 - **Compositional constraints are not enforced.** Counterfactuals in CLR space
   are not guaranteed to map back to a valid composition on the simplex (values
   summing to a constant). Treat the suggested shifts as directional rather than
-  exact recipes. Constrained, simplex-aware counterfactuals are on the roadmap
-  (see the release plan, T4.3).
+  exact recipes. Constrained, simplex-aware counterfactuals are on the roadmap.
 - **Binary classification only** in the current release.
 - **Correlated taxa.** Microbiome features are highly correlated; a
   counterfactual may shift one taxon as a proxy for a correlated group. Corroborate

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,86 +1,101 @@
-Microfactual Documentation
-===========================
+MicroFactual
+============
 
-A user-friendly Python framework for microbiome machine learning workflows.
+**Interpretable, sklearn-native counterfactual explanations for microbiome
+classification.**
 
-**Key Features:**
-- Easy data loading and preprocessing for microbiome datasets
-- Robust filtering and CLR transformation utilities
-- Random Forest modeling with cross-validation and hyperparameter tuning
-- Publication-ready ROC curve visualization
-- Command-line interface for reproducible pipelines
-- Type hints and numpy-style docstrings throughout
+MicroFactual answers a question most microbiome ML tools can't: *"what minimal
+change in taxa abundance would flip this sample's prediction?"* It pairs
+per-sample counterfactual analysis with a clean scikit-learn-compatible surface
+(``Pipeline``, ``GridSearchCV``, ``cross_val_score``) over microbiome-aware
+preprocessing (abundance/prevalence filtering, CLR).
 
-.. image:: https://img.shields.io/github/actions/workflow/status/<your-username>/<your-repo>/ci.yml?branch=main
-   :alt: Build Status
-   :target: https://github.com/<your-username>/<your-repo>/actions
+.. image:: https://github.com/simeonhebrew/MicroFactual/actions/workflows/ci.yml/badge.svg?branch=main
+   :alt: CI
+   :target: https://github.com/simeonhebrew/MicroFactual/actions/workflows/ci.yml
 
-Pipeline Overview
+**Non-goals:** not a replacement for QIIME2's bioinformatics pipeline, not a
+feature-engineering toolkit, not a diversity/phylogenetics library.
+
+Pipeline overview
 -----------------
 
 .. mermaid::
 
-    flowchart TD
-        A[Input Data] -->|Load| B(Dataset)
-        B -->|Filter| C[Preprocessing]
-        C -->|Transform| D[CLR/Scaling]
-        D -->|Train| E[Random Forest]
-        E -->|Explain| F[Counterfactuals]
-        E -->|Visualize| G[ROC Curves / Feature Importance]
+    flowchart LR
+        A[Feature table + metadata] -->|MicrobiomeDataset| B(Preprocessing)
+        B -->|Abundance / Prevalence / CLR| C[MicrobiomeClassifier]
+        C -->|explain_counterfactual| D[Counterfactuals]
+        C -->|plots| E[ROC / importance]
+        D -->|plausible_range + heatmap| F[Actionable, plausible explanations]
 
-Quickstart
-----------
+Installation
+------------
+
+Install from source (not yet published to PyPI):
 
 .. code-block:: bash
 
-    pip install microfactual
+    # Core install (lean)
+    pip install -e .
 
-    # Run the pipeline via CLI
-    microfactual --abundance data/abundance.txt --metadata data/metadata.txt --output_dir results/
+    # With the counterfactual explainability stack (DiCE)
+    pip install -e '.[explainability]'
 
-Usage as a library:
+Quickstart: a counterfactual
+----------------------------
 
 .. code-block:: python
 
-    from microfactual.core.dataset import load_dataset
-    from microfactual.preprocessing import filter_features, clr_transformation
-    from microfactual.models import RandomForestClassifier
-    from microfactual.explainability import CounterfactualExplainer
+    import microfactual as mf
+    from microfactual import AbundanceFilter, PrevalenceFilter, CLRTransform
 
-    # Load and process
-    data = load_dataset('abundance.txt', 'metadata.txt')
-    filtered_data = filter_features(data)
-    transformed_data = clr_transformation(filtered_data)
+    # 1. Load a real feature table + metadata
+    ds = mf.MicrobiomeDataset.from_files(
+        "abundance.tsv", "metadata.tsv",
+        target_column="Group", sample_column="Sample ID",
+    )
 
-    # Train
-    model = RandomForestClassifier()
-    model.fit(transformed_data, labels)
+    # 2. Preprocess into CLR space (real taxon names are preserved end-to-end)
+    X = CLRTransform().fit_transform(
+        PrevalenceFilter(min_prevalence=0.1).fit_transform(
+            AbundanceFilter(min_abundance=1e-5).fit_transform(ds.X)))
+    y = ds.y
 
-    # Explain
-    explainer = CounterfactualExplainer(model)
-    explanation = explainer.explain(instance)
+    # 3. Fit an sklearn-compatible classifier in that space
+    model = mf.MicrobiomeClassifier(preprocessing=None).fit(X, y)
+
+    # 4. What minimal change flips this sample's prediction?
+    cf = mf.explain_counterfactual(
+        model, X.iloc[[0]], background_data=X, y=y,
+        class_names=list(ds.target_names),
+    )
+    print(cf.summary())
+    cf.changes(0)   # taxon, original -> counterfactual, delta, direction
+
+See the :doc:`counterfactuals` guide for plausibility bounds, cohort-level
+importance, and the class-reference heatmap, and :doc:`preprocessing` for how to
+choose the filtering and transform defaults.
 
 Contents
 --------
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Guides
 
    counterfactuals
+   preprocessing
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
    modules
 
-API Reference
--------------
+Links
+-----
 
-- The API documentation is auto-generated from the source code docstrings.
-
-Contributing
-------------
-
-- Contributions are welcome! See the repository for guidelines.
-- For more, see the `README <../README.md>`_ or visit the `GitHub repo <https://github.com/<your-username>/<your-repo>>`_.
-
----
-
-*This documentation is generated with Sphinx.*
+- Source: https://github.com/simeonhebrew/MicroFactual
+- Runnable examples: ``notebooks/`` in the repository (start with the
+  end-to-end feature tour).

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -1,0 +1,95 @@
+Preprocessing: choosing filters and transforms
+===============================================
+
+MicrobiomeClassifier's ``preprocessing="auto"`` applies three steps in order:
+
+1. :class:`~microfactual.preprocessing.transforms.AbundanceFilter` — drop
+   very-low-abundance taxa (``min_abundance=1e-6``).
+2. :class:`~microfactual.preprocessing.transforms.PrevalenceFilter` — drop taxa
+   present in too few samples (``min_prevalence=0.01``).
+3. :class:`~microfactual.preprocessing.transforms.CLRTransform` — centered
+   log-ratio transform (``pseudocount=1e-6``).
+
+Those are the values ``"auto"`` uses. Note the standalone ``PrevalenceFilter``
+class defaults to ``min_prevalence=0.05``; ``"auto"`` deliberately sets a looser
+``0.01``. Use :func:`~microfactual.visualization.exploration.explore` to pick
+these from your own data rather than trusting any default blindly.
+
+Why filter at all?
+------------------
+
+Microbiome feature tables are wide and sparse (often 80–95% zeros). Most taxa are
+low-abundance, rarely observed, or sequencing noise / contaminants. Filtering:
+
+- removes features that carry little signal and inflate the multiple-comparison
+  and overfitting burden;
+- stabilises the CLR transform, whose geometric mean is sensitive to a long tail
+  of near-zero values.
+
+Abundance cutoff
+----------------
+
+The **log10 histogram of per-taxon mean abundance is typically bimodal** — a
+low-abundance "noise" mode and a higher "signal" mode. The trough between them is
+the natural cutoff. ``mf.explore(dataset)`` draws this histogram with the
+proposed cutoff overlaid, so you can see whether ``1e-6`` sits in the trough for
+*your* data (it may not — relative-abundance vs. count tables differ by orders of
+magnitude).
+
+- **Use a higher cutoff** when you only trust well-quantified taxa, or the table
+  is relative abundance already normalised to 1.
+- **Use a lower cutoff** for deeply-sequenced count data where rare taxa are
+  still reliable.
+
+Prevalence cutoff
+-----------------
+
+Prevalence is the fraction of samples in which a taxon appears. The distribution
+is typically U-shaped (taxa present almost never or almost always). ``"auto"``
+uses ``0.01`` (removes taxa seen in <1% of samples); the standalone class
+defaults to ``0.05``. Raise it (e.g. ``0.1``) when you want features informative
+across the cohort rather than a handful of samples — often the bigger lever on
+model stability than the abundance cutoff.
+
+CLR transform
+-------------
+
+Microbiome abundances are **compositional**: they are relative (constrained to a
+constant sum), so only *ratios* between taxa carry information, not absolute
+values. The centered log-ratio (CLR) maps compositions to a real-valued space
+where standard classifiers and distances behave sensibly, by taking the log of
+each part divided by the sample's geometric mean.
+
+- The ``pseudocount`` replaces zeros before the log. Its value affects how
+  strongly zeros are pulled toward the low end; report it alongside results.
+- CLR keeps real taxon names, so counterfactuals and importances stay
+  interpretable (see :doc:`counterfactuals`).
+
+When *not* to CLR: if you plan to interpret absolute abundances directly, or your
+downstream model already assumes compositional structure, CLR may not be
+appropriate.
+
+Known limitations
+-----------------
+
+- **Zero handling is pseudocount-based**, not model-based; results can be
+  sensitive to the pseudocount on very sparse tables.
+- **CLR only**, no ILR/ALR. CLR components are not fully independent (they sum to
+  zero by construction). An isometric log-ratio (ILR) basis avoids this but needs
+  a chosen partition; it is on the roadmap.
+- Filtering thresholds are **global**, not per-class; extremely class-imbalanced
+  taxa may be dropped. Inspect with ``mf.explore`` before committing.
+
+Doing it manually
+-----------------
+
+The transforms are plain scikit-learn transformers, so you can compose them
+yourself (and preserve real taxon names):
+
+.. code-block:: python
+
+    from microfactual import AbundanceFilter, PrevalenceFilter, CLRTransform
+
+    X = CLRTransform().fit_transform(
+        PrevalenceFilter(min_prevalence=0.1).fit_transform(
+            AbundanceFilter(min_abundance=1e-5).fit_transform(dataset.X)))

--- a/src/microfactual/visualization/plots.py
+++ b/src/microfactual/visualization/plots.py
@@ -112,11 +112,11 @@ def plot_feature_importance(
 
     Parameters
     ----------
-    importance : pd.Series, np.ndarray, or model with feature_importances_
+    importance : pd.Series, np.ndarray, or model with ``feature_importances_``
         Feature importance scores. Can be:
         - pd.Series with feature names as index
         - np.ndarray (requires feature_names)
-        - Model object with feature_importances_ attribute
+        - Model object with a ``feature_importances_`` attribute
     feature_names : list of str, optional
         Feature names (required if importance is array or model).
     top_n : int, optional


### PR DESCRIPTION
Docs deployment polish (T1.3) + preprocessing rationale (T2.1), with a correctness/concision pass.

## Changes
- **Rewrote `docs/index.rst`** — the old landing page referenced APIs that don't exist (`load_dataset`, `filter_features`, `clr_transformation`, `RandomForestClassifier`, `CounterfactualExplainer`) and had `<your-username>/<your-repo>` placeholders. Now a counterfactual-first landing page with the verified quickstart and real badges/links.
- **Added `docs/preprocessing.rst`** (T2.1) — rationale for the abundance/prevalence/CLR defaults, when to change them, and compositional limitations.
- **Warning-free Sphinx build (32 → 0)** — `inherited-members: off` (drops sklearn base-class docstring noise), fixed a `feature_importances_` docstring cross-ref ERROR, suppressed third-party `ref.*` noise; project name → `MicroFactual`.
- **README** — docs badge + link to the live site.

## Correctness pass (found + fixed)
- `preprocessing.rst` originally claimed `PrevalenceFilter` defaults to `0.01` — the **class default is 0.05**; `preprocessing="auto"` sets `0.01`. Now stated accurately.
- `index.rst` install said `pip install microfactual` — **not yet on PyPI**; changed to from-source `pip install -e .` to match the README.
- Removed an internal "release plan, T4.3" citation from user-facing docs.

## Notes
- GitHub Pages already serves `gh-pages` at <https://simeonhebrew.github.io/MicroFactual/>; `docs.yml` redeploys on merge to main.
- Verified: no non-existent APIs or placeholders remain in any `.rst`; `counterfactuals.rst` cross-checked against the code (signatures, `counterfactual_importance` columns, plausibility funcs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)