### PR TITLE
chore: PyPI release setup via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+# Build once, then publish via PyPI Trusted Publishing (OIDC — no API tokens).
+#   * push a v* tag        -> publish to TestPyPI
+#   * publish a GH Release -> publish to PyPI
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Validate metadata
+        run: uv run --with twine twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'push' # v* tag
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/microfactual
+    permissions:
+      id-token: write # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release' # GitHub Release published
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/microfactual
+    permissions:
+      id-token: write # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrote the README roadmap (removed duplicated entries) around the v0.2.0 release plan.
 
 ### Added
+- **PyPI release setup**: a `release.yml` workflow that publishes via PyPI Trusted Publishing (OIDC, no tokens) — TestPyPI on a `v*` tag, PyPI on a published GitHub Release. Added `[project.urls]`, single-source dynamic version (read from `microfactual.__version__`), a lean sdist (excludes example datasets/notebooks, 2.4 MB → 36 KB), and `RELEASING.md` with the setup + release process.
 - **`mf.explore(dataset)`**: data-exploration panel for choosing preprocessing cutoffs — log-abundance histogram, prevalence histogram, and a joint prevalence-vs-abundance scatter, all overlaying the proposed `AbundanceFilter`/`PrevalenceFilter` cutoffs and reporting how many taxa are retained. Individual plotters (`plot_abundance_histogram`, `plot_prevalence_histogram`, `plot_prevalence_abundance`) are also exported.
 - **`mf.explain_counterfactual()`**: first-class, documented one-call entry point for per-sample counterfactual explanations (wraps `DiCEExplainer`). Exported at the top level.
 - **Actionable counterfactuals**: `explain_counterfactual()` now applies post-hoc sparsification (`sparse=True`) — greedily reducing each counterfactual to a near-minimal set of taxa changes that still flips the prediction (on the CRC model this cut changes from 220/220 taxa to ~10). Added `features_to_vary` and `permitted_range` to constrain the search to modifiable taxa / plausible ranges.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,67 @@
+# Releasing MicroFactual
+
+Releases are published to PyPI via **Trusted Publishing (OIDC)** — no API tokens
+are stored anywhere. The `.github/workflows/release.yml` workflow builds the
+distributions and publishes them:
+
+- **push a `v*` tag** → publishes to **TestPyPI**
+- **publish a GitHub Release** → publishes to **PyPI**
+
+## One-time setup (maintainer, ~5 minutes)
+
+You must configure the trusted publishers and GitHub environments once. This is
+the only step that needs your PyPI account.
+
+### 1. GitHub environments
+
+Repo → **Settings → Environments** → create two environments:
+
+- `pypi`
+- `testpypi`
+
+(Optionally add "Required reviewers" or a tag protection rule to `pypi` so a
+production publish needs an approval.)
+
+### 2. PyPI trusted publisher
+
+On <https://pypi.org> → your account → **Publishing** → *Add a pending publisher*:
+
+| Field | Value |
+|-------|-------|
+| PyPI Project Name | `microfactual` |
+| Owner | `simeonhebrew` |
+| Repository name | `MicroFactual` |
+| Workflow name | `release.yml` |
+| Environment name | `pypi` |
+
+### 3. TestPyPI trusted publisher
+
+Repeat on <https://test.pypi.org> with **Environment name** `testpypi`.
+
+> Note: your earlier TestPyPI upload was under the name `microfactual-ml`. The
+> canonical name is now `microfactual` (it matches `import microfactual`), so add
+> the pending publisher for `microfactual`.
+
+## Cutting a release
+
+1. Bump the version — **single source of truth** is `microfactual.__version__` in
+   `src/microfactual/__init__.py` (the build reads it via `hatch.version`).
+2. Move the `## [Unreleased]` section in `CHANGELOG.md` to the new version with a
+   date.
+3. Commit and merge to `main`.
+4. **Test the publish first:**
+   ```bash
+   git tag v0.2.0 && git push origin v0.2.0
+   ```
+   This runs the workflow → TestPyPI. Verify:
+   ```bash
+   pip install -i https://test.pypi.org/simple/ microfactual
+   ```
+5. **Publish for real:** create a **GitHub Release** for the tag (Releases → Draft
+   a new release → choose the tag → Publish). This runs the workflow → PyPI.
+
+## Notes
+
+- The build is **backend = hatchling**; `uv build` produces the sdist + wheel.
+- The sdist ships only the package + project metadata (no datasets/notebooks).
+- The version is validated with `twine check` before any upload.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microfactual"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Interpretable, sklearn-native counterfactual explanations for microbiome classification"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -45,6 +45,13 @@ dependencies = [
     "skore>=0.10.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/simeonhebrew/MicroFactual"
+Documentation = "https://simeonhebrew.github.io/MicroFactual/"
+Repository = "https://github.com/simeonhebrew/MicroFactual"
+Changelog = "https://github.com/simeonhebrew/MicroFactual/blob/main/CHANGELOG.md"
+Issues = "https://github.com/simeonhebrew/MicroFactual/issues"
+
 [project.optional-dependencies]
 # Counterfactual explainability stack — install with: pip install microfactual[explainability]
 explainability = [
@@ -71,8 +78,24 @@ docs = [
 [project.scripts]
 microfactual = "microfactual.main:main"
 
+# Single source of truth for the version: microfactual.__version__
+[tool.hatch.version]
+path = "src/microfactual/__init__.py"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/microfactual"]
+
+# Keep the sdist lean: ship the package + project metadata, not the example
+# datasets, notebooks, or docs sources.
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/microfactual",
+    "/README.md",
+    "/LICENSE",
+    "/CHANGELOG.md",
+    "/CITATION.cff",
+    "/pyproject.toml",
+]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Sets up standards-based PyPI publishing. **No API tokens** — uses PyPI Trusted Publishing (OIDC), the current PyPA-recommended approach.

## Verification of current state
- `microfactual` is **available on PyPI** (and matches the import name).
- You previously pushed **`microfactual-ml` v0.1.0 to TestPyPI** (old metadata). The canonical name going forward is `microfactual`.
- `twine check` passed, but the **sdist was 2.4 MB** because it bundled `datasets/` + `notebooks/`.

## Changes
- **`.github/workflows/release.yml`** — build (`uv build`) + `twine check`, then publish via OIDC:
  - `v*` tag → **TestPyPI**
  - published GitHub Release → **PyPI**
- **`pyproject.toml`**:
  - `[project.urls]` (Homepage, Documentation, Repository, Changelog, Issues)
  - **single-source dynamic version** read from `microfactual.__version__` (kills the pyproject/`__init__` drift we hit earlier)
  - **lean sdist** (excludes datasets/notebooks): **2.4 MB → 36 KB**
- **`RELEASING.md`** — the one-time trusted-publisher + GitHub-environment setup, and the cut-a-release steps.

## Verified
- `uv build` + `twine check` pass; wheel metadata carries the URLs + `License-File: LICENSE`; version resolves to `0.2.0`; sdist ships no datasets/notebooks; 79 tests pass.

## Action required from you (can't be automated — needs your PyPI account)
Per `RELEASING.md`: create GitHub environments `pypi`/`testpypi`, and add pending Trusted Publishers on PyPI + TestPyPI for project `microfactual`, repo `simeonhebrew/MicroFactual`, workflow `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)